### PR TITLE
Add permission to impersonate service account

### DIFF
--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -150,12 +150,12 @@ func getRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{"authorization.k8s.io"},
-			Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews"},
+			Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews", "uids"},
 			Verbs:     []string{"create", "impersonate"},
 		},
 		{
 			APIGroups: []string{""},
-			Resources: []string{"users"},
+			Resources: []string{"users", "serviceaccounts"},
 			Verbs:     []string{"impersonate"},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  stolostron/backlog#25548

### Description of changes
- Search API tests use service accounts to test RBAC. Search V2 API needs permission to impersonate service accounts.
