### PR TITLE
Add tokenreview permissions

### DIFF
--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -132,6 +132,11 @@ func getRules() []rbacv1.PolicyRule {
 			Resources: []string{"deployments"},
 			Verbs:     []string{"*"},
 		},
+		{
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
+			Verbs:     []string{"create"},
+		},
 	}
 }
 

--- a/pull-secret.yaml
+++ b/pull-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: search-pull-secret
+data: 
+  .dockerconfigjson: ewogICJhdXRocyI6IHsKICAgICJxdWF5LmlvIjogewogICAgICAiYXV0aCI6ICJhbXh3WVdScGJHeGhPa05uU3pWQlZEQjBaazlIWm5ObVZXMDNSRlJOVGxOTmNuVjVhRmQxY0U5NE1WVmplbEZzZUVzcmJsSm1VSGRZWjNod1NDOUtkbnBXVFZOM1N6UjBOSEpIYkRaNWIydFhibGhWUjJsNVlrbzBZMGh1UlVKblBUMD0iLAogICAgICAiZW1haWwiOiAiIgogICAgfQogIH0KfQ==
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Issue:** https://github.com/stolostron/backlog/issues/17982

### Changes:
The Search API needs to be able to create tokenreviews to validate the user tokens.