### PR TITLE
ACM-16359: Remove memory limits

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -305,11 +305,8 @@ spec:
                   name: https
                   protocol: TCP
                 resources:
-                  limits:
-                    cpu: 200m
-                    memory: 1Gi
                   requests:
-                    cpu: 100m
+                    cpu: 10m
                     memory: 256Mi
               - args:
                 - --health-probe-bind-address=:8081
@@ -345,11 +342,8 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 200m
-                    memory: 6Gi
                   requests:
-                    cpu: 50m
+                    cpu: 10m
                     memory: 256Mi
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,11 +22,8 @@ spec:
           protocol: TCP
           name: https
         resources:
-          limits:
-            cpu: 200m
-            memory: 1Gi
           requests:
-            cpu: 100m
+            cpu: 10m
             memory: 256Mi
       - name: manager
         args:
@@ -34,9 +31,6 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         resources:
-          limits:
-            cpu: 200m
-            memory: 6Gi
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 256Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,11 +61,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 200m
-            memory: 1024Mi
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -260,12 +260,12 @@ func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.Reso
 		}
 
 	} else {
-		// Use default resource requests.
-		cpu := resource.MustParse(defaultResoureMap[deployment]["CPURequest"])
-		memory := resource.MustParse(defaultResoureMap[deployment]["MemoryRequest"])
-		return corev1.ResourceList{
-			corev1.ResourceCPU:    cpu,
-			corev1.ResourceMemory: memory,
+		// Use default requests.
+		if cpu, exists := defaultResoureMap[deployment]["CPURequest"]; exists {
+			requests[corev1.ResourceCPU] = resource.MustParse(cpu)
+		}
+		if memory, exists := defaultResoureMap[deployment]["MemoryRequest"]; exists {
+			requests[corev1.ResourceMemory] = resource.MustParse(memory)
 		}
 	}
 
@@ -301,12 +301,9 @@ func getLimits(deployment string, instance *searchv1alpha1.Search) corev1.Resour
 			}
 		}
 	} else {
-		// Use default limits
-		if mem, exists := defaultResoureMap[deployment]["MemoryLimit"]; exists {
-			memory := resource.MustParse(mem)
-			return corev1.ResourceList{
-				corev1.ResourceMemory: memory,
-			}
+		// Use default memory limit
+		if memory, exists := defaultResoureMap[deployment]["MemoryLimit"]; exists {
+			limits[corev1.ResourceMemory] = resource.MustParse(memory)
 		}
 	}
 	return limits

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -261,7 +261,10 @@ func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.Reso
 
 func getLimits(deployment string, instance *searchv1alpha1.Search) corev1.ResourceList {
 	var cpu, memory, hugepages2Mi, hugepages1Gi resource.Quantity
-	memory = resource.MustParse(defaultResoureMap[deployment]["MemoryLimit"])
+
+	if defaultMemLimit, exists := defaultResoureMap[deployment]["MemoryLimit"]; exists {
+		memory = resource.MustParse(defaultMemLimit)
+	}
 	if !isResourcesCustomized(deployment, instance) {
 		return corev1.ResourceList{
 			corev1.ResourceMemory: memory,

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -236,33 +236,34 @@ func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.Reso
 	requests := corev1.ResourceList{}
 	resources := getDeploymentConfig(deployment, instance).Resources
 
+	// Set default requests. These will get overwritten if we find custom requests later.
+	if cpu, exists := defaultResoureMap[deployment]["CPURequest"]; exists {
+		requests[corev1.ResourceCPU] = resource.MustParse(cpu)
+	}
+	if memory, exists := defaultResoureMap[deployment]["MemoryRequest"]; exists {
+		requests[corev1.ResourceMemory] = resource.MustParse(memory)
+	}
+
+	// Use custom resource requests if these are provided in the search cr instance.
 	if resources != nil && resources.Requests != nil {
 		cpu := *resources.Requests.Cpu()
-		if cpu.String() != "<nil>" && cpu.CmpInt64(0) != 0 {
+		if !cpu.IsZero() {
 			requests[corev1.ResourceCPU] = cpu
 		}
 
 		memory := *resources.Requests.Memory()
-		if memory.String() != "<nil>" && memory.CmpInt64(0) != 0 {
+		if !memory.IsZero() {
 			requests[corev1.ResourceMemory] = memory
 		}
 
 		hugepages2Mi := *resources.Requests.Name(ResourceHugePages2Mi, resource.BinarySI)
-		if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
+		if !hugepages2Mi.IsZero() {
 			requests[ResourceHugePages2Mi] = hugepages2Mi
 		}
 
 		hugepages1Gi := *resources.Requests.Name(ResourceHugePages1Gi, resource.BinarySI)
-		if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
+		if !hugepages1Gi.IsZero() {
 			requests[ResourceHugePages1Gi] = hugepages1Gi
-		}
-	} else {
-		// Use default requests.
-		if cpu, exists := defaultResoureMap[deployment]["CPURequest"]; exists {
-			requests[corev1.ResourceCPU] = resource.MustParse(cpu)
-		}
-		if memory, exists := defaultResoureMap[deployment]["MemoryRequest"]; exists {
-			requests[corev1.ResourceMemory] = resource.MustParse(memory)
 		}
 	}
 
@@ -273,32 +274,34 @@ func getLimits(deployment string, instance *searchv1alpha1.Search) corev1.Resour
 	limits := corev1.ResourceList{}
 	resources := getDeploymentConfig(deployment, instance).Resources
 
+	// Set default memory limit. It will get overwritten if we find custom limits later.
+	if memory, exists := defaultResoureMap[deployment]["MemoryLimit"]; exists {
+		limits[corev1.ResourceMemory] = resource.MustParse(memory)
+	}
+
+	// Use custom resource limits if these are provided in the search cr instance.
 	if resources != nil && resources.Limits != nil {
 		cpu := *resources.Limits.Cpu()
-		if cpu.String() != "<nil>" && cpu.CmpInt64(0) != 0 {
+		if !cpu.IsZero() {
 			limits[corev1.ResourceCPU] = cpu
 		}
 
 		memory := *resources.Limits.Memory()
-		if memory.String() != "<nil>" && memory.CmpInt64(0) != 0 {
+		if !memory.IsZero() {
 			limits[corev1.ResourceMemory] = memory
 		}
 
 		hugepages2Mi := *resources.Limits.Name(ResourceHugePages2Mi, resource.BinarySI)
-		if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
+		if !hugepages2Mi.IsZero() {
 			limits[ResourceHugePages2Mi] = hugepages2Mi
 		}
 
 		hugepages1Gi := *resources.Limits.Name(ResourceHugePages1Gi, resource.BinarySI)
-		if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
+		if !hugepages1Gi.IsZero() {
 			limits[ResourceHugePages1Gi] = hugepages1Gi
 		}
-	} else {
-		// Use default memory limit
-		if memory, exists := defaultResoureMap[deployment]["MemoryLimit"]; exists {
-			limits[corev1.ResourceMemory] = resource.MustParse(memory)
-		}
 	}
+
 	return limits
 }
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -246,19 +246,16 @@ func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.Reso
 		if memory.String() != "<nil>" && memory.CmpInt64(0) != 0 {
 			requests[corev1.ResourceMemory] = memory
 		}
-		if deploymentConfig.Resources.Requests.Name(ResourceHugePages2Mi, resource.BinarySI) != nil {
-			hugepages2Mi := *deploymentConfig.Resources.Requests.Name(ResourceHugePages2Mi, resource.BinarySI)
-			if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
-				requests[ResourceHugePages2Mi] = hugepages2Mi
-			}
-		}
-		if deploymentConfig.Resources.Requests.Name(ResourceHugePages1Gi, resource.BinarySI) != nil {
-			hugepages1Gi := *deploymentConfig.Resources.Requests.Name(ResourceHugePages1Gi, resource.BinarySI)
-			if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
-				requests[ResourceHugePages1Gi] = hugepages1Gi
-			}
+
+		hugepages2Mi := *deploymentConfig.Resources.Requests.Name(ResourceHugePages2Mi, resource.BinarySI)
+		if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
+			requests[ResourceHugePages2Mi] = hugepages2Mi
 		}
 
+		hugepages1Gi := *deploymentConfig.Resources.Requests.Name(ResourceHugePages1Gi, resource.BinarySI)
+		if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
+			requests[ResourceHugePages1Gi] = hugepages1Gi
+		}
 	} else {
 		// Use default requests.
 		if cpu, exists := defaultResoureMap[deployment]["CPURequest"]; exists {
@@ -287,18 +284,14 @@ func getLimits(deployment string, instance *searchv1alpha1.Search) corev1.Resour
 			limits[corev1.ResourceMemory] = memory
 		}
 
-		if deploymentConfig.Resources.Limits.Name(ResourceHugePages2Mi, resource.BinarySI) != nil {
-			hugepages2Mi := *deploymentConfig.Resources.Limits.Name(ResourceHugePages2Mi, resource.BinarySI)
-			if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
-				limits[ResourceHugePages2Mi] = hugepages2Mi
-			}
+		hugepages2Mi := *deploymentConfig.Resources.Limits.Name(ResourceHugePages2Mi, resource.BinarySI)
+		if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
+			limits[ResourceHugePages2Mi] = hugepages2Mi
 		}
 
-		if deploymentConfig.Resources.Limits.Name(ResourceHugePages1Gi, resource.BinarySI) != nil {
-			hugepages1Gi := *deploymentConfig.Resources.Limits.Name(ResourceHugePages1Gi, resource.BinarySI)
-			if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
-				limits[ResourceHugePages1Gi] = hugepages1Gi
-			}
+		hugepages1Gi := *deploymentConfig.Resources.Limits.Name(ResourceHugePages1Gi, resource.BinarySI)
+		if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
+			limits[ResourceHugePages1Gi] = hugepages1Gi
 		}
 	} else {
 		// Use default memory limit

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -234,25 +234,25 @@ func getResourceRequirements(deploymentName string, instance *searchv1alpha1.Sea
 
 func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.ResourceList {
 	requests := corev1.ResourceList{}
-	deploymentConfig := getDeploymentConfig(deployment, instance)
+	resources := getDeploymentConfig(deployment, instance).Resources
 
-	if deploymentConfig.Resources != nil && deploymentConfig.Resources.Requests != nil {
-		cpu := *deploymentConfig.Resources.Requests.Cpu()
+	if resources != nil && resources.Requests != nil {
+		cpu := *resources.Requests.Cpu()
 		if cpu.String() != "<nil>" && cpu.CmpInt64(0) != 0 {
 			requests[corev1.ResourceCPU] = cpu
 		}
 
-		memory := *deploymentConfig.Resources.Requests.Memory()
+		memory := *resources.Requests.Memory()
 		if memory.String() != "<nil>" && memory.CmpInt64(0) != 0 {
 			requests[corev1.ResourceMemory] = memory
 		}
 
-		hugepages2Mi := *deploymentConfig.Resources.Requests.Name(ResourceHugePages2Mi, resource.BinarySI)
+		hugepages2Mi := *resources.Requests.Name(ResourceHugePages2Mi, resource.BinarySI)
 		if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
 			requests[ResourceHugePages2Mi] = hugepages2Mi
 		}
 
-		hugepages1Gi := *deploymentConfig.Resources.Requests.Name(ResourceHugePages1Gi, resource.BinarySI)
+		hugepages1Gi := *resources.Requests.Name(ResourceHugePages1Gi, resource.BinarySI)
 		if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
 			requests[ResourceHugePages1Gi] = hugepages1Gi
 		}
@@ -271,25 +271,25 @@ func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.Reso
 
 func getLimits(deployment string, instance *searchv1alpha1.Search) corev1.ResourceList {
 	limits := corev1.ResourceList{}
-	deploymentConfig := getDeploymentConfig(deployment, instance)
+	resources := getDeploymentConfig(deployment, instance).Resources
 
-	if deploymentConfig.Resources != nil && deploymentConfig.Resources.Limits != nil {
-		cpu := *deploymentConfig.Resources.Limits.Cpu()
+	if resources != nil && resources.Limits != nil {
+		cpu := *resources.Limits.Cpu()
 		if cpu.String() != "<nil>" && cpu.CmpInt64(0) != 0 {
 			limits[corev1.ResourceCPU] = cpu
 		}
 
-		memory := *deploymentConfig.Resources.Limits.Memory()
+		memory := *resources.Limits.Memory()
 		if memory.String() != "<nil>" && memory.CmpInt64(0) != 0 {
 			limits[corev1.ResourceMemory] = memory
 		}
 
-		hugepages2Mi := *deploymentConfig.Resources.Limits.Name(ResourceHugePages2Mi, resource.BinarySI)
+		hugepages2Mi := *resources.Limits.Name(ResourceHugePages2Mi, resource.BinarySI)
 		if hugepages2Mi.String() != "<nil>" && hugepages2Mi.CmpInt64(0) != 0 {
 			limits[ResourceHugePages2Mi] = hugepages2Mi
 		}
 
-		hugepages1Gi := *deploymentConfig.Resources.Limits.Name(ResourceHugePages1Gi, resource.BinarySI)
+		hugepages1Gi := *resources.Limits.Name(ResourceHugePages1Gi, resource.BinarySI)
 		if hugepages1Gi.String() != "<nil>" && hugepages1Gi.CmpInt64(0) != 0 {
 			limits[ResourceHugePages1Gi] = hugepages1Gi
 		}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -237,10 +237,10 @@ func getRequests(deployment string, instance *searchv1alpha1.Search) corev1.Reso
 	resources := getDeploymentConfig(deployment, instance).Resources
 
 	// Set default requests. These will get overwritten if we find custom requests later.
-	if cpu, exists := defaultResoureMap[deployment]["CPURequest"]; exists {
+	if cpu, exists := defaultResourceMap[deployment]["CPURequest"]; exists {
 		requests[corev1.ResourceCPU] = resource.MustParse(cpu)
 	}
-	if memory, exists := defaultResoureMap[deployment]["MemoryRequest"]; exists {
+	if memory, exists := defaultResourceMap[deployment]["MemoryRequest"]; exists {
 		requests[corev1.ResourceMemory] = resource.MustParse(memory)
 	}
 
@@ -275,7 +275,7 @@ func getLimits(deployment string, instance *searchv1alpha1.Search) corev1.Resour
 	resources := getDeploymentConfig(deployment, instance).Resources
 
 	// Set default memory limit. It will get overwritten if we find custom limits later.
-	if memory, exists := defaultResoureMap[deployment]["MemoryLimit"]; exists {
+	if memory, exists := defaultResourceMap[deployment]["MemoryLimit"]; exists {
 		limits[corev1.ResourceMemory] = resource.MustParse(memory)
 	}
 

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -30,35 +30,8 @@ func TestGetDeploymentConfigForNil(t *testing.T) {
 	if deploymentConfig.DeepCopy() == nil {
 		t.Error("DeploymentConfig returned unexpectd nil")
 	}
-	actualCustomized := isDeploymentCustomized("search-api", instance)
-	if !actualCustomized {
-		t.Error("isDeploymentCustomized returned incorrect status")
-	}
 }
-func TestResourcesCustomized(t *testing.T) {
-	instance := &searchv1alpha1.Search{
-		Spec: searchv1alpha1.SearchSpec{
-			Deployments: searchv1alpha1.SearchDeployments{
-				QueryAPI: searchv1alpha1.DeploymentConfig{
-					ReplicaCount: 1,
-					Resources: &corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							"memory": resource.MustParse("25Mi"),
-						},
-						Requests: corev1.ResourceList{
-							"cpu":    resource.MustParse("25m"),
-							"memory": resource.MustParse("10Mi"),
-						},
-					},
-				},
-			},
-		},
-	}
-	want := true
-	if isResourcesCustomized("search-api", instance) != want {
-		t.Error("QueryAPI is not customized")
-	}
-}
+
 func TestResourcesNotCustomized(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{
@@ -79,10 +52,6 @@ func TestResourcesNotCustomized(t *testing.T) {
 		},
 	}
 	os.Setenv("COLLECTOR_IMAGE", "value-from-env")
-	want := false
-	if isResourcesCustomized("search-collector", instance) != want {
-		t.Error("Collector is customized")
-	}
 
 	actualNodelSelector := getNodeSelector("search-collector", instance)
 	if actualNodelSelector != nil {

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -25,7 +25,7 @@ const (
 	default_Postgres_Replicas  = 1
 )
 
-var defaultResoureMap map[string]map[string]string
+var defaultResourceMap map[string]map[string]string
 var defaultReplicaMap map[string]int32
 
 func init() {
@@ -47,7 +47,7 @@ func init() {
 		"MemoryLimit":   default_Postgres_MemoryLimit,
 		"MemoryRequest": default_Postgres_MemoryRequest,
 	}
-	defaultResoureMap = map[string]map[string]string{
+	defaultResourceMap = map[string]map[string]string{
 		apiDeploymentName:       apiResourceMap,
 		collectorDeploymentName: collectorResourceMap,
 		indexerDeploymentName:   indexerResourceMap,

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -3,16 +3,13 @@ package controllers
 
 const (
 	default_API_CPURequest    = "25m"
-	default_API_MemoryLimit   = "1Gi"
 	default_API_MemoryRequest = "1Gi"
 
 	default_Indexer_CPURequest    = "25m"
-	default_Indexer_MemoryLimit   = "1Gi"
 	default_Indexer_MemoryRequest = "32Mi"
 
 	default_Collector_CPURequest    = "25m"
-	default_Collector_MemoryLimit   = "768Mi"
-	default_Collector_MemoryRequest = "64Mi"
+	default_Collector_MemoryRequest = "128Mi"
 
 	default_Postgres_CPURequest             = "25m"
 	default_Postgres_MemoryLimit            = "4Gi"
@@ -35,17 +32,14 @@ func init() {
 	log.Info("Initializing default values")
 	apiResourceMap := map[string]string{
 		"CPURequest":    default_API_CPURequest,
-		"MemoryLimit":   default_API_MemoryLimit,
 		"MemoryRequest": default_API_MemoryRequest,
 	}
 	indexerResourceMap := map[string]string{
 		"CPURequest":    default_Indexer_CPURequest,
-		"MemoryLimit":   default_Indexer_MemoryLimit,
 		"MemoryRequest": default_Indexer_MemoryRequest,
 	}
 	collectorResourceMap := map[string]string{
 		"CPURequest":    default_Collector_CPURequest,
-		"MemoryLimit":   default_Collector_MemoryLimit,
 		"MemoryRequest": default_Collector_MemoryRequest,
 	}
 	postgresResourceMap := map[string]string{

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -2,10 +2,10 @@
 package controllers
 
 const (
-	default_API_CPURequest    = "5m"
+	default_API_CPURequest    = "10m"
 	default_API_MemoryRequest = "512Mi"
 
-	default_Indexer_CPURequest    = "5m"
+	default_Indexer_CPURequest    = "10m"
 	default_Indexer_MemoryRequest = "32Mi"
 
 	default_Collector_CPURequest    = "25m"

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -2,10 +2,10 @@
 package controllers
 
 const (
-	default_API_CPURequest    = "25m"
-	default_API_MemoryRequest = "1Gi"
+	default_API_CPURequest    = "5m"
+	default_API_MemoryRequest = "512Mi"
 
-	default_Indexer_CPURequest    = "25m"
+	default_Indexer_CPURequest    = "5m"
 	default_Indexer_MemoryRequest = "32Mi"
 
 	default_Collector_CPURequest    = "25m"


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-16359

### Description of changes
- Remove memory limit from operator deployment
- Remove default memory limit from search-api, search-indexer, and search-collector deployments.
- Reduce default cpu requests.
