### PR TITLE
ACM-9135: add install strategy

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -148,6 +148,7 @@ spec:
                 - managedclusteraddons/finalizers
                 - clustermanagementaddons/finalizers
                 - managedclusteraddons/status
+                - clustermanagementaddons/status
               verbs:
                 - get
                 - list

--- a/controllers/create_clustermanagementaddon.go
+++ b/controllers/create_clustermanagementaddon.go
@@ -61,6 +61,9 @@ func (r *SearchReconciler) newClusterManagementAddOn(instance *searchv1alpha1.Se
 					},
 				},
 			},
+			InstallStrategy: addonv1alpha1.InstallStrategy{
+				Type: addonv1alpha1.AddonInstallStrategyManual,
+			},
 		},
 	}
 	err := controllerutil.SetControllerReference(instance, cma, r.Scheme)


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-9135

### Description of changes
Resolve issue:
```
#oc -n ocm logs  search-v2-operator-controller-manager-67c57b94dd-v7tld -c manager --tail 7
2023-12-18T21:37:36Z ERROR Reconciler error {"controller": "search", "controllerGroup": "search.open-cluster-management.io", "controllerKind": "Search", "Search":

{"name":"search-v2-operator","namespace":"ocm"}
, "namespace": "ocm", "name": "search-v2-operator", "reconcileID": "3a2b2e07-c72f-4318-aab4-85203faa2f0e", "error": "ClusterManagementAddOn.addon.open-cluster-management.io \"search-collector\" is invalid: spec.installStrategy.type: Unsupported value: \"\": supported values: \"Manual\", \"Placements\""}
```
