### PR TITLE
add fieldSuffix to collectorconfig to prevent collisions

### DIFF
--- a/addon/manifests/chart/templates/collectorconfig_crd.yaml
+++ b/addon/manifests/chart/templates/collectorconfig_crd.yaml
@@ -139,9 +139,9 @@ spec:
                       default: ""
                       description: |-
                         FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
-                        For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+                        For example, if fieldSuffix is "grc", a field named "status" becomes "status.grc".
                         Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
-                        This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+                        This allows different extensions (GRC, Virt, etc.) to use different suffixes in the same config.
                       type: string
                     fields:
                       description: Specifies the additional fields on the resource

--- a/addon/manifests/chart/templates/collectorconfig_crd.yaml
+++ b/addon/manifests/chart/templates/collectorconfig_crd.yaml
@@ -135,6 +135,14 @@ spec:
                       description: '[NOT IMPLEMENTED] Specifies to collect status
                         conditions for the resource.'
                       type: boolean
+                    fieldSuffix:
+                      default: ""
+                      description: |-
+                        FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
+                        For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+                        Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
+                        This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+                      type: string
                     fields:
                       description: Specifies the additional fields on the resource
                         to index by Search Collectors.

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -99,9 +99,9 @@ type CollectionRule struct {
 	// +optional
 	// +kubebuilder:default=""
 	// FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
-	// For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+	// For example, if fieldSuffix is "grc", a field named "status" becomes "status.grc".
 	// Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
-	// This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+	// This allows different extensions (GRC, Virt, etc.) to use different suffixes in the same config.
 	FieldSuffix string `json:"fieldSuffix,omitempty"`
 
 	// +optional

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -97,6 +97,14 @@ type CollectionRule struct {
 	Fields []Field `json:"fields,omitempty"`
 
 	// +optional
+	// +kubebuilder:default=""
+	// FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
+	// For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+	// Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
+	// This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+	FieldSuffix string `json:"fieldSuffix,omitempty"`
+
+	// +optional
 	// [NOT IMPLEMENTED] Specifies to collect annotations for the resource.
 	CollectAnnotations *bool `json:"collectAnnotations,omitempty"`
 

--- a/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
@@ -139,9 +139,9 @@ spec:
                       default: ""
                       description: |-
                         FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
-                        For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+                        For example, if fieldSuffix is "grc", a field named "status" becomes "status.grc".
                         Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
-                        This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+                        This allows different extensions (GRC, Virt, etc.) to use different suffixes in the same config.
                       type: string
                     fields:
                       description: Specifies the additional fields on the resource

--- a/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
@@ -135,6 +135,14 @@ spec:
                       description: '[NOT IMPLEMENTED] Specifies to collect status
                         conditions for the resource.'
                       type: boolean
+                    fieldSuffix:
+                      default: ""
+                      description: |-
+                        FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
+                        For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+                        Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
+                        This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+                      type: string
                     fields:
                       description: Specifies the additional fields on the resource
                         to index by Search Collectors.

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -139,9 +139,9 @@ spec:
                       default: ""
                       description: |-
                         FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
-                        For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+                        For example, if fieldSuffix is "grc", a field named "status" becomes "status.grc".
                         Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
-                        This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+                        This allows different extensions (GRC, Virt, etc.) to use different suffixes in the same config.
                       type: string
                     fields:
                       description: Specifies the additional fields on the resource

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -135,6 +135,14 @@ spec:
                       description: '[NOT IMPLEMENTED] Specifies to collect status
                         conditions for the resource.'
                       type: boolean
+                    fieldSuffix:
+                      default: ""
+                      description: |-
+                        FieldSuffix appended to custom field names in this rule to avoid collisions with built-in fields.
+                        For example, if fieldSuffix is "_grc", a field named "status" becomes "status_grc".
+                        Defaults to "" (no suffix). If a collision is detected, the built-in field takes precedence.
+                        This allows different teams (GRC, Virt, etc.) to use different suffixes in the same config.
+                      type: string
                     fields:
                       description: Specifies the additional fields on the resource
                         to index by Search Collectors.

--- a/controllers/create_indexerservice.go
+++ b/controllers/create_indexerservice.go
@@ -15,7 +15,7 @@ func (r *SearchReconciler) IndexerService(instance *searchv1alpha1.Search) *core
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "search-indexer",
 			Namespace:   instance.GetNamespace(),
-			Annotations: map[string]string{"service.beta.openshift.io/serving-cert-secret-name": "search-indexer-certs"},
+			Annotations: map[string]string{"service.beta.openshift.io/serving-cert-secret-name": "search-indexer-certs"}, // #nosec G101
 			Labels:      map[string]string{"search-monitor": "search-indexer"},
 		},
 	}

--- a/controllers/create_metrics_monitor.go
+++ b/controllers/create_metrics_monitor.go
@@ -93,7 +93,7 @@ func (r *SearchReconciler) ServiceMonitor(instance *searchv1alpha1.Search,
 					Scheme:          "https",
 					ScrapeTimeout:   "10s",
 					Interval:        "60s",
-					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", // #nosec G101
 					TLSConfig: &monitorv1.TLSConfig{
 						SafeTLSConfig: monitorv1.SafeTLSConfig{InsecureSkipVerify: true}},
 				},


### PR DESCRIPTION
### Description of changes
- Added fieldSuffix to collectorConfig to avoid collisions with built in field collection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection rules gain a configurable field suffix: append a custom suffix to indexed field names to avoid collisions with built-in fields; built-in fields continue to take precedence on name conflicts.
* **Chores**
  * Internal tooling and lint-suppression annotations added to service and monitoring configurations (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->