### PR TITLE
Add POD_NAMESPACE env var to search-api deployment

### DIFF
--- a/controllers/create_apideployment.go
+++ b/controllers/create_apideployment.go
@@ -23,6 +23,7 @@ func (r *SearchReconciler) APIDeployment(instance *searchv1alpha1.Search) *appsv
 			newSecretEnvVar("DB_PASS", "database-password", "search-postgres"),
 			newSecretEnvVar("DB_NAME", "database-name", "search-postgres"),
 			newEnvVar("DB_HOST", "search-postgres."+instance.Namespace+".svc"),
+			newEnvVar("POD_NAMESPACE", instance.Namespace),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-12216

### Description of changes
- Added `POD_NAMESPACE` env var by default to search-api deployment
Resolve error:

> E0617 15:02:24.399640       1 fedConfig.go:88] Error getting the search-ca-crt configmap: configmaps "search-ca-crt" not found
> E0617 15:02:24.400708       1 fedConfig.go:92] Error appending CA bundle for local service.
> E0617 15:02:24.405903       1 fedConfig.go:125] Error getting ACM install namespaces: Post "https://search-search-api.open-cluster-management.svc:4010/searchapi/graphql": dial tcp: lookup search-search-api.open-cluster-management.svc on 172.30.0.10:53: no such host
