### PR TITLE
ACM-7320: Update default postgres memory config

### DIFF
--- a/config/crd/bases/search.open-cluster-management.io_searches.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_searches.yaml
@@ -200,7 +200,7 @@ spec:
                               in spec.resourceClaims, that are used by this container.
                               \n This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate. \n This field
-                              is immutable."
+                              is immutable. It can only be set for containers."
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -380,7 +380,7 @@ spec:
                               in spec.resourceClaims, that are used by this container.
                               \n This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate. \n This field
-                              is immutable."
+                              is immutable. It can only be set for containers."
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -560,7 +560,7 @@ spec:
                               in spec.resourceClaims, that are used by this container.
                               \n This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate. \n This field
-                              is immutable."
+                              is immutable. It can only be set for containers."
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -740,7 +740,7 @@ spec:
                               in spec.resourceClaims, that are used by this container.
                               \n This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate. \n This field
-                              is immutable."
+                              is immutable. It can only be set for containers."
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -37,7 +37,7 @@ const (
 	indexerSecretName               = "search-indexer-certs"
 	postgresSecretName              = "search-postgres-certs"
 	POSTGRESQL_SHARED_BUFFERS       = "512MB"
-	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1024MB"
+	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"
 	WORK_MEM                        = "32MB"
 )
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -36,9 +36,9 @@ const (
 	apiSecretName                   = "search-api-certs"
 	indexerSecretName               = "search-indexer-certs"
 	postgresSecretName              = "search-postgres-certs"
-	POSTGRESQL_SHARED_BUFFERS       = "64MB"
-	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "128MB"
-	WORK_MEM                        = "16MB"
+	POSTGRESQL_SHARED_BUFFERS       = "512MB"
+	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1024MB"
+	WORK_MEM                        = "32MB"
 )
 
 var (

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -711,7 +711,7 @@ func TestSearch_controller_DBConfig(t *testing.T) {
 	}
 
 	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl = 'on'")
-	verifyConfigmapDataContent(t, configmap, "postgresql-start.sh", "ALTER ROLE searchuser set work_mem='16MB'")
+	verifyConfigmapDataContent(t, configmap, "postgresql-start.sh", "ALTER ROLE searchuser set work_mem='32MB'")
 
 	//check for created search-postgres deployment
 	dep := &appsv1.Deployment{}
@@ -723,9 +723,9 @@ func TestSearch_controller_DBConfig(t *testing.T) {
 		t.Fatalf("Failed to get deployment %s: %v", "search-postgres", err)
 	}
 	//Should be the default constant values set in common.go
-	verifyDeploymentEnv(t, dep, "WORK_MEM", "16MB")
-	verifyDeploymentEnv(t, dep, "POSTGRESQL_SHARED_BUFFERS", "64MB")
-	verifyDeploymentEnv(t, dep, "POSTGRESQL_EFFECTIVE_CACHE_SIZE", "128MB")
+	verifyDeploymentEnv(t, dep, "WORK_MEM", "32MB")
+	verifyDeploymentEnv(t, dep, "POSTGRESQL_SHARED_BUFFERS", "512MB")
+	verifyDeploymentEnv(t, dep, "POSTGRESQL_EFFECTIVE_CACHE_SIZE", "1GB")
 }
 
 func TestSearch_controller_Metrics(t *testing.T) {


### PR DESCRIPTION
### Related Issue

https://issues.redhat.com/browse/ACM-7320

### Description of changes
- Increase the default memory configuration for postgres to utilize better the default postgres container memory limit of 4Gi.

```
	POSTGRESQL_SHARED_BUFFERS       = "512MB"
	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1024MB"
	WORK_MEM                        = "32MB"
```
