### PR TITLE
ACM-5229: Update default postgres.conf

### DIFF
--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -25,6 +25,7 @@ func (r *SearchReconciler) PostgresConfigmap(instance *searchv1alpha1.Search) *c
 	data["postgresql.conf"] = `ssl = 'on'
 ssl_cert_file = '/sslcert/tls.crt'
 ssl_key_file = '/sslcert/tls.key'
+ssl_ciphers = 'HIGH:!aNULL'
 max_parallel_workers_per_gather = '8'`
 
 	data[startScript] = `psql -d search -U searchuser -c "CREATE SCHEMA IF NOT EXISTS search"

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -902,6 +902,7 @@ func TestSearch_controller_DBConfigAndEnvOverlap(t *testing.T) {
 		t.Fatalf("Failed to get configmap %s: %v", "search-postgres", err)
 	}
 	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl = 'on'")
+	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl_ciphers = 'HIGH:!aNULL'")
 	verifyConfigmapDataContent(t, configmap, "postgresql-start.sh", "ALTER ROLE searchuser set work_mem='33MB'")
 
 	//check for created search-postgres deployment


### PR DESCRIPTION

### Related Issue

https://issues.redhat.com/browse/ACM-5229

### Description of changes
- Updates the default postgres.conf settings to use only HIGH security ciphers.
