### PR TITLE
Remove old postgres and image references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= open-cluster-management.io/search-v2-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/stolostron/search-v2-operator:provide-tag
+IMG ?= quay.io/stolostron/search-v2-operator:placeholder-image-tag
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= open-cluster-management.io/search-v2-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/stolostron/search-v2-operator:2.7.0-dc0fc8c59239b6a0a3f440b7752101523d87f597
+IMG ?= quay.io/stolostron/search-v2-operator:provide-tag
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-23T20:18:45Z"
+    createdAt: "2025-07-23T20:24:38Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: search-v2-operator.v0.0.1
@@ -321,14 +321,14 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: POSTGRES_IMAGE
-                  value: registry.redhat.io/rhel9/postgresql-16:9.6
+                  value: registry.redhat.io/rhel9/postgresql-16:placeholder-image-tag
                 - name: INDEXER_IMAGE
-                  value: quay.io/stolostron/search-indexer:provide-tag
+                  value: quay.io/stolostron/search-indexer:placeholder-image-tag
                 - name: COLLECTOR_IMAGE
-                  value: quay.io/stolostron/search-collector:provide-tag
+                  value: quay.io/stolostron/search-collector:placeholder-image-tag
                 - name: API_IMAGE
-                  value: quay.io/stolostron/search-v2-api:provide-tag
-                image: quay.io/stolostron/search-v2-operator:provide-tag
+                  value: quay.io/stolostron/search-v2-api:placeholder-image-tag
+                image: quay.io/stolostron/search-v2-operator:placeholder-image-tag
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-12-03T20:24:18Z"
+    createdAt: "2025-07-23T20:18:45Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: search-v2-operator.v0.0.1
@@ -321,14 +321,14 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: POSTGRES_IMAGE
-                  value: registry.redhat.io/rhel8/postgresql-13:1-56
+                  value: registry.redhat.io/rhel9/postgresql-16:9.6
                 - name: INDEXER_IMAGE
-                  value: quay.io/stolostron/search-indexer:2.7.0-4c1b1f4f692d5f8be9fca699ea26573227250f39
+                  value: quay.io/stolostron/search-indexer:provide-tag
                 - name: COLLECTOR_IMAGE
-                  value: quay.io/stolostron/search-collector:2.7.0-de589fdba4effc06198db8250c1ae3118125d685
+                  value: quay.io/stolostron/search-collector:provide-tag
                 - name: API_IMAGE
-                  value: quay.io/stolostron/search-v2-api:2.7.0-69590634c2de51ceec786af47ca5fb00f42a631a
-                image: quay.io/stolostron/search-v2-operator:2.7.0-dc0fc8c59239b6a0a3f440b7752101523d87f597
+                  value: quay.io/stolostron/search-v2-api:provide-tag
+                image: quay.io/stolostron/search-v2-operator:provide-tag
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/stolostron/search-v2-operator
-  newTag: latest
+  newTag: provide-tag

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/stolostron/search-v2-operator
-  newTag: provide-tag
+  newTag: placeholder-image-tag

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,13 +35,13 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: POSTGRES_IMAGE
-          value: registry.redhat.io/rhel9/postgresql-16:9.6
+          value: registry.redhat.io/rhel9/postgresql-16:placeholder-image-tag
         - name: INDEXER_IMAGE
-          value: quay.io/stolostron/search-indexer:provide-tag
+          value: quay.io/stolostron/search-indexer:placeholder-image-tag
         - name: COLLECTOR_IMAGE
-          value: quay.io/stolostron/search-collector:provide-tag
+          value: quay.io/stolostron/search-collector:placeholder-image-tag
         - name: API_IMAGE
-          value: quay.io/stolostron/search-v2-api:provide-tag
+          value: quay.io/stolostron/search-v2-api:placeholder-image-tag
         args:
         - --leader-elect
         image: controller:latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,13 +35,13 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: POSTGRES_IMAGE
-          value: registry.redhat.io/rhel8/postgresql-13:1-56
+          value: registry.redhat.io/rhel9/postgresql-16:9.6
         - name: INDEXER_IMAGE
-          value: quay.io/stolostron/search-indexer:2.7.0-4c1b1f4f692d5f8be9fca699ea26573227250f39
+          value: quay.io/stolostron/search-indexer:provide-tag
         - name: COLLECTOR_IMAGE
-          value: quay.io/stolostron/search-collector:2.7.0-de589fdba4effc06198db8250c1ae3118125d685
+          value: quay.io/stolostron/search-collector:provide-tag
         - name: API_IMAGE
-          value: quay.io/stolostron/search-v2-api:2.7.0-69590634c2de51ceec786af47ca5fb00f42a631a
+          value: quay.io/stolostron/search-v2-api:provide-tag
         args:
         - --leader-elect
         image: controller:latest


### PR DESCRIPTION
### Related Issue
Slack Thread: https://redhat-internal.slack.com/archives/CTDEY6EEA/p1752842701991419?thread_ts=1752788080.989469&cid=CTDEY6EEA

### Description of changes
- Removes reference to old postgresql-13
- Removes references to old search component images.
