### PR TITLE
ACM-23280 - remove postgres defaults for effective_cache_size and shared_buffers

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -39,9 +39,7 @@ var (
 	certDefaultMode       = int32(416)
 	AnnotationSearchPause = "search-pause"
 	dbDefaultMap          = map[string]string{
-		"POSTGRESQL_EFFECTIVE_CACHE_SIZE": default_POSTGRESQL_EFFECTIVE_CACHE_SIZE,
-		"POSTGRESQL_SHARED_BUFFERS":       default_POSTGRESQL_SHARED_BUFFERS,
-		"WORK_MEM":                        default_WORK_MEM,
+		"WORK_MEM": default_WORK_MEM,
 	}
 )
 

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -622,9 +622,7 @@ func TestMemoryLimitCustomization(t *testing.T) {
 }
 
 func TestPGDeployment(t *testing.T) {
-	var expectedMap = map[string]string{"POSTGRESQL_SHARED_BUFFERS": "64MB",
-		"POSTGRESQL_EFFECTIVE_CACHE_SIZE": default_POSTGRESQL_EFFECTIVE_CACHE_SIZE,
-		"WORK_MEM":                        "32MB"}
+	var expectedMap = map[string]string{"WORK_MEM": "32MB"}
 
 	var configValueMap = map[string]string{"POSTGRESQL_SHARED_BUFFERS": "64MB",
 		"WORK_MEM": "25MB", //this value is trumped by the envVar
@@ -672,20 +670,6 @@ func TestPGDeployment(t *testing.T) {
 		}
 	}
 
-	// Validate the shared memory volume.
-	var sharedMemoryVolume corev1.Volume
-	for _, vol := range actualDep.Spec.Template.Spec.Volumes {
-		if vol.Name == "dshm" {
-			sharedMemoryVolume = vol
-			break
-		}
-	}
-	if sharedMemoryVolume.Name != "dshm" {
-		t.Errorf("Expected shared volume dshm to be present, but got: %+v ", sharedMemoryVolume)
-	}
-	if !sharedMemoryVolume.VolumeSource.EmptyDir.SizeLimit.Equal(resource.MustParse("1Gi")) {
-		t.Errorf("Expected shared volume SizeLimit to be 1Gi, but got: %+v ", sharedMemoryVolume.VolumeSource.EmptyDir.SizeLimit)
-	}
 }
 
 // Tests for createOrUpdateConfigMap function

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -5,7 +5,6 @@ import (
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -14,12 +13,8 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	image_sha := getImageSha(deploymentName, instance)
 	log.V(2).Info("Using postgres image ", "name", image_sha)
 	deployment := getDeployment(deploymentName, instance)
-	postgresqlSharedBuffers := r.GetDBConfigFromSearchCR(r.context, instance, "POSTGRESQL_SHARED_BUFFERS")
-	postgresqlEffectiveCacheSize := r.GetDBConfigFromSearchCR(r.context, instance, "POSTGRESQL_EFFECTIVE_CACHE_SIZE")
 	postgresqlWorkMem := r.GetDBConfigFromSearchCR(r.context, instance, "WORK_MEM")
 	postgresDefaultEnvVars := []corev1.EnvVar{
-		newEnvVar("POSTGRESQL_SHARED_BUFFERS", postgresqlSharedBuffers),
-		newEnvVar("POSTGRESQL_EFFECTIVE_CACHE_SIZE", postgresqlEffectiveCacheSize),
 		newEnvVar("WORK_MEM", postgresqlWorkMem),
 	}
 	postgresContainer := corev1.Container{
@@ -58,10 +53,6 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 			{
 				Name:      "search-postgres-certs",
 				MountPath: "/sslcert",
-			},
-			{
-				Name:      "dshm",
-				MountPath: "/dev/shm",
 			},
 		},
 		ReadinessProbe: &corev1.Probe{
@@ -104,7 +95,6 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	}
 	postgresContainer.Env = append(postgresContainer.Env, env...)
 	postgresContainer.Resources = getResourceRequirements(deploymentName, instance)
-	shmSizeLimit := resource.MustParse(default_Postgres_SharedMemory)
 	volumes := []corev1.Volume{
 		{
 			Name: "postgresql-cfg",
@@ -142,15 +132,6 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &certDefaultMode,
 					SecretName:  postgresSecretName,
-				},
-			},
-		},
-		{
-			Name: "dshm",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{
-					Medium:    corev1.StorageMediumMemory,
-					SizeLimit: &shmSizeLimit,
 				},
 			},
 		},

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -714,8 +714,6 @@ func TestSearch_controller_DBConfig(t *testing.T) {
 	}
 	//Should be the default constant values set in common.go
 	verifyDeploymentEnv(t, dep, "WORK_MEM", "64MB")
-	verifyDeploymentEnv(t, dep, "POSTGRESQL_SHARED_BUFFERS", "1GB")
-	verifyDeploymentEnv(t, dep, "POSTGRESQL_EFFECTIVE_CACHE_SIZE", "2GB")
 }
 
 func TestSearch_controller_Metrics(t *testing.T) {


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-23280

### Description of changes
- Removed POSTGRESQL_EFFECTIVE_CACHE_SIZE and POSTGRESQL_SHARED_BUFFERS to leverage the auto-tuning feature described in https://catalog.redhat.com/en/software/containers/rhel8/postgresql-16/657c148efd40a94aa696f28e?image=68ae9298cf6ae11bed9b2fee&architecture=amd64#overview

Auto-tune will set shared_memory_size to 25% of memory, effective_cache_size to 50%, and shared_buffers to 25% of memory. Permits overriding these still by adding POSTGRESQL_EFFECTIVE_CACHE_SIZE and POSTGRESQL_SHARED_BUFFERS to Search CR and by adding effective_cache_size and shared_buffers to custom-postgresql.conf as normal. 

Just removes the default override on those two variables.