### PR TITLE
Increase postgres pod termination grace period

### DIFF
--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -158,7 +158,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
 
-	// Use a recreate strategy to reduce the posibility of data corruption.
+	// Use a recreate strategy to reduce the possibility of data corruption.
 	// With the recreate strategy the existing postgres pod will be terminated before the new one starts.
 	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RecreateDeploymentStrategyType,

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -158,6 +158,11 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
 
+	// Use a recreate strategy to reduce the posibility of data corruption.
+	// With the recreate strategy the existing postgres pod will be terminated before the new one starts.
+	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
 	// Increase the termination grace period to allow connections to finish.
 	terminationGracePeriodSeconds := int64(300) // 5 minutes
 	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -158,13 +158,8 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
 
-	// Use a recreate strategy to reduce the posibility of data corruption.
-	// Should consider using a StatefulSet instead to guarantee that at most 1 postgres pod exists at a time.
-	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
-		Type: appsv1.RecreateDeploymentStrategyType,
-	}
 	// Increase the termination grace period to allow connections to finish.
-	terminationGracePeriodSeconds := int64(300) // 5 minutes
+	terminationGracePeriodSeconds := int64(305) // 5 minutes and 5 seconds
 	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 
 	if getNodeSelector(deploymentName, instance) != nil {

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -163,8 +163,8 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RecreateDeploymentStrategyType,
 	}
-	// Increase the termination grce period to reduce the posibility of data corruption.
-	terminationGracePeriodSeconds := int64(120) // 2 minutes
+	// Increase the termination grace period to allow connections to finish.
+	terminationGracePeriodSeconds := int64(300) // 5 minutes
 	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 
 	if getNodeSelector(deploymentName, instance) != nil {

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -159,7 +159,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
 
 	// Increase the termination grace period to allow connections to finish.
-	terminationGracePeriodSeconds := int64(305) // 5 minutes and 5 seconds
+	terminationGracePeriodSeconds := int64(300) // 5 minutes
 	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 
 	if getNodeSelector(deploymentName, instance) != nil {

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -155,6 +155,8 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{postgresContainer}
+	terminationGracePeriodSeconds := int64(120) // 2 minutes
+	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
 	if getNodeSelector(deploymentName, instance) != nil {


### PR DESCRIPTION
### Related Issue

https://issues.redhat.com/browse/ACM-12208

### Description of changes
- Adds `terminationGracePeriodSeconds = 300` to the postgres deployment to extend the termination period to wait while connections are closed and avoid data corruption.
- Use a recreate strategy on the postgres deployment to reduce the possibility of data corruption. With the recreate strategy the existing postgres pod will be terminated before the new one starts.
