### PR TITLE
Change scope of watches to namespace

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -76,23 +76,6 @@ spec:
               verbs:
                 - create
             - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - replicasets
-              verbs:
-                - '*'
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - secrets
-                - serviceaccounts
-                - services
-                - persistentvolumeclaims
-              verbs:
-                - '*'
-            - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
                 - clusterrolebindings
@@ -226,6 +209,10 @@ spec:
                       periodSeconds: 20
                     name: manager
                     env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                       - name: POSTGRES_IMAGE
                         value: registry.redhat.io/rhel8/postgresql-13:1-56
                       - name: INDEXER_IMAGE
@@ -259,17 +246,22 @@ spec:
       permissions:
         - rules:
             - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - '*'
+            - apiGroups:
                 - ""
               resources:
                 - configmaps
+                - secrets
+                - serviceaccounts
+                - services
+                - persistentvolumeclaims
               verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
+                - '*'
             - apiGroups:
                 - coordination.k8s.io
               resources:


### PR DESCRIPTION
Signed-off-by: Xavier Dharmaiyan <xavier@redhat.com>

**Related Issue:**  stolostron/backlog#25847

### Description of changes
- Reduces the scope of resources watched by the operator to only the namespace where it's deployed.
