### PR TITLE
add collectorconfig webhook to bundle to get picked up by mch

### DIFF
--- a/bundle/manifests/search-v2-operator-validatingwebhookconfiguration.yaml
+++ b/bundle/manifests/search-v2-operator-validatingwebhookconfiguration.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: search-v2-operator-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: search-v2-operator-webhook-service
+      path: /validate-search-open-cluster-management-io-v1alpha1-collectorconfig
+  failurePolicy: Fail
+  name: vcollectorconfig.kb.io
+  rules:
+  - apiGroups:
+    - search.open-cluster-management.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - collectorconfigs
+  sideEffects: None

--- a/bundle/manifests/search-v2-operator-validatingwebhookconfiguration.yaml
+++ b/bundle/manifests/search-v2-operator-validatingwebhookconfiguration.yaml
@@ -2,6 +2,8 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
   name: search-v2-operator-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
multiclusterhub-operator bundle update [PR](https://github.com/stolostron/multiclusterhub-operator/pull/3997/changes), need to explicitly add the validatingwebhookconfiguration to bundle/manifests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-side validation webhook for search configuration changes, enforcing validation on create and update operations to improve data integrity and prevent invalid submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->