### PR TITLE
move to TLS13

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -195,6 +195,7 @@ spec:
                       - --upstream=http://127.0.0.1:8080/
                       - --logtostderr=true
                       - --v=10
+                      - "--tls-min-version=VersionTLS13"
                     image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
                     name: kube-rbac-proxy
                     ports:
@@ -212,6 +213,7 @@ spec:
                       - --health-probe-bind-address=:8081
                       - --metrics-bind-address=127.0.0.1:8080
                       - --leader-elect
+                      - "--tls-min-version=VersionTLS13"
                     command:
                       - /manager
                     image: quay.io/stolostron/search-v2-operator:2.7.0-dc0fc8c59239b6a0a3f440b7752101523d87f597

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -213,7 +213,6 @@ spec:
                       - --health-probe-bind-address=:8081
                       - --metrics-bind-address=127.0.0.1:8080
                       - --leader-elect
-                      - "--tls-min-version=VersionTLS13"
                     command:
                       - /manager
                     image: quay.io/stolostron/search-v2-operator:2.7.0-dc0fc8c59239b6a0a3f440b7752101523d87f597


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-5230

### Description of changes
- To move to TLS13 in 2.11. Change not to be backported to previous releases.
Similar to https://github.com/stolostron/multiclusterhub-operator/pull/1029/files and https://github.com/stolostron/multiclusterhub-operator/blob/main/pkg/templates/charts/toggle/insights/templates/policyreport-metrics-deployment.yaml
