### PR TITLE
fix: add collectorconfigs/status RBAC to CSV clusterPermissions

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -267,6 +267,13 @@ spec:
           - patch
           - update
         - apiGroups:
+          - search.open-cluster-management.io
+          resources:
+          - collectorconfigs/status
+          verbs:
+          - patch
+          - update
+        - apiGroups:
           - work.open-cluster-management.io
           resources:
           - manifestworks


### PR DESCRIPTION
## Problem

The search-v2-operator now manages `collectorconfigs/status` (added in #726) but the OLM ClusterServiceVersion `clusterPermissions` section was missing the `patch`/`update` rule for this subresource.

MCH automation builds its `search-v2-operator` ClusterRole from this CSV. Without this entry, MCH strips the permission on the next run, causing the operator to fail reconciliation:

```
clusterroles.rbac.authorization.k8s.io "search" is forbidden: user
"system:serviceaccount:open-cluster-management:search-v2-operator" is
attempting to grant RBAC permissions not currently held:
{APIGroups:["search.open-cluster-management.io"],
 Resources:["collectorconfigs/status"], Verbs:["patch" "update"]}
```

This blocked MCH in `Installing` status on build `5.0.0-73`.

## Fix

Add `collectorconfigs/status` with `patch`/`update` to the CSV `clusterPermissions` section. Only the `/status` subresource needs to be added — base `collectorconfigs` get/list/watch is already covered by the existing wildcard rule.

## Related

- #726 — feature PR that introduced the `collectorconfigs/status` RBAC in the Go code
- stolostron/multiclusterhub-operator#4192 — companion fix adding the rule to the MCH ClusterRole template

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search operator capabilities to enable administrators to update and manage collector configurations more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->