### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -18,7 +18,7 @@ COPY addon/ addon/
 
 # Build
 RUN go mod vendor
-RUN CGO_ENABLED=1 go build -a -o manager main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -a -o manager main.go
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001 \


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-0000

### Description of changes
- Added ...
