### PR TITLE
ACM-15056: remove search-pull-secret from search-serviceaccount

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -58,10 +58,6 @@ func getServiceAccountName() string {
 	return "search-serviceaccount"
 }
 
-func getImagePullSecretName() string {
-	return "search-pull-secret"
-}
-
 func getDefaultDBConfig(varName string) string {
 	value, okay := dbDefaultMap[varName]
 	if okay {

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -29,6 +29,13 @@ func (r *SearchReconciler) createSearchServiceAccount(ctx context.Context,
 			return &reconcile.Result{}, err
 		}
 	}
+	if len(found.ImagePullSecrets) > 1 {
+		if err = r.Update(ctx, sa); err != nil {
+			log.Error(err, "Could not update serviceaccount "+sa.Name)
+			return &reconcile.Result{}, err
+		}
+		log.Info("Updated serviceaccount " + sa.Name)
+	}
 	log.V(2).Info("Created serviceaccount", "ServiceAccount", sa.Name)
 	return nil, nil
 }
@@ -44,9 +51,6 @@ func (r *SearchReconciler) SearchServiceAccount(instance *searchv1alpha1.Search)
 			Name:      getServiceAccountName(),
 			Namespace: instance.GetNamespace(),
 		},
-		ImagePullSecrets: []corev1.LocalObjectReference{{
-			Name: getImagePullSecretName(),
-		}},
 	}
 
 	err := controllerutil.SetControllerReference(instance, sa, r.Scheme)


### PR DESCRIPTION
ACM-15056

### Description of changes
-Removes search-pull-secret from search-serviceaccount. When installing Search via OperatorHub, there is no search-pull-secret that exists. search-serviceaccount references search-pull-secret and will continually log warnings "FailedToRetrieveImagePullSecret" for pods search-postgres, search-api, search-collector, and search-indexer. This bug became visible from the change https://github.com/kubernetes/kubernetes/pull/117927. Simply removing the non-used secret from the serviceaccount resolves the issue.

After removing the secret from the serviceaccount and redeploying the search-collector, we can see the issue resolved for the search-collector as it has the latest version of the serviceaccount, while the other pods are still logging the warning.

```
44m (x64 over 119m)     Warning   FailedToRetrieveImagePullSecret   Pod/search-collector-788d47cc8f-lpxq4                                  Unable to retrieve some image pull secrets (search-pull-secret); attempting to pull the image may not succeed.
4m17s (x97 over 119m)   Warning   FailedToRetrieveImagePullSecret   Pod/search-api-5bdd9748bf-676vh                                        Unable to retrieve some image pull secrets (search-pull-secret); attempting to pull the image may not succeed.
3m54s (x96 over 119m)   Warning   FailedToRetrieveImagePullSecret   Pod/search-postgres-69744fdd7-vlfjr                                    Unable to retrieve some image pull secrets (search-pull-secret); attempting to pull the image may not succeed.
3m38s (x97 over 119m)   Warning   FailedToRetrieveImagePullSecret   Pod/search-indexer-57f6cc8db4-rcmf9                                    Unable to retrieve some image pull secrets (search-pull-secret); attempting to pull the image may not succeed.
```
