### PR TITLE
[release-2.12] fix multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY controllers/ controllers/
 COPY addon/ addon/
 
 # Build
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=1 go build -a -o manager main.go
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001 \

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -18,7 +18,7 @@ COPY addon/ addon/
 
 # Build
 RUN go mod vendor
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=1 go build -a -o manager main.go
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001 \


### PR DESCRIPTION
### Description of changes
- Fixing multi-arch builds. all non amd64 build-images jobs kept failing because for all other arch types, amd64 was hard-coded in.
