### PR TITLE
ACM-3226 Update description for unimplemented settings

### DIFF
--- a/api/v1alpha1/search_types.go
+++ b/api/v1alpha1/search_types.go
@@ -41,7 +41,7 @@ type SearchSpec struct {
 	DBStorage StorageSpec `json:"dbStorage,omitempty"`
 
 	// +optional
-	//Configmap name contains parameters to override default db parameters
+	// Configmap name contains parameters to override default db parameters
 	DBConfig string `json:"dbConfig,omitempty"`
 
 	// +optional
@@ -49,11 +49,11 @@ type SearchSpec struct {
 	Deployments SearchDeployments `json:"deployments,omitempty"`
 
 	// +optional
-	// Specifies deployment replication for improved availability. Options are: Basic and High (default)
+	// [PLACEHOLDER, NOT IMPLEMENTED] Specifies deployment replication for improved availability. Options are: Basic and High (default)
 	AvailabilityConfig AvailabilityType `json:"availabilityConfig,omitempty"`
 
 	// +optional
-	// Kubernetes secret name containing user provided db secret
+	// [PLACEHOLDER, NOT IMPLEMENTED] Kubernetes secret name containing user provided db secret
 	// Secret should contain connection parameters [db_host, db_port, db_user, db_password, db_name, ca_cert]
 	// Not supported for development preview.
 	ExternalDBInstance string `json:"externalDBInstance,omitempty"`

--- a/bundle/manifests/search.open-cluster-management.io_searches.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_searches.yaml
@@ -35,8 +35,9 @@ spec:
             description: SearchSpec defines the desired state of Search
             properties:
               availabilityConfig:
-                description: '[CURRENTLY UNAVAILABLE] Specifies deployment replication for improved availability.
-                  Options are: Basic and High (default)'
+                description: '[PLACEHOLDER, NOT IMPLEMENTED] Specifies deployment
+                  replication for improved availability. Options are: Basic and High
+                  (default)'
                 type: string
               dbConfig:
                 description: Configmap name contains parameters to override default
@@ -237,9 +238,10 @@ spec:
                     type: object
                 type: object
               externalDBInstance:
-                description: [CURRENTLY UNAVAILABLE] Kubernetes secret name containing user provided db secret
-                  Secret should contain connection parameters [db_host, db_port, db_user,
-                  db_password, db_name, ca_cert] Not supported for development preview.
+                description: '[PLACEHOLDER, NOT IMPLEMENTED] Kubernetes secret name
+                  containing user provided db secret Secret should contain connection
+                  parameters [db_host, db_port, db_user, db_password, db_name, ca_cert]
+                  Not supported for development preview.'
                 type: string
               imagePullPolicy:
                 description: ImagePullPolicy
@@ -302,13 +304,14 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/search.open-cluster-management.io_searches.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_searches.yaml
@@ -37,8 +37,9 @@ spec:
             description: SearchSpec defines the desired state of Search
             properties:
               availabilityConfig:
-                description: '[CURRENTLY UNAVAILABLE] Specifies deployment replication for improved availability.
-                  Options are: Basic and High (default)'
+                description: '[PLACEHOLDER, NOT IMPLEMENTED] Specifies deployment
+                  replication for improved availability. Options are: Basic and High
+                  (default)'
                 type: string
               dbConfig:
                 description: Configmap name contains parameters to override default
@@ -239,9 +240,10 @@ spec:
                     type: object
                 type: object
               externalDBInstance:
-                description: [CURRENTLY UNAVAILABLE] Kubernetes secret name containing user provided db secret
-                  Secret should contain connection parameters [db_host, db_port, db_user,
-                  db_password, db_name, ca_cert] Not supported for development preview.
+                description: '[PLACEHOLDER, NOT IMPLEMENTED] Kubernetes secret name
+                  containing user provided db secret Secret should contain connection
+                  parameters [db_host, db_port, db_user, db_password, db_name, ca_cert]
+                  Not supported for development preview.'
                 type: string
               imagePullPolicy:
                 description: ImagePullPolicy
@@ -304,13 +306,14 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://issues.redhat.com/browse/ACM-3226

### Description of changes
- Update `api/v1alpha1/search_types.go`
- Run `make test` to propagate changes to `config/crd/bases/search.open-cluster-management.io_searches.yaml`
- Copy changes into `bundle/manifests/search.open-cluster-management.io_searches.yaml`
