### PR TITLE
CLUSTER_NAMESPACE env no longer needed on collector deployment

### DIFF
--- a/addon/addon_test.go
+++ b/addon/addon_test.go
@@ -164,22 +164,22 @@ func TestManifest(t *testing.T) {
 					if object.Spec.Template.Spec.Containers[0].Args[0] != test.expectedArgs {
 						t.Errorf("expected args is %s, but got %s", test.expectedLimit, object.Spec.Template.Spec.Containers[0].Args[0])
 					}
-					if object.Spec.Template.Spec.Containers[0].Env[4].Name != "REDISCOVER_RATE_MS" {
+					if object.Spec.Template.Spec.Containers[0].Env[3].Name != "REDISCOVER_RATE_MS" {
 						t.Errorf("expected env is REDISCOVER_RATE_MS, but got %s", object.Spec.Template.Spec.Containers[0].Env[4].Name)
 					}
-					if object.Spec.Template.Spec.Containers[0].Env[5].Name != "HEARTBEAT_MS" {
+					if object.Spec.Template.Spec.Containers[0].Env[4].Name != "HEARTBEAT_MS" {
 						t.Errorf("expected env is HEARTBEAT_MS, but got %s", object.Spec.Template.Spec.Containers[0].Env[5].Name)
 					}
-					if object.Spec.Template.Spec.Containers[0].Env[6].Name != "REPORT_RATE_MS" {
+					if object.Spec.Template.Spec.Containers[0].Env[5].Name != "REPORT_RATE_MS" {
 						t.Errorf("expected env is REPORT_RATE_MS, but got %s", object.Spec.Template.Spec.Containers[0].Env[6].Name)
 					}
-					if object.Spec.Template.Spec.Containers[0].Env[4].Value != "4000" {
+					if object.Spec.Template.Spec.Containers[0].Env[3].Value != "4000" {
 						t.Errorf("expected value is 4000, but got %s", object.Spec.Template.Spec.Containers[0].Env[4].Value)
 					}
-					if object.Spec.Template.Spec.Containers[0].Env[5].Value != "3000" {
+					if object.Spec.Template.Spec.Containers[0].Env[4].Value != "3000" {
 						t.Errorf("expected value is 3000, but got %s", object.Spec.Template.Spec.Containers[0].Env[5].Value)
 					}
-					if object.Spec.Template.Spec.Containers[0].Env[6].Value != "2000" {
+					if object.Spec.Template.Spec.Containers[0].Env[5].Value != "2000" {
 						t.Errorf("expected value is 2000, but got %s", object.Spec.Template.Spec.Containers[0].Env[6].Value)
 					}
 

--- a/addon/manifests/chart/Chart.yaml
+++ b/addon/manifests/chart/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A helm chart of search-collector addon
 name: search-collector
-version: 2.7.0
+version: 2.9.0

--- a/addon/manifests/chart/templates/deployment.yaml
+++ b/addon/manifests/chart/templates/deployment.yaml
@@ -31,8 +31,6 @@ spec:
         env:
         - name: CLUSTER_NAME
           value: "{{ .Values.clusterName }}"
-        - name: CLUSTER_NAMESPACE
-          value: "{{ .Values.clusterName }}"
         - name: HUB_CONFIG
           value: /hubconfig/kubeconfig
         - name: POD_NAMESPACE

--- a/scripts/postgres-debug.sh
+++ b/scripts/postgres-debug.sh
@@ -79,7 +79,7 @@ psql -d search -U searchuser -c "SELECT edgetype, count(*) FROM search.edges GRO
 printf "\n>>> Intercluster edge count by cluster:\n\n"
 psql -d search -U searchuser -c "SELECT cluster, count(*) FROM search.edges WHERE edgetype = 'interCluster' GROUP BY cluster ORDER BY count DESC;"
 
-printf "/n>>> Total interCluster edge count:\n\n"
+printf "\n>>> Total interCluster edge count:\n\n"
 psql -d search -U searchuser -c "SELECT count(*) FROM search.edges WHERE edgetype = 'interCluster';"
 
 


### PR DESCRIPTION
### Related Issue
N/A

**This change requires that the collector PR is merged first:** https://github.com/stolostron/search-collector/pull/260

### Description of changes
- Env `CLUSTER_NAMESPACE` is no longer used by the collector pod because it's always equal to `CLUSTER_NAME`.
- Remove env from search add-on deployment.
