### PR TITLE
ACM-7320 Postgres container shared memory

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -33,21 +33,19 @@ const (
 	postgresConfigmapName = "search-postgres"
 	caCertConfigmapName   = "search-ca-crt"
 
-	apiSecretName                   = "search-api-certs"
-	indexerSecretName               = "search-indexer-certs"
-	postgresSecretName              = "search-postgres-certs"
-	POSTGRESQL_CONTAINER_SHARED_MEM = "1Gi"  // Postgres container Memory * 0.25
-	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"  // Postgres container Memory * 0.5
-	POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Postgres container Memory * 0.25
-	WORK_MEM                        = "64MB" // Postgres container Memory * 0.25 / max_connections
+	apiSecretName      = "search-api-certs"
+	indexerSecretName  = "search-indexer-certs"
+	postgresSecretName = "search-postgres-certs"
 )
 
 var (
 	certDefaultMode       = int32(416)
 	AnnotationSearchPause = "search-pause"
 )
-var dbDefaultMap = map[string]string{"POSTGRESQL_SHARED_BUFFERS": POSTGRESQL_SHARED_BUFFERS, "WORK_MEM": WORK_MEM,
-	"POSTGRESQL_EFFECTIVE_CACHE_SIZE": POSTGRESQL_EFFECTIVE_CACHE_SIZE,
+var dbDefaultMap = map[string]string{
+	"POSTGRESQL_EFFECTIVE_CACHE_SIZE": default_POSTGRESQL_EFFECTIVE_CACHE_SIZE,
+	"POSTGRESQL_SHARED_BUFFERS":       default_POSTGRESQL_SHARED_BUFFERS,
+	"WORK_MEM":                        default_WORK_MEM,
 }
 
 func generateLabels(key, val string) map[string]string {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -36,9 +36,9 @@ const (
 	apiSecretName                   = "search-api-certs"
 	indexerSecretName               = "search-indexer-certs"
 	postgresSecretName              = "search-postgres-certs"
-	POSTGRESQL_SHARED_BUFFERS       = "512MB"
-	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"
-	WORK_MEM                        = "32MB"
+	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"  // Postgres container Memory * 0.5
+	POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Postgres container Memory * 0.25 - Also used for container shared memory.
+	WORK_MEM                        = "64MB" // Postgres container Memory * 0.25 / max_connections
 )
 
 var (

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -36,8 +36,9 @@ const (
 	apiSecretName                   = "search-api-certs"
 	indexerSecretName               = "search-indexer-certs"
 	postgresSecretName              = "search-postgres-certs"
+	POSTGRESQL_CONTAINER_SHARED_MEM = "1Gi"  // Postgres container Memory * 0.25
 	POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"  // Postgres container Memory * 0.5
-	POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Postgres container Memory * 0.25 - Also used for container shared memory.
+	POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Postgres container Memory * 0.25
 	WORK_MEM                        = "64MB" // Postgres container Memory * 0.25 / max_connections
 )
 

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -652,7 +652,7 @@ func TestMemoryLimitCustomization(t *testing.T) {
 
 func TestPGDeployment(t *testing.T) {
 	var expectedMap = map[string]string{"POSTGRESQL_SHARED_BUFFERS": "64MB",
-		"POSTGRESQL_EFFECTIVE_CACHE_SIZE": POSTGRESQL_EFFECTIVE_CACHE_SIZE,
+		"POSTGRESQL_EFFECTIVE_CACHE_SIZE": default_POSTGRESQL_EFFECTIVE_CACHE_SIZE,
 		"WORK_MEM":                        "32MB"}
 
 	var configValueMap = map[string]string{"POSTGRESQL_SHARED_BUFFERS": "64MB",

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -694,6 +694,13 @@ func TestPGDeployment(t *testing.T) {
 	r := &SearchReconciler{Client: cl, Scheme: s}
 	actualDep := r.PGDeployment(search)
 
+	vols := actualDep.Spec.Template.Spec.Volumes
+	for _, vol := range vols {
+		if vol.Name == "dshm" && !vol.VolumeSource.EmptyDir.SizeLimit.Equal(resource.MustParse("1Gi")) {
+			t.Errorf("Expected shared volume SizeLimit to be 1Gi, but got: %+v ", vol.VolumeSource.EmptyDir.SizeLimit)
+		}
+	}
+
 	for _, env := range actualDep.Spec.Template.Spec.Containers[0].Env {
 		if env.Value != expectedMap[env.Name] {
 			t.Errorf("Expected %s for %s, but got %s", expectedMap[env.Name], env.Name, env.Value)

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -99,9 +99,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	}
 	postgresContainer.Env = append(postgresContainer.Env, env...)
 	postgresContainer.Resources = getResourceRequirements(deploymentName, instance)
-	shmSizeLimit := resource.Quantity{
-		Format: resource.MustParse(default_Postgres_SharedMemory).Format,
-	}
+	shmSizeLimit := resource.MustParse(default_Postgres_SharedMemory)
 	volumes := []corev1.Volume{
 		{
 			Name: "postgresql-cfg",

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -135,7 +135,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					Medium: corev1.StorageMediumMemory,
 					SizeLimit: &resource.Quantity{
-						Format: resource.MustParse(postgresqlSharedBuffers).Format, // Default to 1GB
+						Format: resource.MustParse(POSTGRESQL_CONTAINER_SHARED_MEM).Format, // Default to 1GB
 					},
 				},
 			},

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -5,6 +5,7 @@ import (
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -52,6 +53,10 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 			{
 				Name:      "search-postgres-certs",
 				MountPath: "/sslcert",
+			},
+			{
+				Name:      "dshm",
+				MountPath: "/dev/shm",
 			},
 		},
 		ReadinessProbe: &corev1.Probe{
@@ -121,6 +126,17 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &certDefaultMode,
 					SecretName:  postgresSecretName,
+				},
+			},
+		},
+		{
+			Name: "dshm",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
+					SizeLimit: &resource.Quantity{
+						Format: "1Gi", // TODO: Should it be 1/4 of memory limit Or POSGRESQL_SHARED_BUFFERS?
+					},
 				},
 			},
 		},

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -135,7 +135,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					Medium: corev1.StorageMediumMemory,
 					SizeLimit: &resource.Quantity{
-						Format: resource.MustParse(POSTGRESQL_CONTAINER_SHARED_MEM).Format, // Default to 1GB
+						Format: resource.MustParse(default_Postgres_SharedMemory).Format,
 					},
 				},
 			},

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -135,7 +135,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					Medium: corev1.StorageMediumMemory,
 					SizeLimit: &resource.Quantity{
-						Format: "1Gi", // TODO: Should it be 1/4 of memory limit Or POSGRESQL_SHARED_BUFFERS?
+						Format: resource.MustParse(postgresqlSharedBuffers).Format, // Default to 1GB
 					},
 				},
 			},

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -14,9 +14,13 @@ const (
 	default_Collector_MemoryLimit   = "768Mi"
 	default_Collector_MemoryRequest = "64Mi"
 
-	default_Postgres_CPURequest    = "25m"
-	default_Postgres_MemoryLimit   = "4Gi"
-	default_Postgres_MemoryRequest = "128Mi"
+	default_Postgres_CPURequest             = "25m"
+	default_Postgres_MemoryLimit            = "4Gi"
+	default_Postgres_MemoryRequest          = "1Gi"
+	default_Postgres_SharedMemory           = "1Gi"  // Postgres container MemoryLimit * 0.25
+	default_POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"  // Postgres container MemoryLimit * 0.5
+	default_POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Postgres container MemoryLimit * 0.25
+	default_WORK_MEM                        = "64MB" // Postgres container MemoryLimit * 0.25 / max_connections
 
 	default_API_Replicas       = 1
 	default_Indexer_Replicas   = 1

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -17,10 +17,10 @@ const (
 	default_Postgres_CPURequest             = "25m"
 	default_Postgres_MemoryLimit            = "4Gi"
 	default_Postgres_MemoryRequest          = "1Gi"
-	default_Postgres_SharedMemory           = "1Gi"  // Postgres container MemoryLimit * 0.25
-	default_POSTGRESQL_EFFECTIVE_CACHE_SIZE = "1GB"  // Postgres container MemoryLimit * 0.5
-	default_POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Postgres container MemoryLimit * 0.25
-	default_WORK_MEM                        = "64MB" // Postgres container MemoryLimit * 0.25 / max_connections
+	default_Postgres_SharedMemory           = "1Gi"  // Container MemoryLimit * 0.25
+	default_POSTGRESQL_EFFECTIVE_CACHE_SIZE = "2GB"  // Container MemoryLimit * 0.5
+	default_POSTGRESQL_SHARED_BUFFERS       = "1GB"  // Container MemoryLimit * 0.25
+	default_WORK_MEM                        = "64MB" // Container MemoryLimit * 0.25 / max_connections
 
 	default_API_Replicas       = 1
 	default_Indexer_Replicas   = 1

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -719,7 +719,7 @@ func TestSearch_controller_DBConfig(t *testing.T) {
 	}
 
 	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl = 'on'")
-	verifyConfigmapDataContent(t, configmap, "postgresql-start.sh", "ALTER ROLE searchuser set work_mem='32MB'")
+	verifyConfigmapDataContent(t, configmap, "postgresql-start.sh", "ALTER ROLE searchuser set work_mem='64MB'")
 
 	//check for created search-postgres deployment
 	dep := &appsv1.Deployment{}
@@ -731,8 +731,8 @@ func TestSearch_controller_DBConfig(t *testing.T) {
 		t.Fatalf("Failed to get deployment %s: %v", "search-postgres", err)
 	}
 	//Should be the default constant values set in common.go
-	verifyDeploymentEnv(t, dep, "WORK_MEM", "32MB")
-	verifyDeploymentEnv(t, dep, "POSTGRESQL_SHARED_BUFFERS", "512MB")
+	verifyDeploymentEnv(t, dep, "WORK_MEM", "64MB")
+	verifyDeploymentEnv(t, dep, "POSTGRESQL_SHARED_BUFFERS", "1GB")
 	verifyDeploymentEnv(t, dep, "POSTGRESQL_EFFECTIVE_CACHE_SIZE", "1GB")
 }
 

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -733,7 +733,7 @@ func TestSearch_controller_DBConfig(t *testing.T) {
 	//Should be the default constant values set in common.go
 	verifyDeploymentEnv(t, dep, "WORK_MEM", "64MB")
 	verifyDeploymentEnv(t, dep, "POSTGRESQL_SHARED_BUFFERS", "1GB")
-	verifyDeploymentEnv(t, dep, "POSTGRESQL_EFFECTIVE_CACHE_SIZE", "1GB")
+	verifyDeploymentEnv(t, dep, "POSTGRESQL_EFFECTIVE_CACHE_SIZE", "2GB")
 }
 
 func TestSearch_controller_Metrics(t *testing.T) {


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-7320

### Description of changes
- Configure the postgres container shared memory to 1Gi. Previous default was 64MB.
- Configure default postgres max_parallel_workers_per_gather to 8. Postgres default was 2.
- Update default POSTGRESQL_EFFECTIVE_CACHE_SIZE to 2GB from 1GB.
- Update default POSTGRESQL_SHARED_BUFFERS to 1GB from 512MB.
- Update default WORK_MEM to 64MB from 32MB.
