### PR TITLE
Allow search-api to impersonate using pod token

### DIFF
--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -155,7 +155,7 @@ func getRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{"authentication.k8s.io", "authorization.k8s.io"},
-			Resources: []string{"uids"},
+			Resources: []string{"uids", "userextras/authentication.kubernetes.io/pod-name", "userextras/authentication.kubernetes.io/pod-uid"},
 			Verbs:     []string{"impersonate"},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://issues.redhat.com/browse/ACM-2170

### Description of changes
- Update search-api permissions to accept tokens from other pod. The pod token is different from the ServiceAccount, so need the correct impersonation permissions.
