### PR TITLE
ACM-21883 - integration collector config

### DIFF
--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -33,6 +33,13 @@ const (
 // was applied successfully. When False, the Message field describes which rules were skipped and why.
 const CollectorConfigConditionApplied = "Applied"
 
+// IntegrationTeamLabel is the label key that integration teams apply to their CollectorConfig CRs
+// so the operator discovers and merges them into the merged-collector-config.
+const IntegrationTeamLabel = "search.open-cluster-management.io/config-type"
+
+// IntegrationTeamLabelValue is the expected value for IntegrationTeamLabel.
+const IntegrationTeamLabelValue = "integration"
+
 // Reason constants for the CollectorConfig Applied condition.
 const (
 	// CollectorConfigReasonApplied means all rules were processed and applied successfully.

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -17,10 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-const (
-	operatorServiceAccount = "search-serviceaccount"
-)
-
 // log is for logging in this package.
 var collectorconfiglog = logf.Log.WithName("collectorconfig-resource")
 
@@ -69,7 +65,7 @@ func (r *CollectorConfig) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	}
 	collectorconfiglog.Info("validate update", "name", cc.Name)
 
-	// Check both old and new objects — prevents stripping the integration label to bypass protection.
+	// Check both old and new objects — prevents stripping the owner reference to bypass protection.
 	if err := rejectIfProtected(ctx, cc); err != nil {
 		return nil, err
 	}
@@ -285,33 +281,36 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
-// isProtectedConfig returns true for configs managed by the operator.
-// This includes merged-collector-config (by name) and any config labeled as an integration team config.
-func isProtectedConfig(name string, labels map[string]string) bool {
-	if name == "merged-collector-config" {
-		return true
-	}
-	if labels[IntegrationTeamLabel] == IntegrationTeamLabelValue {
-		return true
+// isOperatorOwned returns true if the CollectorConfig has a controller owner reference,
+// indicating it is managed by the operator and should not be modified directly.
+func isOperatorOwned(cc *CollectorConfig) bool {
+	for _, ref := range cc.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			return true
+		}
 	}
 	return false
 }
 
-// isOperatorServiceAccount checks whether the request originates from the operator's service account
-// in the same namespace as the CollectorConfig being acted on.
-func isOperatorServiceAccount(ctx context.Context) bool {
+// rejectIfProtected returns an error if the config has a controller owner reference
+// and the caller is not a service account in the same namespace (i.e., not the operator).
+func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
+	if !isOperatorOwned(cc) {
+		return nil
+	}
+
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
-		return false
+		return fmt.Errorf("could not extract admission request: %v", err)
 	}
-	expectedUser := fmt.Sprintf("system:serviceaccount:%s:%s", req.Namespace, operatorServiceAccount)
-	return req.UserInfo.Username == expectedUser
-}
 
-// rejectIfProtected returns an error if the config is operator-managed and the caller is not the operator SA.
-func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
-	if isProtectedConfig(cc.Name, cc.Labels) && !isOperatorServiceAccount(ctx) {
-		return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", cc.Name)
+	// Allow any service account in the resource's namespace.
+	// Only the operator namespace should have write RBAC for CollectorConfigs,
+	// so namespace-scoped SA check is sufficient.
+	expectedPrefix := fmt.Sprintf("system:serviceaccount:%s:", req.Namespace)
+	if strings.HasPrefix(req.UserInfo.Username, expectedPrefix) {
+		return nil
 	}
-	return nil
+
+	return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", cc.Name)
 }

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -297,14 +297,15 @@ func isProtectedConfig(name string, labels map[string]string) bool {
 	return false
 }
 
-// isOperatorServiceAccount checks whether the request originates from the operator's service account.
+// isOperatorServiceAccount checks whether the request originates from the operator's service account
+// in the same namespace as the CollectorConfig being acted on.
 func isOperatorServiceAccount(ctx context.Context) bool {
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
 		return false
 	}
-	return strings.HasPrefix(req.UserInfo.Username, "system:serviceaccount:") &&
-		strings.HasSuffix(req.UserInfo.Username, ":"+operatorServiceAccount)
+	expectedUser := fmt.Sprintf("system:serviceaccount:%s:%s", req.Namespace, operatorServiceAccount)
+	return req.UserInfo.Username == expectedUser
 }
 
 // rejectIfProtected returns an error if the config is operator-managed and the caller is not the operator SA.

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -49,7 +49,7 @@ func (r *CollectorConfig) ValidateCreate(ctx context.Context, obj runtime.Object
 	}
 	collectorconfiglog.Info("validate create", "name", cc.Name)
 
-	if err := rejectIfProtected(ctx, cc.Name); err != nil {
+	if err := rejectIfProtected(ctx, cc); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +65,7 @@ func (r *CollectorConfig) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	}
 	collectorconfiglog.Info("validate update", "name", cc.Name)
 
-	if err := rejectIfProtected(ctx, cc.Name); err != nil {
+	if err := rejectIfProtected(ctx, cc); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func (r *CollectorConfig) ValidateDelete(ctx context.Context, obj runtime.Object
 	}
 	collectorconfiglog.Info("validate delete", "name", cc.Name)
 
-	if err := rejectIfProtected(ctx, cc.Name); err != nil {
+	if err := rejectIfProtected(ctx, cc); err != nil {
 		return nil, err
 	}
 
@@ -278,8 +278,15 @@ func contains(slice []string, item string) bool {
 }
 
 // isProtectedConfig returns true for configs managed by the operator.
-func isProtectedConfig(name string) bool {
-	return name == "merged-collector-config" || name == "integration-collector-config"
+// This includes merged-collector-config (by name) and any config labeled as an integration team config.
+func isProtectedConfig(name string, labels map[string]string) bool {
+	if name == "merged-collector-config" {
+		return true
+	}
+	if labels["search.open-cluster-management.io/config-type"] == "integration" {
+		return true
+	}
+	return false
 }
 
 // isOperatorServiceAccount checks whether the request originates from the operator's service account.
@@ -293,9 +300,9 @@ func isOperatorServiceAccount(ctx context.Context) bool {
 }
 
 // rejectIfProtected returns an error if the config is operator-managed and the caller is not the operator SA.
-func rejectIfProtected(ctx context.Context, name string) error {
-	if isProtectedConfig(name) && !isOperatorServiceAccount(ctx) {
-		return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", name)
+func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
+	if isProtectedConfig(cc.Name, cc.Labels) && !isOperatorServiceAccount(ctx) {
+		return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", cc.Name)
 	}
 	return nil
 }

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -17,6 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+const (
+	operatorServiceAccount = "search-serviceaccount"
+)
+
 // log is for logging in this package.
 var collectorconfiglog = logf.Log.WithName("collectorconfig-resource")
 
@@ -33,7 +37,7 @@ func (r *CollectorConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-search-open-cluster-management-io-v1alpha1-collectorconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=create;update,versions=v1alpha1,name=vcollectorconfig.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-search-open-cluster-management-io-v1alpha1-collectorconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=create;update;delete,versions=v1alpha1,name=vcollectorconfig.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &CollectorConfig{}
 
@@ -44,6 +48,10 @@ func (r *CollectorConfig) ValidateCreate(ctx context.Context, obj runtime.Object
 		return nil, fmt.Errorf("expected a CollectorConfig object but got %T", obj)
 	}
 	collectorconfiglog.Info("validate create", "name", cc.Name)
+
+	if err := rejectIfProtected(ctx, cc.Name); err != nil {
+		return nil, err
+	}
 
 	err := cc.validateCollectorConfig()
 	return nil, err
@@ -57,6 +65,10 @@ func (r *CollectorConfig) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	}
 	collectorconfiglog.Info("validate update", "name", cc.Name)
 
+	if err := rejectIfProtected(ctx, cc.Name); err != nil {
+		return nil, err
+	}
+
 	err := cc.validateCollectorConfig()
 	return nil, err
 }
@@ -69,7 +81,10 @@ func (r *CollectorConfig) ValidateDelete(ctx context.Context, obj runtime.Object
 	}
 	collectorconfiglog.Info("validate delete", "name", cc.Name)
 
-	// No validation needed for deletion
+	if err := rejectIfProtected(ctx, cc.Name); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -260,4 +275,27 @@ func contains(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+// isProtectedConfig returns true for configs managed by the operator.
+func isProtectedConfig(name string) bool {
+	return name == "merged-collector-config" || name == "integration-collector-config"
+}
+
+// isOperatorServiceAccount checks whether the request originates from the operator's service account.
+func isOperatorServiceAccount(ctx context.Context) bool {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(req.UserInfo.Username, "system:serviceaccount:") &&
+		strings.HasSuffix(req.UserInfo.Username, ":"+operatorServiceAccount)
+}
+
+// rejectIfProtected returns an error if the config is operator-managed and the caller is not the operator SA.
+func rejectIfProtected(ctx context.Context, name string) error {
+	if isProtectedConfig(name) && !isOperatorServiceAccount(ctx) {
+		return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", name)
+	}
+	return nil
 }

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -63,9 +63,17 @@ func (r *CollectorConfig) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	if !ok {
 		return nil, fmt.Errorf("expected a CollectorConfig object but got %T", newObj)
 	}
+	oldCC, ok := oldObj.(*CollectorConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a CollectorConfig object but got %T", oldObj)
+	}
 	collectorconfiglog.Info("validate update", "name", cc.Name)
 
+	// Check both old and new objects — prevents stripping the integration label to bypass protection.
 	if err := rejectIfProtected(ctx, cc); err != nil {
+		return nil, err
+	}
+	if err := rejectIfProtected(ctx, oldCC); err != nil {
 		return nil, err
 	}
 
@@ -283,7 +291,7 @@ func isProtectedConfig(name string, labels map[string]string) bool {
 	if name == "merged-collector-config" {
 		return true
 	}
-	if labels["search.open-cluster-management.io/config-type"] == "integration" {
+	if labels[IntegrationTeamLabel] == IntegrationTeamLabelValue {
 		return true
 	}
 	return false

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -417,10 +417,10 @@ func TestRejectNonOperatorAddIntegrationLabel(t *testing.T) {
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
 
-// Non-operator creating customer-collector-config → allowed.
-func TestAllowNonOperatorCreateCustomer(t *testing.T) {
+// Non-operator creating user-collector-config → allowed.
+func TestAllowNonOperatorCreateUser(t *testing.T) {
 	c := validConfig()
-	c.Name = "customer-collector-config"
+	c.Name = "user-collector-config"
 	_, err := c.ValidateCreate(nonOperatorCtx(), c)
 	assert.NoError(t, err)
 }

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -325,7 +325,8 @@ func TestRejectCollectConditionsWithoutApiGroups(t *testing.T) {
 func ctxWithUser(username string) context.Context {
 	return admission.NewContextWithRequest(context.Background(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
-			UserInfo: authenticationv1.UserInfo{Username: username},
+			UserInfo:  authenticationv1.UserInfo{Username: username},
+			Namespace: "open-cluster-management",
 		},
 	})
 }
@@ -457,4 +458,13 @@ func TestAllowOperatorDeleteProtected(t *testing.T) {
 	c.Name = "merged-collector-config"
 	_, err := c.ValidateDelete(operatorCtx(), c)
 	assert.NoError(t, err)
+}
+
+// SA with the correct name but wrong namespace → rejected.
+func TestRejectOperatorSAFromWrongNamespace(t *testing.T) {
+	wrongNsCtx := ctxWithUser("system:serviceaccount:attacker-ns:search-serviceaccount")
+	c := validConfig()
+	c.Name = "merged-collector-config"
+	_, err := c.ValidateCreate(wrongNsCtx, c)
+	assert.Error(t, err)
 }

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -347,13 +347,22 @@ func TestRejectNonOperatorCreateMerged(t *testing.T) {
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
 
-// Non-operator creating integration-collector-config → rejected.
-func TestRejectNonOperatorCreateIntegration(t *testing.T) {
+// Non-operator creating a labeled integration team config → rejected.
+func TestRejectNonOperatorCreateLabeledIntegrationConfig(t *testing.T) {
 	c := validConfig()
-	c.Name = "integration-collector-config"
+	c.Name = "team-a-collector-config"
+	c.Labels = map[string]string{"search.open-cluster-management.io/config-type": "integration"}
 	_, err := c.ValidateCreate(nonOperatorCtx(), c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator creating an unlabeled config → allowed.
+func TestAllowNonOperatorCreateUnlabeledConfig(t *testing.T) {
+	c := validConfig()
+	c.Name = "my-custom-config"
+	_, err := c.ValidateCreate(nonOperatorCtx(), c)
+	assert.NoError(t, err)
 }
 
 // Non-operator updating merged-collector-config → rejected.
@@ -375,10 +384,11 @@ func TestRejectNonOperatorDeleteMerged(t *testing.T) {
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
 
-// Non-operator deleting integration-collector-config → rejected.
-func TestRejectNonOperatorDeleteIntegration(t *testing.T) {
+// Non-operator deleting a labeled integration team config → rejected.
+func TestRejectNonOperatorDeleteLabeledIntegrationConfig(t *testing.T) {
 	c := validConfig()
-	c.Name = "integration-collector-config"
+	c.Name = "team-a-collector-config"
+	c.Labels = map[string]string{"search.open-cluster-management.io/config-type": "integration"}
 	_, err := c.ValidateDelete(nonOperatorCtx(), c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
@@ -400,12 +410,21 @@ func TestAllowOperatorCreateMerged(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// Operator SA updating integration-collector-config → allowed.
-func TestAllowOperatorUpdateIntegration(t *testing.T) {
+// Operator SA updating merged-collector-config → allowed.
+func TestAllowOperatorUpdateMerged(t *testing.T) {
 	old := validConfig()
-	old.Name = "integration-collector-config"
+	old.Name = "merged-collector-config"
 	updated := old.DeepCopy()
 	_, err := updated.ValidateUpdate(operatorCtx(), old, updated)
+	assert.NoError(t, err)
+}
+
+// Operator SA creating a labeled integration team config → allowed.
+func TestAllowOperatorCreateLabeledIntegrationConfig(t *testing.T) {
+	c := validConfig()
+	c.Name = "team-a-collector-config"
+	c.Labels = map[string]string{"search.open-cluster-management.io/config-type": "integration"}
+	_, err := c.ValidateCreate(operatorCtx(), c)
 	assert.NoError(t, err)
 }
 

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -351,7 +351,7 @@ func TestRejectNonOperatorCreateMerged(t *testing.T) {
 func TestRejectNonOperatorCreateLabeledIntegrationConfig(t *testing.T) {
 	c := validConfig()
 	c.Name = "team-a-collector-config"
-	c.Labels = map[string]string{"search.open-cluster-management.io/config-type": "integration"}
+	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
 	_, err := c.ValidateCreate(nonOperatorCtx(), c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
@@ -388,8 +388,31 @@ func TestRejectNonOperatorDeleteMerged(t *testing.T) {
 func TestRejectNonOperatorDeleteLabeledIntegrationConfig(t *testing.T) {
 	c := validConfig()
 	c.Name = "team-a-collector-config"
-	c.Labels = map[string]string{"search.open-cluster-management.io/config-type": "integration"}
+	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
 	_, err := c.ValidateDelete(nonOperatorCtx(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator stripping the integration label on update → rejected.
+func TestRejectNonOperatorStripIntegrationLabel(t *testing.T) {
+	old := validConfig()
+	old.Name = "team-a-collector-config"
+	old.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
+	updated := old.DeepCopy()
+	updated.Labels = map[string]string{} // strip the label
+	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator adding the integration label on update → rejected.
+func TestRejectNonOperatorAddIntegrationLabel(t *testing.T) {
+	old := validConfig()
+	old.Name = "my-config"
+	updated := old.DeepCopy()
+	updated.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
+	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
@@ -423,7 +446,7 @@ func TestAllowOperatorUpdateMerged(t *testing.T) {
 func TestAllowOperatorCreateLabeledIntegrationConfig(t *testing.T) {
 	c := validConfig()
 	c.Name = "team-a-collector-config"
-	c.Labels = map[string]string{"search.open-cluster-management.io/config-type": "integration"}
+	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
 	_, err := c.ValidateCreate(operatorCtx(), c)
 	assert.NoError(t, err)
 }

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -332,139 +332,122 @@ func ctxWithUser(username string) context.Context {
 }
 
 func operatorCtx() context.Context {
-	return ctxWithUser("system:serviceaccount:open-cluster-management:search-serviceaccount")
+	return ctxWithUser("system:serviceaccount:open-cluster-management:search-v2-operator")
 }
 
 func nonOperatorCtx() context.Context {
-	return ctxWithUser("system:serviceaccount:open-cluster-management:default")
+	return ctxWithUser("system:serviceaccount:other-ns:default")
 }
 
-// Non-operator creating merged-collector-config → rejected.
-func TestRejectNonOperatorCreateMerged(t *testing.T) {
+func boolPtr(b bool) *bool { return &b }
+
+func ownedConfig() *CollectorConfig {
 	c := validConfig()
-	c.Name = "merged-collector-config"
+	c.Namespace = "open-cluster-management"
+	c.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "search.open-cluster-management.io/v1alpha1",
+			Kind:       "Search",
+			Name:       "search-v2-operator",
+			Controller: boolPtr(true),
+		},
+	}
+	return c
+}
+
+// Non-operator creating an owned config → rejected.
+func TestRejectNonOperatorCreateOwned(t *testing.T) {
+	c := ownedConfig()
 	_, err := c.ValidateCreate(nonOperatorCtx(), c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
 
-// Non-operator creating a labeled integration team config → rejected.
-func TestRejectNonOperatorCreateLabeledIntegrationConfig(t *testing.T) {
-	c := validConfig()
-	c.Name = "team-a-collector-config"
-	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
-	_, err := c.ValidateCreate(nonOperatorCtx(), c)
+// Non-operator updating an owned config → rejected.
+func TestRejectNonOperatorUpdateOwned(t *testing.T) {
+	old := ownedConfig()
+	updated := old.DeepCopy()
+	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
 
-// Non-operator creating an unlabeled config → allowed.
-func TestAllowNonOperatorCreateUnlabeledConfig(t *testing.T) {
+// Non-operator deleting an owned config → rejected.
+func TestRejectNonOperatorDeleteOwned(t *testing.T) {
+	c := ownedConfig()
+	_, err := c.ValidateDelete(nonOperatorCtx(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator stripping the owner reference on update → rejected (old object is still owned).
+func TestRejectNonOperatorStripOwnerRef(t *testing.T) {
+	old := ownedConfig()
+	updated := old.DeepCopy()
+	updated.OwnerReferences = nil
+	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator creating an unowned config → allowed.
+func TestAllowNonOperatorCreateUnowned(t *testing.T) {
 	c := validConfig()
 	c.Name = "my-custom-config"
 	_, err := c.ValidateCreate(nonOperatorCtx(), c)
 	assert.NoError(t, err)
 }
 
-// Non-operator updating merged-collector-config → rejected.
-func TestRejectNonOperatorUpdateMerged(t *testing.T) {
+// Non-operator updating an unowned config → allowed.
+func TestAllowNonOperatorUpdateUnowned(t *testing.T) {
 	old := validConfig()
-	old.Name = "merged-collector-config"
 	updated := old.DeepCopy()
 	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "managed by the search operator")
+	assert.NoError(t, err)
 }
 
-// Non-operator deleting merged-collector-config → rejected.
-func TestRejectNonOperatorDeleteMerged(t *testing.T) {
+// Non-operator deleting an unowned config → allowed.
+func TestAllowNonOperatorDeleteUnowned(t *testing.T) {
 	c := validConfig()
-	c.Name = "merged-collector-config"
 	_, err := c.ValidateDelete(nonOperatorCtx(), c)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "managed by the search operator")
+	assert.NoError(t, err)
 }
 
-// Non-operator deleting a labeled integration team config → rejected.
-func TestRejectNonOperatorDeleteLabeledIntegrationConfig(t *testing.T) {
+// Non-operator creating a labeled integration config (no owner ref) → allowed.
+func TestAllowNonOperatorCreateLabeledIntegrationConfig(t *testing.T) {
 	c := validConfig()
-	c.Name = "team-a-collector-config"
 	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
-	_, err := c.ValidateDelete(nonOperatorCtx(), c)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "managed by the search operator")
-}
-
-// Non-operator stripping the integration label on update → rejected.
-func TestRejectNonOperatorStripIntegrationLabel(t *testing.T) {
-	old := validConfig()
-	old.Name = "team-a-collector-config"
-	old.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
-	updated := old.DeepCopy()
-	updated.Labels = map[string]string{} // strip the label
-	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "managed by the search operator")
-}
-
-// Non-operator adding the integration label on update → rejected.
-func TestRejectNonOperatorAddIntegrationLabel(t *testing.T) {
-	old := validConfig()
-	old.Name = "my-config"
-	updated := old.DeepCopy()
-	updated.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
-	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "managed by the search operator")
-}
-
-// Non-operator creating user-collector-config → allowed.
-func TestAllowNonOperatorCreateUser(t *testing.T) {
-	c := validConfig()
-	c.Name = "user-collector-config"
 	_, err := c.ValidateCreate(nonOperatorCtx(), c)
 	assert.NoError(t, err)
 }
 
-// Operator SA creating merged-collector-config → allowed.
-func TestAllowOperatorCreateMerged(t *testing.T) {
-	c := validConfig()
-	c.Name = "merged-collector-config"
+// Operator SA creating an owned config → allowed.
+func TestAllowOperatorCreateOwned(t *testing.T) {
+	c := ownedConfig()
 	_, err := c.ValidateCreate(operatorCtx(), c)
 	assert.NoError(t, err)
 }
 
-// Operator SA updating merged-collector-config → allowed.
-func TestAllowOperatorUpdateMerged(t *testing.T) {
-	old := validConfig()
-	old.Name = "merged-collector-config"
+// Operator SA updating an owned config → allowed.
+func TestAllowOperatorUpdateOwned(t *testing.T) {
+	old := ownedConfig()
 	updated := old.DeepCopy()
 	_, err := updated.ValidateUpdate(operatorCtx(), old, updated)
 	assert.NoError(t, err)
 }
 
-// Operator SA creating a labeled integration team config → allowed.
-func TestAllowOperatorCreateLabeledIntegrationConfig(t *testing.T) {
-	c := validConfig()
-	c.Name = "team-a-collector-config"
-	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
-	_, err := c.ValidateCreate(operatorCtx(), c)
-	assert.NoError(t, err)
-}
-
-// Operator SA deleting protected configs → allowed.
-func TestAllowOperatorDeleteProtected(t *testing.T) {
-	c := validConfig()
-	c.Name = "merged-collector-config"
+// Operator SA deleting an owned config → allowed.
+func TestAllowOperatorDeleteOwned(t *testing.T) {
+	c := ownedConfig()
 	_, err := c.ValidateDelete(operatorCtx(), c)
 	assert.NoError(t, err)
 }
 
-// SA with the correct name but wrong namespace → rejected.
-func TestRejectOperatorSAFromWrongNamespace(t *testing.T) {
-	wrongNsCtx := ctxWithUser("system:serviceaccount:attacker-ns:search-serviceaccount")
-	c := validConfig()
-	c.Name = "merged-collector-config"
+// SA from wrong namespace acting on an owned config → rejected.
+func TestRejectSAFromWrongNamespace(t *testing.T) {
+	wrongNsCtx := ctxWithUser("system:serviceaccount:attacker-ns:search-v2-operator")
+	c := ownedConfig()
 	_, err := c.ValidateCreate(wrongNsCtx, c)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
 }

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func validConfig() *CollectorConfig {
@@ -315,4 +318,101 @@ func TestRejectCollectConditionsWithoutApiGroups(t *testing.T) {
 	_, err := c.ValidateCreate(context.Background(), c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "must specify at least one apiGroup")
+}
+
+// --- Webhook protection tests ---
+
+func ctxWithUser(username string) context.Context {
+	return admission.NewContextWithRequest(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UserInfo: authenticationv1.UserInfo{Username: username},
+		},
+	})
+}
+
+func operatorCtx() context.Context {
+	return ctxWithUser("system:serviceaccount:open-cluster-management:search-serviceaccount")
+}
+
+func nonOperatorCtx() context.Context {
+	return ctxWithUser("system:serviceaccount:open-cluster-management:default")
+}
+
+// Non-operator creating merged-collector-config → rejected.
+func TestRejectNonOperatorCreateMerged(t *testing.T) {
+	c := validConfig()
+	c.Name = "merged-collector-config"
+	_, err := c.ValidateCreate(nonOperatorCtx(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator creating integration-collector-config → rejected.
+func TestRejectNonOperatorCreateIntegration(t *testing.T) {
+	c := validConfig()
+	c.Name = "integration-collector-config"
+	_, err := c.ValidateCreate(nonOperatorCtx(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator updating merged-collector-config → rejected.
+func TestRejectNonOperatorUpdateMerged(t *testing.T) {
+	old := validConfig()
+	old.Name = "merged-collector-config"
+	updated := old.DeepCopy()
+	_, err := updated.ValidateUpdate(nonOperatorCtx(), old, updated)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator deleting merged-collector-config → rejected.
+func TestRejectNonOperatorDeleteMerged(t *testing.T) {
+	c := validConfig()
+	c.Name = "merged-collector-config"
+	_, err := c.ValidateDelete(nonOperatorCtx(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator deleting integration-collector-config → rejected.
+func TestRejectNonOperatorDeleteIntegration(t *testing.T) {
+	c := validConfig()
+	c.Name = "integration-collector-config"
+	_, err := c.ValidateDelete(nonOperatorCtx(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Non-operator creating customer-collector-config → allowed.
+func TestAllowNonOperatorCreateCustomer(t *testing.T) {
+	c := validConfig()
+	c.Name = "customer-collector-config"
+	_, err := c.ValidateCreate(nonOperatorCtx(), c)
+	assert.NoError(t, err)
+}
+
+// Operator SA creating merged-collector-config → allowed.
+func TestAllowOperatorCreateMerged(t *testing.T) {
+	c := validConfig()
+	c.Name = "merged-collector-config"
+	_, err := c.ValidateCreate(operatorCtx(), c)
+	assert.NoError(t, err)
+}
+
+// Operator SA updating integration-collector-config → allowed.
+func TestAllowOperatorUpdateIntegration(t *testing.T) {
+	old := validConfig()
+	old.Name = "integration-collector-config"
+	updated := old.DeepCopy()
+	_, err := updated.ValidateUpdate(operatorCtx(), old, updated)
+	assert.NoError(t, err)
+}
+
+// Operator SA deleting protected configs → allowed.
+func TestAllowOperatorDeleteProtected(t *testing.T) {
+	c := validConfig()
+	c.Name = "merged-collector-config"
+	_, err := c.ValidateDelete(operatorCtx(), c)
+	assert.NoError(t, err)
 }

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -245,6 +245,26 @@ spec:
         - apiGroups:
           - search.open-cluster-management.io
           resources:
+          - collectorconfigs
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - search.open-cluster-management.io
+          resources:
+          - collectorconfigs/status
+          - searches/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - search.open-cluster-management.io
+          resources:
           - searches
           verbs:
           - get
@@ -257,21 +277,6 @@ spec:
           resources:
           - searches/finalizers
           verbs:
-          - update
-        - apiGroups:
-          - search.open-cluster-management.io
-          resources:
-          - searches/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - search.open-cluster-management.io
-          resources:
-          - collectorconfigs/status
-          verbs:
-          - patch
           - update
         - apiGroups:
           - work.open-cluster-management.io
@@ -517,6 +522,7 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - collectorconfigs
     sideEffects: None

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -207,8 +207,21 @@ rules:
 - apiGroups:
   - search.open-cluster-management.io
   resources:
-  - collectorconfigs/status
+  - collectorconfigs
   verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - collectorconfigs/status
+  - searches/status
+  verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -226,14 +239,6 @@ rules:
   resources:
   - searches/finalizers
   verbs:
-  - update
-- apiGroups:
-  - search.open-cluster-management.io
-  resources:
-  - searches/status
-  verbs:
-  - get
-  - patch
   - update
 - apiGroups:
   - work.open-cluster-management.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -21,6 +21,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - collectorconfigs
   sideEffects: None

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -19,11 +19,6 @@ import (
 const (
 	customerCollectorConfigName = "customer-collector-config"
 	mergedCollectorConfigName   = "merged-collector-config"
-
-	// integrationTeamLabel is the label key that integration teams apply to their CollectorConfig CRs
-	// so the operator discovers and merges them into merged-collector-config.
-	integrationTeamLabel      = "search.open-cluster-management.io/config-type"
-	integrationTeamLabelValue = "integration"
 )
 
 // createOrUpdateMergedCollectorConfig discovers all integration team CollectorConfig CRs (by label)
@@ -39,7 +34,7 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 	teamConfigs := &searchv1alpha1.CollectorConfigList{}
 	err := r.List(ctx, teamConfigs,
 		client.InNamespace(namespace),
-		client.MatchingLabels{integrationTeamLabel: integrationTeamLabelValue},
+		client.MatchingLabels{searchv1alpha1.IntegrationTeamLabel: searchv1alpha1.IntegrationTeamLabelValue},
 	)
 	if err != nil {
 		log.Error(err, "Could not list integration team CollectorConfigs")
@@ -50,6 +45,8 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 	sort.Slice(teamConfigs.Items, func(i, j int) bool {
 		return teamConfigs.Items[i].Name < teamConfigs.Items[j].Name
 	})
+
+	// FUTURE: detect and handle rule collisions between integration team configs.
 
 	// Build merged spec: integration team rules first, then customer rules.
 	mergedSpec := searchv1alpha1.CollectorConfigSpec{}

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -17,12 +17,12 @@ import (
 )
 
 const (
-	customerCollectorConfigName = "customer-collector-config"
-	mergedCollectorConfigName   = "merged-collector-config"
+	userCollectorConfigName   = "user-collector-config"
+	mergedCollectorConfigName = "merged-collector-config"
 )
 
 // createOrUpdateMergedCollectorConfig discovers all integration team CollectorConfig CRs (by label)
-// and the customer-collector-config (by name), merges their CollectionRules, and writes the result
+// and the user-collector-config (by name), merges their CollectionRules, and writes the result
 // to merged-collector-config.
 func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 	ctx context.Context,
@@ -48,25 +48,25 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 
 	// FUTURE: detect and handle rule collisions between integration team configs.
 
-	// Build merged spec: integration team rules first, then customer rules.
+	// Build merged spec: integration team rules first, then user rules.
 	mergedSpec := searchv1alpha1.CollectorConfigSpec{}
 	for _, tc := range teamConfigs.Items {
 		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, tc.Spec.CollectionRules...)
 	}
 
-	// Get customer-collector-config. Not found is fine, customer may not have created one.
-	customerCC := &searchv1alpha1.CollectorConfig{}
+	// Get user-collector-config. Not found is fine, user may not have created one.
+	userCC := &searchv1alpha1.CollectorConfig{}
 	err = r.Get(ctx, types.NamespacedName{
-		Name:      customerCollectorConfigName,
+		Name:      userCollectorConfigName,
 		Namespace: namespace,
-	}, customerCC)
+	}, userCC)
 	if err != nil && !errors.IsNotFound(err) {
 		return &reconcile.Result{}, err
 	}
 	if err == nil {
-		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, customerCC.Spec.CollectionRules...)
-		if customerCC.Spec.CollectNamespaces != nil {
-			mergedSpec.CollectNamespaces = customerCC.Spec.CollectNamespaces.DeepCopy()
+		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, userCC.Spec.CollectionRules...)
+		if userCC.Spec.CollectNamespaces != nil {
+			mergedSpec.CollectNamespaces = userCC.Spec.CollectNamespaces.DeepCopy()
 		}
 	}
 

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -17,19 +17,19 @@ import (
 )
 
 const (
-	customerCollectorConfigName    = "customer-collector-config"
-	integrationCollectorConfigName = "integration-collector-config"
-	mergedCollectorConfigName      = "merged-collector-config"
+	customerCollectorConfigName = "customer-collector-config"
+	mergedCollectorConfigName   = "merged-collector-config"
 
 	// integrationTeamLabel is the label key that integration teams apply to their CollectorConfig CRs
-	// so the operator discovers and merges them into integration-collector-config.
+	// so the operator discovers and merges them into merged-collector-config.
 	integrationTeamLabel      = "search.open-cluster-management.io/config-type"
 	integrationTeamLabelValue = "integration"
 )
 
-// createOrUpdateIntegrationCollectorConfig discovers all CollectorConfig CRs labeled as integration
-// team configs, merges their CollectionRules, and writes the result to integration-collector-config.
-func (r *SearchReconciler) createOrUpdateIntegrationCollectorConfig(
+// createOrUpdateMergedCollectorConfig discovers all integration team CollectorConfig CRs (by label)
+// and the customer-collector-config (by name), merges their CollectionRules, and writes the result
+// to merged-collector-config.
+func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 	ctx context.Context,
 	instance *searchv1alpha1.Search,
 ) (*reconcile.Result, error) {
@@ -51,136 +51,31 @@ func (r *SearchReconciler) createOrUpdateIntegrationCollectorConfig(
 		return teamConfigs.Items[i].Name < teamConfigs.Items[j].Name
 	})
 
-	// Merge all CollectionRules from team configs.
-	var mergedRules []searchv1alpha1.CollectionRule
+	// Build merged spec: integration team rules first, then customer rules.
+	mergedSpec := searchv1alpha1.CollectorConfigSpec{}
 	for _, tc := range teamConfigs.Items {
-		mergedRules = append(mergedRules, tc.Spec.CollectionRules...)
-	}
-
-	mergedSpec := searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: mergedRules,
-	}
-	// Ensure non-nil slice so DeepEqual works consistently.
-	if mergedSpec.CollectionRules == nil {
-		mergedSpec.CollectionRules = []searchv1alpha1.CollectionRule{}
-	}
-
-	// Get or create integration-collector-config.
-	found := &searchv1alpha1.CollectorConfig{}
-	err = r.Get(ctx, types.NamespacedName{
-		Name:      integrationCollectorConfigName,
-		Namespace: namespace,
-	}, found)
-	if err != nil && errors.IsNotFound(err) {
-		cc := &searchv1alpha1.CollectorConfig{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "CollectorConfig",
-				APIVersion: searchv1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      integrationCollectorConfigName,
-				Namespace: namespace,
-			},
-			Spec: mergedSpec,
-		}
-		if errRef := controllerutil.SetControllerReference(instance, cc, r.Scheme); errRef != nil {
-			log.V(2).Info("Could not set controller reference for integration-collector-config")
-		}
-		err = r.Create(ctx, cc)
-		if err != nil {
-			// FUTURE: detect and handle rule collisions between integration team configs. Leverage status conditions of erroneous config
-			log.Error(err, "Could not create integration-collector-config")
-			return &reconcile.Result{}, err
-		}
-		log.V(2).Info("Created integration-collector-config", "ruleCount", len(mergedRules))
-		return nil, nil
-	} else if err != nil {
-		return &reconcile.Result{}, err
-	}
-
-	// Update only if the spec has changed.
-	if !equality.Semantic.DeepEqual(found.Spec, mergedSpec) {
-		found.Spec = mergedSpec
-		if err := r.Update(ctx, found); err != nil {
-			log.Error(err, "Could not update integration-collector-config")
-			return &reconcile.Result{}, err
-		}
-		log.V(2).Info("Updated integration-collector-config", "ruleCount", len(mergedRules))
-	}
-
-	return nil, nil
-}
-
-func (r *SearchReconciler) createCollectorConfig(
-	ctx context.Context,
-	cc *searchv1alpha1.CollectorConfig,
-) (*reconcile.Result, error) {
-	found := &searchv1alpha1.CollectorConfig{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      cc.Name,
-		Namespace: cc.Namespace,
-	}, found)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			err = r.Create(ctx, cc)
-			if err != nil {
-				log.Error(err, "Could not create CollectorConfig", "name", cc.Name)
-				return &reconcile.Result{}, err
-			}
-			log.V(2).Info("Created CollectorConfig", "name", cc.Name)
-			return nil, nil
-		}
-		log.Error(err, "Could not get CollectorConfig", "name", cc.Name)
-		return &reconcile.Result{}, err
-	}
-	return nil, nil
-}
-
-// createOrUpdateMergedCollectorConfig computes the union of integration-collector-config and
-// customer-collector-config, then creates or updates merged-collector-config.
-func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
-	ctx context.Context,
-	instance *searchv1alpha1.Search,
-) (*reconcile.Result, error) {
-	namespace := instance.GetNamespace()
-
-	// Get integration-collector-config. If it doesn't exist, the operator hasn't created it yet.
-	integrationCC := &searchv1alpha1.CollectorConfig{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      integrationCollectorConfigName,
-		Namespace: namespace,
-	}, integrationCC)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.V(2).Info("integration-collector-config not found, skipping merge")
-			return nil, nil
-		}
-		return &reconcile.Result{}, err
+		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, tc.Spec.CollectionRules...)
 	}
 
 	// Get customer-collector-config. Not found is fine, customer may not have created one.
 	customerCC := &searchv1alpha1.CollectorConfig{}
-	customerExists := true
 	err = r.Get(ctx, types.NamespacedName{
 		Name:      customerCollectorConfigName,
 		Namespace: namespace,
 	}, customerCC)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			customerExists = false
-		} else {
-			return &reconcile.Result{}, err
-		}
+	if err != nil && !errors.IsNotFound(err) {
+		return &reconcile.Result{}, err
 	}
-
-	// Compute merged spec
-	mergedSpec := searchv1alpha1.CollectorConfigSpec{}
-	mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, integrationCC.Spec.CollectionRules...)
-	if customerExists {
+	if err == nil {
 		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, customerCC.Spec.CollectionRules...)
 		if customerCC.Spec.CollectNamespaces != nil {
 			mergedSpec.CollectNamespaces = customerCC.Spec.CollectNamespaces.DeepCopy()
 		}
+	}
+
+	// Ensure non-nil slice so DeepEqual works consistently.
+	if mergedSpec.CollectionRules == nil {
+		mergedSpec.CollectionRules = []searchv1alpha1.CollectionRule{}
 	}
 
 	// Get or create merged-collector-config.
@@ -209,7 +104,7 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 			log.Error(err, "Could not create merged-collector-config")
 			return &reconcile.Result{}, err
 		}
-		log.V(2).Info("Created merged-collector-config")
+		log.V(2).Info("Created merged-collector-config", "ruleCount", len(mergedSpec.CollectionRules))
 		return nil, nil
 	} else if err != nil {
 		return &reconcile.Result{}, err
@@ -222,7 +117,7 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 			log.Error(err, "Could not update merged-collector-config")
 			return &reconcile.Result{}, err
 		}
-		log.V(2).Info("Updated merged-collector-config")
+		log.V(2).Info("Updated merged-collector-config", "ruleCount", len(mergedSpec.CollectionRules))
 	}
 
 	return nil, nil

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -94,7 +94,8 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 			Spec: mergedSpec,
 		}
 		if errRef := controllerutil.SetControllerReference(instance, merged, r.Scheme); errRef != nil {
-			log.V(2).Info("Could not set controller reference for merged-collector-config")
+			log.Error(errRef, "Could not set controller reference for merged-collector-config")
+			return &reconcile.Result{}, errRef
 		}
 		err = r.Create(ctx, merged)
 		if err != nil {

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -1,14 +1,17 @@
 // Copyright Contributors to the Open Cluster Management project
+
 package controllers
 
 import (
 	"context"
+	"sort"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -17,49 +20,95 @@ const (
 	customerCollectorConfigName    = "customer-collector-config"
 	integrationCollectorConfigName = "integration-collector-config"
 	mergedCollectorConfigName      = "merged-collector-config"
+
+	// integrationTeamLabel is the label key that integration teams apply to their CollectorConfig CRs
+	// so the operator discovers and merges them into integration-collector-config.
+	integrationTeamLabel      = "search.open-cluster-management.io/config-type"
+	integrationTeamLabelValue = "integration"
 )
 
-// IntegrationCollectorConfig returns the CollectorConfig managed by the operator for integration teams.
-// This config is merged with the customer-collector-config to produce the merged-collector-config
-// that the collector reads. Integration teams extend collection by adding rules to CollectionRules.
-//
-// Example: to collect a custom field from a Policy CRD, add a rule:
-//
-//	{
-//		Action: searchv1alpha1.ActionInclude,
-//		FieldSuffix: "GRC",
-//		ResourceSelector: searchv1alpha1.ResourceSelector{
-//			APIGroups: []string{"policy.open-cluster-management.io"},
-//			Kinds:     []string{"Policy"},
-//		},
-//		Fields: []searchv1alpha1.Field{
-//			{Name: "severity", JSONPath: "{.spec.severity}"},
-//		},
-//	}
-//
-// Note: Integration teams should always set a FieldSuffix to avoid collisions with customer-defined fields.
-func (r *SearchReconciler) IntegrationCollectorConfig(
+// createOrUpdateIntegrationCollectorConfig discovers all CollectorConfig CRs labeled as integration
+// team configs, merges their CollectionRules, and writes the result to integration-collector-config.
+func (r *SearchReconciler) createOrUpdateIntegrationCollectorConfig(
+	ctx context.Context,
 	instance *searchv1alpha1.Search,
-) *searchv1alpha1.CollectorConfig {
-	cc := &searchv1alpha1.CollectorConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CollectorConfig",
-			APIVersion: searchv1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      integrationCollectorConfigName,
-			Namespace: instance.GetNamespace(),
-		},
-		Spec: searchv1alpha1.CollectorConfigSpec{
-			CollectionRules: []searchv1alpha1.CollectionRule{},
-		},
+) (*reconcile.Result, error) {
+	namespace := instance.GetNamespace()
+
+	// List all integration team CollectorConfigs by label.
+	teamConfigs := &searchv1alpha1.CollectorConfigList{}
+	err := r.List(ctx, teamConfigs,
+		client.InNamespace(namespace),
+		client.MatchingLabels{integrationTeamLabel: integrationTeamLabelValue},
+	)
+	if err != nil {
+		log.Error(err, "Could not list integration team CollectorConfigs")
+		return &reconcile.Result{}, err
 	}
 
-	err := controllerutil.SetControllerReference(instance, cc, r.Scheme)
-	if err != nil {
-		log.V(2).Info("Could not set controller reference for integration-collector-config")
+	// Sort by name for deterministic merge order.
+	sort.Slice(teamConfigs.Items, func(i, j int) bool {
+		return teamConfigs.Items[i].Name < teamConfigs.Items[j].Name
+	})
+
+	// Merge all CollectionRules from team configs.
+	var mergedRules []searchv1alpha1.CollectionRule
+	for _, tc := range teamConfigs.Items {
+		mergedRules = append(mergedRules, tc.Spec.CollectionRules...)
 	}
-	return cc
+
+	mergedSpec := searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: mergedRules,
+	}
+	// Ensure non-nil slice so DeepEqual works consistently.
+	if mergedSpec.CollectionRules == nil {
+		mergedSpec.CollectionRules = []searchv1alpha1.CollectionRule{}
+	}
+
+	// Get or create integration-collector-config.
+	found := &searchv1alpha1.CollectorConfig{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      integrationCollectorConfigName,
+		Namespace: namespace,
+	}, found)
+	if err != nil && errors.IsNotFound(err) {
+		cc := &searchv1alpha1.CollectorConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CollectorConfig",
+				APIVersion: searchv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      integrationCollectorConfigName,
+				Namespace: namespace,
+			},
+			Spec: mergedSpec,
+		}
+		if errRef := controllerutil.SetControllerReference(instance, cc, r.Scheme); errRef != nil {
+			log.V(2).Info("Could not set controller reference for integration-collector-config")
+		}
+		err = r.Create(ctx, cc)
+		if err != nil {
+			// FUTURE: detect and handle rule collisions between integration team configs. Leverage status conditions of erroneous config
+			log.Error(err, "Could not create integration-collector-config")
+			return &reconcile.Result{}, err
+		}
+		log.V(2).Info("Created integration-collector-config", "ruleCount", len(mergedRules))
+		return nil, nil
+	} else if err != nil {
+		return &reconcile.Result{}, err
+	}
+
+	// Update only if the spec has changed.
+	if !equality.Semantic.DeepEqual(found.Spec, mergedSpec) {
+		found.Spec = mergedSpec
+		if err := r.Update(ctx, found); err != nil {
+			log.Error(err, "Could not update integration-collector-config")
+			return &reconcile.Result{}, err
+		}
+		log.V(2).Info("Updated integration-collector-config", "ruleCount", len(mergedRules))
+	}
+
+	return nil, nil
 }
 
 func (r *SearchReconciler) createCollectorConfig(

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -1,0 +1,180 @@
+// Copyright Contributors to the Open Cluster Management project
+package controllers
+
+import (
+	"context"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	customerCollectorConfigName    = "customer-collector-config"
+	integrationCollectorConfigName = "integration-collector-config"
+	mergedCollectorConfigName      = "merged-collector-config"
+)
+
+// IntegrationCollectorConfig returns the CollectorConfig managed by the operator for integration teams.
+// This config is merged with the customer-collector-config to produce the merged-collector-config
+// that the collector reads. Integration teams extend collection by adding rules to CollectionRules.
+//
+// Example: to collect a custom field from a Policy CRD, add a rule:
+//
+//	{
+//		Action: searchv1alpha1.ActionInclude,
+//		FieldSuffix: "GRC",
+//		ResourceSelector: searchv1alpha1.ResourceSelector{
+//			APIGroups: []string{"policy.open-cluster-management.io"},
+//			Kinds:     []string{"Policy"},
+//		},
+//		Fields: []searchv1alpha1.Field{
+//			{Name: "severity", JSONPath: "{.spec.severity}"},
+//		},
+//	}
+//
+// Note: Integration teams should always set a FieldSuffix to avoid collisions with customer-defined fields.
+func (r *SearchReconciler) IntegrationCollectorConfig(
+	instance *searchv1alpha1.Search,
+) *searchv1alpha1.CollectorConfig {
+	cc := &searchv1alpha1.CollectorConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CollectorConfig",
+			APIVersion: searchv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      integrationCollectorConfigName,
+			Namespace: instance.GetNamespace(),
+		},
+		Spec: searchv1alpha1.CollectorConfigSpec{
+			CollectionRules: []searchv1alpha1.CollectionRule{},
+		},
+	}
+
+	err := controllerutil.SetControllerReference(instance, cc, r.Scheme)
+	if err != nil {
+		log.V(2).Info("Could not set controller reference for integration-collector-config")
+	}
+	return cc
+}
+
+func (r *SearchReconciler) createCollectorConfig(
+	ctx context.Context,
+	cc *searchv1alpha1.CollectorConfig,
+) (*reconcile.Result, error) {
+	found := &searchv1alpha1.CollectorConfig{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      cc.Name,
+		Namespace: cc.Namespace,
+	}, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err = r.Create(ctx, cc)
+			if err != nil {
+				log.Error(err, "Could not create CollectorConfig", "name", cc.Name)
+				return &reconcile.Result{}, err
+			}
+			log.V(2).Info("Created CollectorConfig", "name", cc.Name)
+			return nil, nil
+		}
+		log.Error(err, "Could not get CollectorConfig", "name", cc.Name)
+		return &reconcile.Result{}, err
+	}
+	return nil, nil
+}
+
+// createOrUpdateMergedCollectorConfig computes the union of integration-collector-config and
+// customer-collector-config, then creates or updates merged-collector-config.
+func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
+	ctx context.Context,
+	instance *searchv1alpha1.Search,
+) (*reconcile.Result, error) {
+	namespace := instance.GetNamespace()
+
+	// Get integration-collector-config. If it doesn't exist, the operator hasn't created it yet.
+	integrationCC := &searchv1alpha1.CollectorConfig{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      integrationCollectorConfigName,
+		Namespace: namespace,
+	}, integrationCC)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(2).Info("integration-collector-config not found, skipping merge")
+			return nil, nil
+		}
+		return &reconcile.Result{}, err
+	}
+
+	// Get customer-collector-config. Not found is fine, customer may not have created one.
+	customerCC := &searchv1alpha1.CollectorConfig{}
+	customerExists := true
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      customerCollectorConfigName,
+		Namespace: namespace,
+	}, customerCC)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			customerExists = false
+		} else {
+			return &reconcile.Result{}, err
+		}
+	}
+
+	// Compute merged spec
+	mergedSpec := searchv1alpha1.CollectorConfigSpec{}
+	mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, integrationCC.Spec.CollectionRules...)
+	if customerExists {
+		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, customerCC.Spec.CollectionRules...)
+		if customerCC.Spec.CollectNamespaces != nil {
+			mergedSpec.CollectNamespaces = customerCC.Spec.CollectNamespaces.DeepCopy()
+		}
+	}
+
+	// Get or create merged-collector-config.
+	found := &searchv1alpha1.CollectorConfig{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      mergedCollectorConfigName,
+		Namespace: namespace,
+	}, found)
+	if err != nil && errors.IsNotFound(err) {
+		merged := &searchv1alpha1.CollectorConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CollectorConfig",
+				APIVersion: searchv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mergedCollectorConfigName,
+				Namespace: namespace,
+			},
+			Spec: mergedSpec,
+		}
+		if errRef := controllerutil.SetControllerReference(instance, merged, r.Scheme); errRef != nil {
+			log.V(2).Info("Could not set controller reference for merged-collector-config")
+		}
+		err = r.Create(ctx, merged)
+		if err != nil {
+			log.Error(err, "Could not create merged-collector-config")
+			return &reconcile.Result{}, err
+		}
+		log.V(2).Info("Created merged-collector-config")
+		return nil, nil
+	} else if err != nil {
+		return &reconcile.Result{}, err
+	}
+
+	// Update only if the spec has changed.
+	if !equality.Semantic.DeepEqual(found.Spec, mergedSpec) {
+		found.Spec = mergedSpec
+		if err := r.Update(ctx, found); err != nil {
+			log.Error(err, "Could not update merged-collector-config")
+			return &reconcile.Result{}, err
+		}
+		log.V(2).Info("Updated merged-collector-config")
+	}
+
+	return nil, nil
+}

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -1,0 +1,361 @@
+// Copyright Contributors to the Open Cluster Management project
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testNamespace = "open-cluster-management"
+
+func newSearchInstance() *searchv1alpha1.Search {
+	return &searchv1alpha1.Search{
+		TypeMeta: metav1.TypeMeta{Kind: "Search", APIVersion: searchv1alpha1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OperatorName,
+			Namespace: testNamespace,
+		},
+		Spec: searchv1alpha1.SearchSpec{},
+	}
+}
+
+func newCollectorConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
+	return &searchv1alpha1.CollectorConfig{
+		TypeMeta: metav1.TypeMeta{Kind: "CollectorConfig", APIVersion: searchv1alpha1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: spec,
+	}
+}
+
+func setupReconciler(objs ...runtime.Object) *SearchReconciler {
+	s := scheme.Scheme
+	_ = searchv1alpha1.SchemeBuilder.AddToScheme(s)
+	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	return &SearchReconciler{Client: cl, Scheme: s}
+}
+
+func getMergedConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, error) {
+	merged := &searchv1alpha1.CollectorConfig{}
+	err := r.Get(context.TODO(), types.NamespacedName{
+		Name:      mergedCollectorConfigName,
+		Namespace: testNamespace,
+	}, merged)
+	return merged, err
+}
+
+// Test: only integration-collector-config exists -> merged = integration rules
+func TestMerge_IntegrationOnly(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "GRC",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+				Fields:           []searchv1alpha1.Field{{Name: "severity", JSONPath: "{.spec.severity}"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, integrationCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1)
+	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Nil(t, merged.Spec.CollectNamespaces)
+}
+
+// Test: both exist -> merged = union of both rule sets
+func TestMerge_BothExist(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "GRC",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"Secret"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, integrationCC, customerCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 2)
+	// Integration rules come first
+	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Equal(t, searchv1alpha1.ActionExclude, merged.Spec.CollectionRules[1].Action)
+}
+
+// Test: customer-collector-config has empty rules -> merged = integration only
+func TestMerge_CustomerEmptyRules(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "GRC",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	r := setupReconciler(instance, integrationCC, customerCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1)
+	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+}
+
+// Test: both empty -> merged has empty rules
+func TestMerge_BothEmpty(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	r := setupReconciler(instance, integrationCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Empty(t, merged.Spec.CollectionRules)
+}
+
+// Test: customer-collector-config has collectNamespaces -> merged inherits it
+func TestMerge_CustomerCollectNamespaces(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+		CollectNamespaces: &searchv1alpha1.CollectNamespaces{
+			NamespaceSelector: &searchv1alpha1.NamespaceSelector{
+				Include: []string{"production-*"},
+				Exclude: []string{"production-debug"},
+			},
+		},
+	})
+	r := setupReconciler(instance, integrationCC, customerCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.NotNil(t, merged.Spec.CollectNamespaces)
+	assert.Equal(t, []string{"production-*"}, merged.Spec.CollectNamespaces.NamespaceSelector.Include)
+	assert.Equal(t, []string{"production-debug"}, merged.Spec.CollectNamespaces.NamespaceSelector.Exclude)
+}
+
+// Test: customer has no collectNamespaces -> merged has no namespace restriction
+func TestMerge_NoCollectNamespaces(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	r := setupReconciler(instance, integrationCC, customerCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Nil(t, merged.Spec.CollectNamespaces)
+}
+
+// Test: integration-collector-config not found -> skip merge, no error
+func TestMerge_IntegrationNotFound(t *testing.T) {
+	instance := newSearchInstance()
+	r := setupReconciler(instance)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	// merged-collector-config should not exist
+	_, err = getMergedConfig(r)
+	assert.True(t, err != nil, "merged-collector-config should not exist")
+}
+
+// Test: idempotency, reconcile with no changes produces no update
+func TestMerge_Idempotency(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "GRC",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, integrationCC)
+
+	// First call creates merged-collector-config
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged1, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	rv1 := merged1.ResourceVersion
+
+	// Second call should not update (spec unchanged)
+	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged2, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Equal(t, rv1, merged2.ResourceVersion)
+}
+
+// Test: customer deleted after merge -> merged updates to integration only
+func TestMerge_CustomerDeleted(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "GRC",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"Secret"}},
+			},
+		},
+		CollectNamespaces: &searchv1alpha1.CollectNamespaces{
+			NamespaceSelector: &searchv1alpha1.NamespaceSelector{
+				Include: []string{"prod-*"},
+			},
+		},
+	})
+	r := setupReconciler(instance, integrationCC, customerCC)
+
+	// First merge with both configs
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 2)
+	assert.NotNil(t, merged.Spec.CollectNamespaces)
+
+	// Delete customer-collector-config
+	err = r.Delete(context.TODO(), customerCC)
+	assert.Nil(t, err)
+
+	// Re-merge, should revert to integration only
+	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err = getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1)
+	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Nil(t, merged.Spec.CollectNamespaces)
+}
+
+// Test: merged-collector-config has owner reference to Search CR
+func TestMerge_OwnerReference(t *testing.T) {
+	instance := newSearchInstance()
+	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	r := setupReconciler(instance, integrationCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.OwnerReferences, 1)
+	assert.Equal(t, OperatorName, merged.OwnerReferences[0].Name)
+	assert.Equal(t, "Search", merged.OwnerReferences[0].Kind)
+}
+
+// Test: createCollectorConfig creates integration-collector-config if not found
+func TestCreateCollectorConfig(t *testing.T) {
+	instance := newSearchInstance()
+	r := setupReconciler(instance)
+
+	cc := r.IntegrationCollectorConfig(instance)
+	result, err := r.createCollectorConfig(context.TODO(), cc)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	// Verify it was created
+	found := &searchv1alpha1.CollectorConfig{}
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      integrationCollectorConfigName,
+		Namespace: testNamespace,
+	}, found)
+	assert.Nil(t, err)
+	assert.Equal(t, integrationCollectorConfigName, found.Name)
+	assert.Empty(t, found.Spec.CollectionRules)
+}
+
+// Test: createCollectorConfig is idempotent, does not error if already exists
+func TestCreateCollectorConfig_AlreadyExists(t *testing.T) {
+	instance := newSearchInstance()
+	existingCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
+	r := setupReconciler(instance, existingCC)
+
+	cc := r.IntegrationCollectorConfig(instance)
+	result, err := r.createCollectorConfig(context.TODO(), cc)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+}

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -38,11 +38,29 @@ func newCollectorConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *s
 	}
 }
 
+// newIntegrationTeamConfig creates a CollectorConfig with the integration team label.
+func newIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
+	cc := newCollectorConfig(name, spec)
+	cc.Labels = map[string]string{
+		integrationTeamLabel: integrationTeamLabelValue,
+	}
+	return cc
+}
+
 func setupReconciler(objs ...runtime.Object) *SearchReconciler {
 	s := scheme.Scheme
 	_ = searchv1alpha1.SchemeBuilder.AddToScheme(s)
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	return &SearchReconciler{Client: cl, Scheme: s}
+}
+
+func getIntegrationConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, error) {
+	cc := &searchv1alpha1.CollectorConfig{}
+	err := r.Get(context.TODO(), types.NamespacedName{
+		Name:      integrationCollectorConfigName,
+		Namespace: testNamespace,
+	}, cc)
+	return cc, err
 }
 
 func getMergedConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, error) {
@@ -54,40 +72,265 @@ func getMergedConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, erro
 	return merged, err
 }
 
-// Test: only integration-collector-config exists -> merged = integration rules
-func TestMerge_IntegrationOnly(t *testing.T) {
+// --- Integration team config discovery tests ---
+
+func TestIntegration_MultipleTeamConfigs(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "GRC",
+				FieldSuffix:      "FOO",
 				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
 				Fields:           []searchv1alpha1.Field{{Name: "severity", JSONPath: "{.spec.severity}"}},
 			},
 		},
 	})
-	r := setupReconciler(instance, integrationCC)
+	teamB := newIntegrationTeamConfig("team-b-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "BAR",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"kubevirt.io"}, Kinds: []string{"VirtualMachine"}},
+				Fields:           []searchv1alpha1.Field{{Name: "running", JSONPath: "{.spec.running}"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA, teamB)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
+
+	integrationCC, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, integrationCC.Spec.CollectionRules, 2)
+}
+
+func TestIntegration_ZeroTeamConfigs(t *testing.T) {
+	instance := newSearchInstance()
+	r := setupReconciler(instance)
+
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	integrationCC, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Empty(t, integrationCC.Spec.CollectionRules)
+}
+
+func TestIntegration_TeamConfigDeleted(t *testing.T) {
+	instance := newSearchInstance()
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "FOO",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	teamB := newIntegrationTeamConfig("team-b-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "BAR",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"kubevirt.io"}, Kinds: []string{"VirtualMachine"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA, teamB)
+
+	// First merge with both team configs.
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	integrationCC, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, integrationCC.Spec.CollectionRules, 2)
+
+	// Delete team-b.
+	err = r.Delete(context.TODO(), teamB)
+	assert.Nil(t, err)
+
+	// Re-merge should have only team-a's rules.
+	result, err = r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	integrationCC, err = getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, integrationCC.Spec.CollectionRules, 1)
+	assert.Equal(t, "FOO", integrationCC.Spec.CollectionRules[0].FieldSuffix)
+}
+
+func TestIntegration_Idempotency(t *testing.T) {
+	instance := newSearchInstance()
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "FOO",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA)
+
+	// First call creates integration-collector-config.
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	cc1, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	rv1 := cc1.ResourceVersion
+
+	// Second call with no changes should not update.
+	result, err = r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	cc2, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Equal(t, rv1, cc2.ResourceVersion)
+}
+
+func TestIntegration_DeterministicOrder(t *testing.T) {
+	instance := newSearchInstance()
+	// Create in reverse alphabetical order to verify sorting.
+	teamZ := newIntegrationTeamConfig("z-team-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{Action: searchv1alpha1.ActionInclude, FieldSuffix: "Z", ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"Pod"}}},
+		},
+	})
+	teamA := newIntegrationTeamConfig("a-team-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{Action: searchv1alpha1.ActionInclude, FieldSuffix: "A", ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"Service"}}},
+		},
+	})
+	teamM := newIntegrationTeamConfig("m-team-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{Action: searchv1alpha1.ActionInclude, FieldSuffix: "M", ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"ConfigMap"}}},
+		},
+	})
+	r := setupReconciler(instance, teamZ, teamA, teamM)
+
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	integrationCC, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, integrationCC.Spec.CollectionRules, 3)
+	assert.Equal(t, "A", integrationCC.Spec.CollectionRules[0].FieldSuffix)
+	assert.Equal(t, "M", integrationCC.Spec.CollectionRules[1].FieldSuffix)
+	assert.Equal(t, "Z", integrationCC.Spec.CollectionRules[2].FieldSuffix)
+}
+
+func TestIntegration_OnlyLabeledConfigsIncluded(t *testing.T) {
+	instance := newSearchInstance()
+	// Labeled integration team config — should be included.
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "FOO",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+			},
+		},
+	})
+	// Unlabeled config — should NOT be included.
+	unlabeled := newCollectorConfig("unlabeled-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"Secret"}},
+			},
+		},
+	})
+	// Customer config — should NOT be included in integration merge.
+	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"ConfigMap"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA, unlabeled, customerCC)
+
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	integrationCC, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, integrationCC.Spec.CollectionRules, 1)
+	assert.Equal(t, "FOO", integrationCC.Spec.CollectionRules[0].FieldSuffix)
+}
+
+func TestIntegration_OwnerReference(t *testing.T) {
+	instance := newSearchInstance()
+	r := setupReconciler(instance)
+
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	integrationCC, err := getIntegrationConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, integrationCC.OwnerReferences, 1)
+	assert.Equal(t, OperatorName, integrationCC.OwnerReferences[0].Name)
+	assert.Equal(t, "Search", integrationCC.OwnerReferences[0].Kind)
+}
+
+// --- End-to-end merge tests (integration + customer → merged) ---
+
+// runFullMerge calls both stages: integration team merge, then final merge.
+func runFullMerge(r *SearchReconciler, instance *searchv1alpha1.Search) error {
+	if result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance); err != nil || result != nil {
+		return err
+	}
+	if result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance); err != nil || result != nil {
+		return err
+	}
+	return nil
+}
+
+func TestMerge_IntegrationOnly(t *testing.T) {
+	instance := newSearchInstance()
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				FieldSuffix:      "FOO",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
+				Fields:           []searchv1alpha1.Field{{Name: "severity", JSONPath: "{.spec.severity}"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA)
+
+	err := runFullMerge(r, instance)
+	assert.Nil(t, err)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Len(t, merged.Spec.CollectionRules, 1)
-	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 	assert.Nil(t, merged.Spec.CollectNamespaces)
 }
 
-// Test: both exist -> merged = union of both rule sets
 func TestMerge_BothExist(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "GRC",
+				FieldSuffix:      "FOO",
 				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
 			},
 		},
@@ -100,28 +343,26 @@ func TestMerge_BothExist(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, integrationCC, customerCC)
+	r := setupReconciler(instance, teamA, customerCC)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Len(t, merged.Spec.CollectionRules, 2)
-	// Integration rules come first
-	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	// Integration rules come first.
+	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 	assert.Equal(t, searchv1alpha1.ActionExclude, merged.Spec.CollectionRules[1].Action)
 }
 
-// Test: customer-collector-config has empty rules -> merged = integration only
 func TestMerge_CustomerEmptyRules(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "GRC",
+				FieldSuffix:      "FOO",
 				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
 			},
 		},
@@ -129,39 +370,32 @@ func TestMerge_CustomerEmptyRules(t *testing.T) {
 	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
-	r := setupReconciler(instance, integrationCC, customerCC)
+	r := setupReconciler(instance, teamA, customerCC)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Len(t, merged.Spec.CollectionRules, 1)
-	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 }
 
-// Test: both empty -> merged has empty rules
 func TestMerge_BothEmpty(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
-	r := setupReconciler(instance, integrationCC)
+	r := setupReconciler(instance) // No team configs, no customer config.
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Empty(t, merged.Spec.CollectionRules)
 }
 
-// Test: customer-collector-config has collectNamespaces -> merged inherits it
 func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
 	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
@@ -173,11 +407,10 @@ func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, integrationCC, customerCC)
+	r := setupReconciler(instance, teamA, customerCC)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -186,81 +419,80 @@ func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 	assert.Equal(t, []string{"production-debug"}, merged.Spec.CollectNamespaces.NamespaceSelector.Exclude)
 }
 
-// Test: customer has no collectNamespaces -> merged has no namespace restriction
 func TestMerge_NoCollectNamespaces(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
 	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
-	r := setupReconciler(instance, integrationCC, customerCC)
+	r := setupReconciler(instance, teamA, customerCC)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Nil(t, merged.Spec.CollectNamespaces)
 }
 
-// Test: integration-collector-config not found -> skip merge, no error
-func TestMerge_IntegrationNotFound(t *testing.T) {
+func TestMerge_NoTeamConfigs(t *testing.T) {
 	instance := newSearchInstance()
 	r := setupReconciler(instance)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	// With no team configs, integration-collector-config should still be created (empty).
+	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	// merged-collector-config should not exist
-	_, err = getMergedConfig(r)
-	assert.True(t, err != nil, "merged-collector-config should not exist")
+	// Merged should also work.
+	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Empty(t, merged.Spec.CollectionRules)
 }
 
-// Test: idempotency, reconcile with no changes produces no update
 func TestMerge_Idempotency(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "GRC",
+				FieldSuffix:      "FOO",
 				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
 			},
 		},
 	})
-	r := setupReconciler(instance, integrationCC)
+	r := setupReconciler(instance, teamA)
 
-	// First call creates merged-collector-config
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	// First full merge.
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged1, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	rv1 := merged1.ResourceVersion
 
-	// Second call should not update (spec unchanged)
-	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	// Second full merge should not update (spec unchanged).
+	err = runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged2, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Equal(t, rv1, merged2.ResourceVersion)
 }
 
-// Test: customer deleted after merge -> merged updates to integration only
 func TestMerge_CustomerDeleted(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "GRC",
+				FieldSuffix:      "FOO",
 				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
 			},
 		},
@@ -278,45 +510,38 @@ func TestMerge_CustomerDeleted(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, integrationCC, customerCC)
+	r := setupReconciler(instance, teamA, customerCC)
 
-	// First merge with both configs
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	// First merge with both.
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Len(t, merged.Spec.CollectionRules, 2)
 	assert.NotNil(t, merged.Spec.CollectNamespaces)
 
-	// Delete customer-collector-config
+	// Delete customer-collector-config.
 	err = r.Delete(context.TODO(), customerCC)
 	assert.Nil(t, err)
 
-	// Re-merge, should revert to integration only
-	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	// Re-merge, should revert to integration only.
+	err = runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err = getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Len(t, merged.Spec.CollectionRules, 1)
-	assert.Equal(t, "GRC", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 	assert.Nil(t, merged.Spec.CollectNamespaces)
 }
 
-// Test: merged-collector-config has owner reference to Search CR
 func TestMerge_OwnerReference(t *testing.T) {
 	instance := newSearchInstance()
-	integrationCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
-	r := setupReconciler(instance, integrationCC)
+	r := setupReconciler(instance)
 
-	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	err := runFullMerge(r, instance)
 	assert.Nil(t, err)
-	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -325,36 +550,39 @@ func TestMerge_OwnerReference(t *testing.T) {
 	assert.Equal(t, "Search", merged.OwnerReferences[0].Kind)
 }
 
-// Test: createCollectorConfig creates integration-collector-config if not found
+// --- createCollectorConfig helper tests ---
+
 func TestCreateCollectorConfig(t *testing.T) {
 	instance := newSearchInstance()
 	r := setupReconciler(instance)
 
-	cc := r.IntegrationCollectorConfig(instance)
+	cc := newCollectorConfig("test-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
 	result, err := r.createCollectorConfig(context.TODO(), cc)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	// Verify it was created
+	// Verify it was created.
 	found := &searchv1alpha1.CollectorConfig{}
 	err = r.Get(context.TODO(), types.NamespacedName{
-		Name:      integrationCollectorConfigName,
+		Name:      "test-config",
 		Namespace: testNamespace,
 	}, found)
 	assert.Nil(t, err)
-	assert.Equal(t, integrationCollectorConfigName, found.Name)
-	assert.Empty(t, found.Spec.CollectionRules)
+	assert.Equal(t, "test-config", found.Name)
 }
 
-// Test: createCollectorConfig is idempotent, does not error if already exists
 func TestCreateCollectorConfig_AlreadyExists(t *testing.T) {
 	instance := newSearchInstance()
-	existingCC := newCollectorConfig(integrationCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	existingCC := newCollectorConfig("test-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
 	r := setupReconciler(instance, existingCC)
 
-	cc := r.IntegrationCollectorConfig(instance)
+	cc := newCollectorConfig("test-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{},
+	})
 	result, err := r.createCollectorConfig(context.TODO(), cc)
 	assert.Nil(t, err)
 	assert.Nil(t, result)

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -54,15 +54,6 @@ func setupReconciler(objs ...runtime.Object) *SearchReconciler {
 	return &SearchReconciler{Client: cl, Scheme: s}
 }
 
-func getIntegrationConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, error) {
-	cc := &searchv1alpha1.CollectorConfig{}
-	err := r.Get(context.TODO(), types.NamespacedName{
-		Name:      integrationCollectorConfigName,
-		Namespace: testNamespace,
-	}, cc)
-	return cc, err
-}
-
 func getMergedConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, error) {
 	merged := &searchv1alpha1.CollectorConfig{}
 	err := r.Get(context.TODO(), types.NamespacedName{
@@ -72,9 +63,9 @@ func getMergedConfig(r *SearchReconciler) (*searchv1alpha1.CollectorConfig, erro
 	return merged, err
 }
 
-// --- Integration team config discovery tests ---
+// --- Integration team discovery tests ---
 
-func TestIntegration_MultipleTeamConfigs(t *testing.T) {
+func TestMerge_MultipleTeamConfigs(t *testing.T) {
 	instance := newSearchInstance()
 	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
@@ -98,29 +89,29 @@ func TestIntegration_MultipleTeamConfigs(t *testing.T) {
 	})
 	r := setupReconciler(instance, teamA, teamB)
 
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err := getIntegrationConfig(r)
+	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Len(t, integrationCC.Spec.CollectionRules, 2)
+	assert.Len(t, merged.Spec.CollectionRules, 2)
 }
 
-func TestIntegration_ZeroTeamConfigs(t *testing.T) {
+func TestMerge_ZeroConfigs(t *testing.T) {
 	instance := newSearchInstance()
 	r := setupReconciler(instance)
 
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err := getIntegrationConfig(r)
+	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Empty(t, integrationCC.Spec.CollectionRules)
+	assert.Empty(t, merged.Spec.CollectionRules)
 }
 
-func TestIntegration_TeamConfigDeleted(t *testing.T) {
+func TestMerge_TeamConfigDeleted(t *testing.T) {
 	instance := newSearchInstance()
 	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
@@ -143,62 +134,30 @@ func TestIntegration_TeamConfigDeleted(t *testing.T) {
 	r := setupReconciler(instance, teamA, teamB)
 
 	// First merge with both team configs.
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err := getIntegrationConfig(r)
+	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Len(t, integrationCC.Spec.CollectionRules, 2)
+	assert.Len(t, merged.Spec.CollectionRules, 2)
 
 	// Delete team-b.
 	err = r.Delete(context.TODO(), teamB)
 	assert.Nil(t, err)
 
 	// Re-merge should have only team-a's rules.
-	result, err = r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err = getIntegrationConfig(r)
+	merged, err = getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Len(t, integrationCC.Spec.CollectionRules, 1)
-	assert.Equal(t, "FOO", integrationCC.Spec.CollectionRules[0].FieldSuffix)
+	assert.Len(t, merged.Spec.CollectionRules, 1)
+	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 }
 
-func TestIntegration_Idempotency(t *testing.T) {
-	instance := newSearchInstance()
-	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{
-			{
-				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "FOO",
-				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
-			},
-		},
-	})
-	r := setupReconciler(instance, teamA)
-
-	// First call creates integration-collector-config.
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
-	assert.Nil(t, err)
-	assert.Nil(t, result)
-
-	cc1, err := getIntegrationConfig(r)
-	assert.Nil(t, err)
-	rv1 := cc1.ResourceVersion
-
-	// Second call with no changes should not update.
-	result, err = r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
-	assert.Nil(t, err)
-	assert.Nil(t, result)
-
-	cc2, err := getIntegrationConfig(r)
-	assert.Nil(t, err)
-	assert.Equal(t, rv1, cc2.ResourceVersion)
-}
-
-func TestIntegration_DeterministicOrder(t *testing.T) {
+func TestMerge_DeterministicOrder(t *testing.T) {
 	instance := newSearchInstance()
 	// Create in reverse alphabetical order to verify sorting.
 	teamZ := newIntegrationTeamConfig("z-team-config", searchv1alpha1.CollectorConfigSpec{
@@ -218,19 +177,19 @@ func TestIntegration_DeterministicOrder(t *testing.T) {
 	})
 	r := setupReconciler(instance, teamZ, teamA, teamM)
 
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err := getIntegrationConfig(r)
+	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Len(t, integrationCC.Spec.CollectionRules, 3)
-	assert.Equal(t, "A", integrationCC.Spec.CollectionRules[0].FieldSuffix)
-	assert.Equal(t, "M", integrationCC.Spec.CollectionRules[1].FieldSuffix)
-	assert.Equal(t, "Z", integrationCC.Spec.CollectionRules[2].FieldSuffix)
+	assert.Len(t, merged.Spec.CollectionRules, 3)
+	assert.Equal(t, "A", merged.Spec.CollectionRules[0].FieldSuffix)
+	assert.Equal(t, "M", merged.Spec.CollectionRules[1].FieldSuffix)
+	assert.Equal(t, "Z", merged.Spec.CollectionRules[2].FieldSuffix)
 }
 
-func TestIntegration_OnlyLabeledConfigsIncluded(t *testing.T) {
+func TestMerge_OnlyLabeledConfigsIncluded(t *testing.T) {
 	instance := newSearchInstance()
 	// Labeled integration team config — should be included.
 	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
@@ -251,54 +210,51 @@ func TestIntegration_OnlyLabeledConfigsIncluded(t *testing.T) {
 			},
 		},
 	})
-	// Customer config — should NOT be included in integration merge.
-	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	r := setupReconciler(instance, teamA, unlabeled)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1)
+	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
+}
+
+func TestMerge_Idempotency(t *testing.T) {
+	instance := newSearchInstance()
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
-				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"ConfigMap"}},
+				FieldSuffix:      "FOO",
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
 			},
 		},
 	})
-	r := setupReconciler(instance, teamA, unlabeled, customerCC)
+	r := setupReconciler(instance, teamA)
 
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	// First call creates merged-collector-config.
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err := getIntegrationConfig(r)
+	merged1, err := getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Len(t, integrationCC.Spec.CollectionRules, 1)
-	assert.Equal(t, "FOO", integrationCC.Spec.CollectionRules[0].FieldSuffix)
-}
+	rv1 := merged1.ResourceVersion
 
-func TestIntegration_OwnerReference(t *testing.T) {
-	instance := newSearchInstance()
-	r := setupReconciler(instance)
-
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
+	// Second call with no changes should not update.
+	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	integrationCC, err := getIntegrationConfig(r)
+	merged2, err := getMergedConfig(r)
 	assert.Nil(t, err)
-	assert.Len(t, integrationCC.OwnerReferences, 1)
-	assert.Equal(t, OperatorName, integrationCC.OwnerReferences[0].Name)
-	assert.Equal(t, "Search", integrationCC.OwnerReferences[0].Kind)
+	assert.Equal(t, rv1, merged2.ResourceVersion)
 }
 
-// --- End-to-end merge tests (integration + customer → merged) ---
-
-// runFullMerge calls both stages: integration team merge, then final merge.
-func runFullMerge(r *SearchReconciler, instance *searchv1alpha1.Search) error {
-	if result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance); err != nil || result != nil {
-		return err
-	}
-	if result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance); err != nil || result != nil {
-		return err
-	}
-	return nil
-}
+// --- Integration + customer merge tests ---
 
 func TestMerge_IntegrationOnly(t *testing.T) {
 	instance := newSearchInstance()
@@ -314,8 +270,9 @@ func TestMerge_IntegrationOnly(t *testing.T) {
 	})
 	r := setupReconciler(instance, teamA)
 
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -345,8 +302,9 @@ func TestMerge_BothExist(t *testing.T) {
 	})
 	r := setupReconciler(instance, teamA, customerCC)
 
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -372,8 +330,9 @@ func TestMerge_CustomerEmptyRules(t *testing.T) {
 	})
 	r := setupReconciler(instance, teamA, customerCC)
 
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -381,23 +340,8 @@ func TestMerge_CustomerEmptyRules(t *testing.T) {
 	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 }
 
-func TestMerge_BothEmpty(t *testing.T) {
-	instance := newSearchInstance()
-	r := setupReconciler(instance) // No team configs, no customer config.
-
-	err := runFullMerge(r, instance)
-	assert.Nil(t, err)
-
-	merged, err := getMergedConfig(r)
-	assert.Nil(t, err)
-	assert.Empty(t, merged.Spec.CollectionRules)
-}
-
 func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 	instance := newSearchInstance()
-	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
 	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 		CollectNamespaces: &searchv1alpha1.CollectNamespaces{
@@ -407,10 +351,11 @@ func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, teamA, customerCC)
+	r := setupReconciler(instance, customerCC)
 
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -421,69 +366,18 @@ func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 
 func TestMerge_NoCollectNamespaces(t *testing.T) {
 	instance := newSearchInstance()
-	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
 	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
-	r := setupReconciler(instance, teamA, customerCC)
+	r := setupReconciler(instance, customerCC)
 
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Nil(t, merged.Spec.CollectNamespaces)
-}
-
-func TestMerge_NoTeamConfigs(t *testing.T) {
-	instance := newSearchInstance()
-	r := setupReconciler(instance)
-
-	// With no team configs, integration-collector-config should still be created (empty).
-	result, err := r.createOrUpdateIntegrationCollectorConfig(context.TODO(), instance)
-	assert.Nil(t, err)
-	assert.Nil(t, result)
-
-	// Merged should also work.
-	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
-	assert.Nil(t, err)
-	assert.Nil(t, result)
-
-	merged, err := getMergedConfig(r)
-	assert.Nil(t, err)
-	assert.Empty(t, merged.Spec.CollectionRules)
-}
-
-func TestMerge_Idempotency(t *testing.T) {
-	instance := newSearchInstance()
-	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{
-			{
-				Action:           searchv1alpha1.ActionInclude,
-				FieldSuffix:      "FOO",
-				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"policy.open-cluster-management.io"}, Kinds: []string{"Policy"}},
-			},
-		},
-	})
-	r := setupReconciler(instance, teamA)
-
-	// First full merge.
-	err := runFullMerge(r, instance)
-	assert.Nil(t, err)
-
-	merged1, err := getMergedConfig(r)
-	assert.Nil(t, err)
-	rv1 := merged1.ResourceVersion
-
-	// Second full merge should not update (spec unchanged).
-	err = runFullMerge(r, instance)
-	assert.Nil(t, err)
-
-	merged2, err := getMergedConfig(r)
-	assert.Nil(t, err)
-	assert.Equal(t, rv1, merged2.ResourceVersion)
 }
 
 func TestMerge_CustomerDeleted(t *testing.T) {
@@ -513,8 +407,9 @@ func TestMerge_CustomerDeleted(t *testing.T) {
 	r := setupReconciler(instance, teamA, customerCC)
 
 	// First merge with both.
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
@@ -526,8 +421,9 @@ func TestMerge_CustomerDeleted(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Re-merge, should revert to integration only.
-	err = runFullMerge(r, instance)
+	result, err = r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err = getMergedConfig(r)
 	assert.Nil(t, err)
@@ -540,50 +436,13 @@ func TestMerge_OwnerReference(t *testing.T) {
 	instance := newSearchInstance()
 	r := setupReconciler(instance)
 
-	err := runFullMerge(r, instance)
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
+	assert.Nil(t, result)
 
 	merged, err := getMergedConfig(r)
 	assert.Nil(t, err)
 	assert.Len(t, merged.OwnerReferences, 1)
 	assert.Equal(t, OperatorName, merged.OwnerReferences[0].Name)
 	assert.Equal(t, "Search", merged.OwnerReferences[0].Kind)
-}
-
-// --- createCollectorConfig helper tests ---
-
-func TestCreateCollectorConfig(t *testing.T) {
-	instance := newSearchInstance()
-	r := setupReconciler(instance)
-
-	cc := newCollectorConfig("test-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
-	result, err := r.createCollectorConfig(context.TODO(), cc)
-	assert.Nil(t, err)
-	assert.Nil(t, result)
-
-	// Verify it was created.
-	found := &searchv1alpha1.CollectorConfig{}
-	err = r.Get(context.TODO(), types.NamespacedName{
-		Name:      "test-config",
-		Namespace: testNamespace,
-	}, found)
-	assert.Nil(t, err)
-	assert.Equal(t, "test-config", found.Name)
-}
-
-func TestCreateCollectorConfig_AlreadyExists(t *testing.T) {
-	instance := newSearchInstance()
-	existingCC := newCollectorConfig("test-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
-	r := setupReconciler(instance, existingCC)
-
-	cc := newCollectorConfig("test-config", searchv1alpha1.CollectorConfigSpec{
-		CollectionRules: []searchv1alpha1.CollectionRule{},
-	})
-	result, err := r.createCollectorConfig(context.TODO(), cc)
-	assert.Nil(t, err)
-	assert.Nil(t, result)
 }

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -42,7 +42,7 @@ func newCollectorConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *s
 func newIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
 	cc := newCollectorConfig(name, spec)
 	cc.Labels = map[string]string{
-		integrationTeamLabel: integrationTeamLabelValue,
+		searchv1alpha1.IntegrationTeamLabel: searchv1alpha1.IntegrationTeamLabelValue,
 	}
 	return cc
 }

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -254,7 +254,7 @@ func TestMerge_Idempotency(t *testing.T) {
 	assert.Equal(t, rv1, merged2.ResourceVersion)
 }
 
-// --- Integration + customer merge tests ---
+// --- Integration + user merge tests ---
 
 func TestMerge_IntegrationOnly(t *testing.T) {
 	instance := newSearchInstance()
@@ -292,7 +292,7 @@ func TestMerge_BothExist(t *testing.T) {
 			},
 		},
 	})
-	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionExclude,
@@ -300,7 +300,7 @@ func TestMerge_BothExist(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, teamA, customerCC)
+	r := setupReconciler(instance, teamA, userCC)
 
 	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
@@ -314,7 +314,7 @@ func TestMerge_BothExist(t *testing.T) {
 	assert.Equal(t, searchv1alpha1.ActionExclude, merged.Spec.CollectionRules[1].Action)
 }
 
-func TestMerge_CustomerEmptyRules(t *testing.T) {
+func TestMerge_UserEmptyRules(t *testing.T) {
 	instance := newSearchInstance()
 	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
@@ -325,10 +325,10 @@ func TestMerge_CustomerEmptyRules(t *testing.T) {
 			},
 		},
 	})
-	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
-	r := setupReconciler(instance, teamA, customerCC)
+	r := setupReconciler(instance, teamA, userCC)
 
 	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
@@ -340,9 +340,9 @@ func TestMerge_CustomerEmptyRules(t *testing.T) {
 	assert.Equal(t, "FOO", merged.Spec.CollectionRules[0].FieldSuffix)
 }
 
-func TestMerge_CustomerCollectNamespaces(t *testing.T) {
+func TestMerge_UserCollectNamespaces(t *testing.T) {
 	instance := newSearchInstance()
-	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 		CollectNamespaces: &searchv1alpha1.CollectNamespaces{
 			NamespaceSelector: &searchv1alpha1.NamespaceSelector{
@@ -351,7 +351,7 @@ func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, customerCC)
+	r := setupReconciler(instance, userCC)
 
 	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
@@ -366,10 +366,10 @@ func TestMerge_CustomerCollectNamespaces(t *testing.T) {
 
 func TestMerge_NoCollectNamespaces(t *testing.T) {
 	instance := newSearchInstance()
-	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{},
 	})
-	r := setupReconciler(instance, customerCC)
+	r := setupReconciler(instance, userCC)
 
 	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
 	assert.Nil(t, err)
@@ -380,7 +380,7 @@ func TestMerge_NoCollectNamespaces(t *testing.T) {
 	assert.Nil(t, merged.Spec.CollectNamespaces)
 }
 
-func TestMerge_CustomerDeleted(t *testing.T) {
+func TestMerge_UserDeleted(t *testing.T) {
 	instance := newSearchInstance()
 	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
@@ -391,7 +391,7 @@ func TestMerge_CustomerDeleted(t *testing.T) {
 			},
 		},
 	})
-	customerCC := newCollectorConfig(customerCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionExclude,
@@ -404,7 +404,7 @@ func TestMerge_CustomerDeleted(t *testing.T) {
 			},
 		},
 	})
-	r := setupReconciler(instance, teamA, customerCC)
+	r := setupReconciler(instance, teamA, userCC)
 
 	// First merge with both.
 	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
@@ -416,8 +416,8 @@ func TestMerge_CustomerDeleted(t *testing.T) {
 	assert.Len(t, merged.Spec.CollectionRules, 2)
 	assert.NotNil(t, merged.Spec.CollectNamespaces)
 
-	// Delete customer-collector-config.
-	err = r.Delete(context.TODO(), customerCC)
+	// Delete user-collector-config.
+	err = r.Delete(context.TODO(), userCC)
 	assert.Nil(t, err)
 
 	// Re-merge, should revert to integration only.

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -420,7 +420,7 @@ func (r *SearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				// Trigger on customer config (by name) or any integration team config (by label).
 				if name == customerCollectorConfigName ||
-					a.GetLabels()[integrationTeamLabel] == integrationTeamLabelValue {
+					a.GetLabels()[searchv1alpha1.IntegrationTeamLabel] == searchv1alpha1.IntegrationTeamLabelValue {
 					return []reconcile.Request{
 						{
 							NamespacedName: types.NamespacedName{

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -85,7 +85,8 @@ var cleanOnce sync.Once
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/finalizers,verbs=update
-//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs/status,verbs=update;patch
+//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=create;delete;get;list;patch
 //+kubebuilder:rbac:groups=multicluster.openshift.io,resources=multiclusterengines,verbs=get;list
 
@@ -168,6 +169,16 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createRoleBinding(ctx, r.ClusterRoleBinding(instance))
 	if result != nil {
 		log.Error(err, "ClusterRoleBinding setup failed")
+		return *result, err
+	}
+	result, err = r.createCollectorConfig(ctx, r.IntegrationCollectorConfig(instance))
+	if result != nil {
+		log.Error(err, "Integration CollectorConfig setup failed")
+		return *result, err
+	}
+	result, err = r.createOrUpdateMergedCollectorConfig(ctx, instance)
+	if result != nil {
+		log.Error(err, "Merged CollectorConfig setup failed")
 		return *result, err
 	}
 	result, err = r.createSecret(ctx, r.PGSecret(instance))
@@ -398,6 +409,22 @@ func (r *SearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 							NamespacedName: types.NamespacedName{
 								Name:      OperatorName,
 								Namespace: os.Getenv("POD_NAMESPACE"),
+							},
+						},
+					}
+				}
+				return nil
+			}),
+		).
+		Watches(&searchv1alpha1.CollectorConfig{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, a client.Object) []reconcile.Request {
+				name := a.GetName()
+				if name == customerCollectorConfigName || name == integrationCollectorConfigName {
+					return []reconcile.Request{
+						{
+							NamespacedName: types.NamespacedName{
+								Name:      OperatorName,
+								Namespace: a.GetNamespace(),
 							},
 						},
 					}

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -171,7 +171,7 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "ClusterRoleBinding setup failed")
 		return *result, err
 	}
-	result, err = r.createCollectorConfig(ctx, r.IntegrationCollectorConfig(instance))
+	result, err = r.createOrUpdateIntegrationCollectorConfig(ctx, instance)
 	if result != nil {
 		log.Error(err, "Integration CollectorConfig setup failed")
 		return *result, err
@@ -419,7 +419,13 @@ func (r *SearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&searchv1alpha1.CollectorConfig{}, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, a client.Object) []reconcile.Request {
 				name := a.GetName()
-				if name == customerCollectorConfigName || name == integrationCollectorConfigName {
+				// Skip operator-managed outputs to prevent reconcile loops.
+				if name == mergedCollectorConfigName || name == integrationCollectorConfigName {
+					return nil
+				}
+				// Trigger on customer config (by name) or any integration team config (by label).
+				if name == customerCollectorConfigName ||
+					a.GetLabels()[integrationTeamLabel] == integrationTeamLabelValue {
 					return []reconcile.Request{
 						{
 							NamespacedName: types.NamespacedName{

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -171,11 +171,6 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "ClusterRoleBinding setup failed")
 		return *result, err
 	}
-	result, err = r.createOrUpdateIntegrationCollectorConfig(ctx, instance)
-	if result != nil {
-		log.Error(err, "Integration CollectorConfig setup failed")
-		return *result, err
-	}
 	result, err = r.createOrUpdateMergedCollectorConfig(ctx, instance)
 	if result != nil {
 		log.Error(err, "Merged CollectorConfig setup failed")
@@ -419,8 +414,8 @@ func (r *SearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&searchv1alpha1.CollectorConfig{}, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, a client.Object) []reconcile.Request {
 				name := a.GetName()
-				// Skip operator-managed outputs to prevent reconcile loops.
-				if name == mergedCollectorConfigName || name == integrationCollectorConfigName {
+				// Skip operator-managed output to prevent reconcile loops.
+				if name == mergedCollectorConfigName {
 					return nil
 				}
 				// Trigger on customer config (by name) or any integration team config (by label).

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -418,8 +418,8 @@ func (r *SearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				if name == mergedCollectorConfigName {
 					return nil
 				}
-				// Trigger on customer config (by name) or any integration team config (by label).
-				if name == customerCollectorConfigName ||
+				// Trigger on user config (by name) or any integration team config (by label).
+				if name == userCollectorConfigName ||
 					a.GetLabels()[searchv1alpha1.IntegrationTeamLabel] == searchv1alpha1.IntegrationTeamLabelValue {
 					return []reconcile.Request{
 						{


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-21883

### Description of changes
- Added integration teams CollectorConfig and process for merging customer + integration team into a meged CollectorConfig to be finally consumed by the collector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator-managed collector configs are protected from unauthorized create/update/delete.
  * Webhook validation now runs on deletes as well as creates/updates.
  * Collector configs from multiple sources are automatically merged deterministically; user configs can augment merged output.

* **Chores**
  * Expanded RBAC to support collector configuration management and webhook operations.

* **Tests**
  * Added tests for admission protection, merge logic, reconciliation, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->