### PR TITLE
adding create selfsubjectaccessreview and selfsubjectrulesreview permissions

### DIFF
--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -137,6 +137,16 @@ func getRules() []rbacv1.PolicyRule {
 			Resources: []string{"tokenreviews"},
 			Verbs:     []string{"create"},
 		},
+		{
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"selfsubjectaccessreviews"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"selfsubjectrulesreviews"},
+			Verbs:     []string{"create"},
+		},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Anxhela <acoba@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/17982

### Changes:

Search API needs to create these resources in order to check user actions.