### PR TITLE
Removed installstrategy from CMA spec

### DIFF
--- a/bundle/manifests/search-collector.clustermanagementaddon.yaml
+++ b/bundle/manifests/search-collector.clustermanagementaddon.yaml
@@ -9,5 +9,3 @@ spec:
       Collects cluster data to be indexed by search components on the hub
       cluster.
     displayName: Search Collector
-  installStrategy:
-    type: Manual


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-9340

### Description of changes
- Removing install strategy from CMA spec. By default, the install strategy is type manual; therefore, we don't need to define it.
