### PR TITLE
ACM-18847 Add permission to create/delete VirtualMachineSnapshot resources

### DIFF
--- a/controllers/virtual_machines_setup.go
+++ b/controllers/virtual_machines_setup.go
@@ -245,6 +245,13 @@ func (r *SearchReconciler) createVMClusterPermission(ctx context.Context, cluste
 							},
 							"verbs": []interface{}{"update"},
 						},
+						map[string]interface{}{
+							"apiGroups": []interface{}{"snapshot.kubevirt.io"},
+							"resources": []interface{}{
+								"virtualmachinesnapshots",
+							},
+							"verbs": []interface{}{"create", "delete"},
+						},
 					},
 				},
 				"clusterRoleBinding": map[string]interface{}{


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-18847

### Description of changes
- Updated ClusterPermission to grant permission to create VirtualMachineSnapshot resources.
