### PR TITLE
ACM-22418 Set default postgres statement_timeout

### DIFF
--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -26,7 +26,8 @@ func (r *SearchReconciler) PostgresConfigmap(instance *searchv1alpha1.Search) *c
 ssl_cert_file = '/sslcert/tls.crt'
 ssl_key_file = '/sslcert/tls.key'
 ssl_ciphers = 'HIGH:!aNULL'
-max_parallel_workers_per_gather = '8'`
+max_parallel_workers_per_gather = '8'
+statement_timeout = '60000'`
 
 	data[startScript] = `psql -d search -U searchuser -c "CREATE SCHEMA IF NOT EXISTS search"
 psql -d search -U searchuser -c "CREATE TABLE IF NOT EXISTS search.resources (uid TEXT PRIMARY KEY, cluster TEXT, data JSONB)"


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-22418

### Description of changes
- Sets postgres default `statement_timeout = '60000'` to provide a fail-safe to limit the impact from inefficient queries.
