### PR TITLE
Missing permission to patch manifestwork

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-05-15T03:58:13Z"
+    createdAt: "2024-05-16T18:00:07Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: search-v2-operator.v0.0.1
@@ -307,7 +307,7 @@ spec:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
-                      fieldPath: metadata.namespace
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: POSTGRES_IMAGE
                   value: registry.redhat.io/rhel8/postgresql-13:1-56
                 - name: INDEXER_IMAGE

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -79,7 +79,7 @@ var cleanOnce sync.Once
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/finalizers,verbs=update
-//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=create;delete;get;list
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=create;delete;get;list;patch
 //+kubebuilder:rbac:groups=multicluster.openshift.io,resources=multiclusterengines,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Add missing permission to patch manifestwork.
- Update `metadata.annotations['olm.targetNamespaces']` to reduce manual changes after make bundle.
