### PR TITLE
ACM-33144: Update webhook to accept unbraced jsonPath expressions

### DIFF
--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -196,7 +196,7 @@ func (r *CollectorConfig) validateField(customField *Field, path *field.Path) fi
 		allErrs = append(allErrs, field.Invalid(
 			path.Child("jsonPath"),
 			customField.JSONPath,
-			"must be a valid JSONPath expression starting with '{.' and ending with '}'",
+			"must be a valid JSONPath expression (e.g. \".spec.myField\" or \"{.spec.myField}\")",
 		))
 	}
 
@@ -233,23 +233,27 @@ func isValidFieldSuffix(suffix string) bool {
 	return fieldSuffixPattern.MatchString(suffix)
 }
 
-// isValidJSONPath performs basic JSONPath syntax validation
+// isValidJSONPath performs basic JSONPath syntax validation.
+// Accepts both braced ("{.spec.myField}") and unbraced (".spec.myField") forms —
+// the collector normalizes to braced form at runtime (ACM-33144).
 func isValidJSONPath(jsonPath string) bool {
-	// FUTURE: ACM-33144 removes necessity of '{}' in jsonPath and default to parse-based validation check
-	// Must start with {. and end with }
-	if !strings.HasPrefix(jsonPath, "{.") || !strings.HasSuffix(jsonPath, "}") {
+	// Normalize to braced form for validation regardless of input format.
+	normalized := "{" + strings.TrimSuffix(strings.TrimPrefix(jsonPath, "{"), "}") + "}"
+
+	// Must start with {. — at least one path segment is required.
+	if !strings.HasPrefix(normalized, "{.") {
 		return false
 	}
 
-	// Basic validation - contains at least one path element
-	inner := strings.TrimPrefix(strings.TrimSuffix(jsonPath, "}"), "{.")
+	// Must have content after the opening {.
+	inner := strings.TrimPrefix(strings.TrimSuffix(normalized, "}"), "{.")
 	if len(inner) < 1 {
 		return false
 	}
 
-	// Parse-based validation
+	// Parse-based validation using the k8s jsonpath library.
 	jp := jsonpath.New("collectorconfig-field")
-	return jp.Parse(jsonPath) == nil
+	return jp.Parse(normalized) == nil
 }
 
 // contains checks if a slice contains a string

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -145,6 +145,24 @@ func TestAcceptFieldWithNoType(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Accept an unbraced jsonPath — the collector auto-wraps it at runtime (ACM-33144).
+func TestAcceptUnbracedJSONPath(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0].Fields = []Field{{Name: "status", JSONPath: ".status.phase"}}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Accept a complex unbraced jsonPath with a filter expression.
+func TestAcceptUnbracedJSONPathWithFilter(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0].Fields = []Field{
+		{Name: "ready", JSONPath: ".status.conditions[?(@.type=='Ready')].status"},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
 // Reject a fieldSuffix containing uppercase letters.
 func TestRejectFieldSuffixWithUppercase(t *testing.T) {
 	c := validConfig()


### PR DESCRIPTION
## Summary

Companion fix for stolostron/search-collector#884.

The collector auto-normalizes user-supplied jsonPath values at runtime (wraps
unbraced .spec.myField to {.spec.myField} before calling the k8s jsonpath
library). However, the admission webhook isValidJSONPath function was still
requiring the braced form at admission time, so any CollectorConfig submitted
with an unbraced path was rejected before the collector could ever see it.

## Changes

- **collectorconfig_webhook.go** - isValidJSONPath now normalizes the input
  (strips any partial braces and re-wraps) before parse-based validation,
  accepting both {.spec.myField} and .spec.myField consistently.
- **collectorconfig_webhook_test.go** - two new tests covering unbraced simple
  path and unbraced filter-expression acceptance; existing rejection tests still pass.

## Test plan

- [ ] go test ./api/... - all tests pass
- [ ] Manual: apply CollectorConfig with jsonPath .spec.replicas - webhook accepts it

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSONPath validation in CollectorConfig now accepts both braced (`{.field}`) and unbraced (`.field`) input formats.
  * Enhanced validation error messages now include examples of accepted JSONPath formats for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->