### PR TITLE
[WIP] ACM-22991 - handle old postgres versions

### DIFF
--- a/tools/Dockerfile.postgres
+++ b/tools/Dockerfile.postgres
@@ -1,0 +1,7 @@
+FROM quay.io/stolostron/postgresql-16:9.5-1732622748
+
+COPY --chmod=755 before-start.sh /usr/local/bin/before-start.sh
+
+ENTRYPOINT ["/usr/local/bin/before-start.sh"]
+
+CMD ["postgres"]

--- a/tools/before-start.sh
+++ b/tools/before-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PGDATA="/var/lib/pgsql/data"
+PGVERSION_FILE="$PGDATA/userdata/PG_VERSION"
+
+echo "[INFO] Running before-start.sh pre-check..."
+
+if [[ -f "$PGVERSION_FILE" ]]; then
+    CURRENT_VERSION=$(cat "$PGVERSION_FILE" | tr -d '[:space:]')
+    echo "[INFO] Detected existing PostgreSQL version: $CURRENT_VERSION"
+
+    if [[ "$CURRENT_VERSION" == "13" ]]; then
+        echo "[WARN] Found PostgreSQL 13 data directory. This is incompatible with PostgreSQL 16."
+        echo "[WARN] Clearing $PGDATA so Postgres 16 can initialize fresh."
+
+        # Safety check: only delete if path looks correct
+        if [[ "$PGDATA" == "/var/lib/pgsql/data" ]]; then
+            rm -rf "${PGDATA}"/*
+        else
+            echo "[ERROR] PGDATA path ($PGDATA) is unexpected, refusing to delete."
+            exit 1
+        fi
+    else
+        echo "[INFO] PG_VERSION is not 13, keeping existing data."
+    fi
+else
+    echo "[INFO] No existing PG_VERSION file found. Assuming fresh install."
+fi
+
+echo "[INFO] Pre-check complete. Handing off to Postgres..."
+exec /usr/bin/run-postgresql


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-22991

### Description of changes
- Added before-start.sh script to check for prior postgres versioned persistent storage files. If outdated, delete the data and proceed with postgres start up which will recreate proper versioned and structured filesystem and repopulate from Search.
