### PR TITLE
[release-2.11] fix sast-snyk-check add missing params

### DIFF
--- a/.tekton/search-v2-operator-acm-211-pull-request.yaml
+++ b/.tekton/search-v2-operator-acm-211-pull-request.yaml
@@ -345,6 +345,10 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.3@sha256:e0c1675c9813618910115f04fd6b3a9ff32d1bd4e2b9c975f1112aa1eae0d149
         - name: kind
           value: task
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
### Description of changes
- Added image-digest and image-url params to fix https://github.com/stolostron/search-v2-operator/pull/459