### PR TITLE
increase memory limit for manager container in operator

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -334,7 +334,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 1Gi
+                    memory: 4Gi
                   requests:
                     cpu: 50m
                     memory: 256Mi

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -33,3 +33,10 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        resources:
+          limits:
+            cpu: 200m
+            memory: 4Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/[ACM-11936

### Description of changes
- Increased memory limit to 4Gi to avoid crashlooping in scale env.
