### PR TITLE
update operator memory to 6Gi

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -334,7 +334,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 4Gi
+                    memory: 6Gi
                   requests:
                     cpu: 50m
                     memory: 256Mi

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -36,7 +36,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 4Gi
+            memory: 6Gi
           requests:
             cpu: 50m
             memory: 256Mi


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
[https://issues.redhat.com/browse/ACM-11936](https://issues.redhat.com/browse/%5BACM-11936)

**Description of changes**

Increased memory limit to 6Gi to avoid crashlooping in scale env.
