### PR TITLE
Use pull secret from ServiceAccount

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -249,7 +249,7 @@ spec:
                     memory: 50Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-              imagePullPolicy: Always
+              imagePullPolicy: Always 
               imagePullSecrets:
               - name: search-pull-secret
               securityContext:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -128,15 +128,6 @@ func getContainerArgs(deploymentName string, instance *searchv1alpha1.Search) []
 	return result
 }
 
-// func getImagePullSecret(deploymentName string, instance *searchv1alpha1.Search) []corev1.LocalObjectReference {
-// 	result := []corev1.LocalObjectReference{}
-// 	if instance.Spec.ImagePullSecret != "" {
-// 		return append(result, corev1.LocalObjectReference{Name: instance.Spec.ImagePullSecret})
-// 	}
-// 	default_pull_secret := getImagePullSecretName()
-// 	return append(result, corev1.LocalObjectReference{Name: default_pull_secret})
-// }
-
 func getRoleName() string {
 	return "search"
 }

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -86,10 +86,6 @@ func TestResourcesNotCustomized(t *testing.T) {
 	if actualImagePullPolicy != "Always" {
 		t.Error("ImagePullPolicy Not expected")
 	}
-	// actualImagePullSecret := getImagePullSecret("search-collector", instance)
-	// if actualImagePullSecret[0].Name != "search-pull-secret" {
-	// 	t.Error("ImagePullSecret Not expected")
-	// }
 	actualImageSha := getImageSha("search-collector", instance)
 	if actualImageSha != "value-from-env" {
 		t.Error("ImageOverride with incorrect image")
@@ -133,10 +129,6 @@ func TestAPICustomization(t *testing.T) {
 	if *actualReplicaCount != int32(5) {
 		t.Error("ReplicaCount Not expected")
 	}
-	// actualImagePullSecret := getImagePullSecret(testFor, instance)
-	// if actualImagePullSecret[0].Name != "personal-pull-secret" {
-	// 	t.Error("ImagePullSecret Not expected")
-	// }
 	request_memory_want := "10Mi"
 	request_cpu_want := "25m"
 	limit_cpu_want := "40m"
@@ -200,10 +192,6 @@ func TestIndexerCustomization(t *testing.T) {
 	if *actualReplicaCount != int32(5) {
 		t.Error("ReplicaCount Not expected")
 	}
-	// actualImagePullSecret := getImagePullSecret(testFor, instance)
-	// if actualImagePullSecret[0].Name != "personal-pull-secret" {
-	// 	t.Error("ImagePullSecret Not expected")
-	// }
 	request_memory_want := "10Mi"
 	request_cpu_want := "25m"
 	limit_cpu_want := "40m"
@@ -269,10 +257,6 @@ func TestCollectorCustomization(t *testing.T) {
 	if *actualReplicaCount != int32(5) {
 		t.Error("ReplicaCount Not expected")
 	}
-	// actualImagePullSecret := getImagePullSecret(testFor, instance)
-	// if actualImagePullSecret[0].Name != "personal-pull-secret" {
-	// 	t.Error("ImagePullSecret Not expected")
-	// }
 	request_memory_want := "10Mi"
 	request_cpu_want := "25m"
 	limit_cpu_want := "40m"
@@ -340,10 +324,6 @@ func TestPostgresCustomization(t *testing.T) {
 	if *actualReplicaCount != int32(5) {
 		t.Error("ReplicaCount Not expected")
 	}
-	// actualImagePullSecret := getImagePullSecret(testFor, instance)
-	// if actualImagePullSecret[0].Name != "personal-pull-secret" {
-	// 	t.Error("ImagePullSecret Not expected")
-	// }
 	request_memory_want := "10Mi"
 	request_cpu_want := "25m"
 	limit_cpu_want := "40m"

--- a/controllers/create_apideployment.go
+++ b/controllers/create_apideployment.go
@@ -74,7 +74,6 @@ func (r *SearchReconciler) APIDeployment(instance *searchv1alpha1.Search) *appsv
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{apiContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
-	// deployment.Spec.Template.Spec.ImagePullSecrets = getImagePullSecret(deploymentName, instance)
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_collectordeployment.go
+++ b/controllers/create_collectordeployment.go
@@ -69,7 +69,6 @@ func (r *SearchReconciler) CollectorDeployment(instance *searchv1alpha1.Search) 
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{collectorContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
-	// deployment.Spec.Template.Spec.ImagePullSecrets = getImagePullSecret(deploymentName, instance)
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_indexerdeployment.go
+++ b/controllers/create_indexerdeployment.go
@@ -76,7 +76,6 @@ func (r *SearchReconciler) IndexerDeployment(instance *searchv1alpha1.Search) *a
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{indexerContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
-	// deployment.Spec.Template.Spec.ImagePullSecrets = getImagePullSecret(deploymentName, instance)
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -108,7 +108,6 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{postgresContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
-	// deployment.Spec.Template.Spec.ImagePullSecrets = getImagePullSecret(deploymentName, instance)
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  N/A

### Description of changes
Simplify implementation by using the imagePullSecret from the service account instead of adding to each individual deployment.