### PR TITLE
Fix name of ManagedServiceAccount for VM actions

### DIFF
--- a/controllers/virtual_machines_setup.go
+++ b/controllers/virtual_machines_setup.go
@@ -18,7 +18,7 @@ import (
 const (
 	CONDITION_VM_ACTIONS  = "VirtualMachineActionsReady"
 	clusterPermissionName = "virtual-machine-actions"
-	managedSAName         = "virtual-machine-actor"
+	managedSAName         = "vm-actor"
 )
 
 var (


### PR DESCRIPTION
### Related Issue

N/A

### Description of changes
- This PR reverts the ManagedServiceAccount name used for VM actions.
- Renames the managedSAName constant from "virtual-machine-actor" to "vm-actor" in the virtual_machines_setup.go file.
