### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -31,6 +31,7 @@ USER ${USER_UID}
 ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="acm-search-operator-container" \
+      url="https://github.com/stolostron/search-v2-operator" \
       description="Search operator service" \
       maintainer="acm-contact@redhat.com" \
       name="search-operator" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** search-v2-operator

**Branch details:** search-v2-operator (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/search-v2-operator

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.