### PR TITLE
ACM-32738 - configurable collection - additionalPrinterColumns

### DIFF
--- a/addon/manifests/chart/templates/collectorconfig_crd.yaml
+++ b/addon/manifests/chart/templates/collectorconfig_crd.yaml
@@ -130,7 +130,7 @@ spec:
                         progressively more columns.
                         For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
                         priority 0 through 5 will be collected.
-                        Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+                        Omitting this field or setting to -1 after having been set will disable collection for the matched resource.
                       minimum: -1
                       type: integer
                     collectAnnotations:

--- a/addon/manifests/chart/templates/collectorconfig_crd.yaml
+++ b/addon/manifests/chart/templates/collectorconfig_crd.yaml
@@ -124,16 +124,22 @@ spec:
                       - exclude
                       type: string
                     collectAdditionalPrinterColumnsPriority:
-                      description: '[NOT IMPLEMENTED] Specifies to collect additionalPrinterColumns
-                        from the CRD with the specified priority or higher.'
+                      description: |-
+                        Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
+                        the specified value. Priority 0 collects only the most important columns; higher values include
+                        progressively more columns.
+                        For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
+                        priority 0 through 5 will be collected.
+                        Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+                      minimum: -1
                       type: integer
                     collectAnnotations:
                       description: '[NOT IMPLEMENTED] Specifies to collect annotations
                         for the resource.'
                       type: boolean
                     collectConditions:
-                      description: '[NOT IMPLEMENTED] Specifies to collect status
-                        conditions for the resource.'
+                      description: Enable collection of status conditions for the
+                        resource.
                       type: boolean
                     fieldSuffix:
                       default: ""
@@ -182,7 +188,8 @@ spec:
                             type: string
                           type: array
                         kinds:
-                          description: Specifies kinds of resources.
+                          description: Specifies kinds of resources. Use "*" to match
+                            all kinds in the apiGroup (not permitted with fields).
                           items:
                             type: string
                           type: array
@@ -195,6 +202,7 @@ spec:
                   - resourceSelector
                   type: object
                 type: array
+            type: object
           status:
             description: CollectorConfigStatus defines the observed state of CollectorConfig.
             properties:

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -147,7 +147,12 @@ type CollectionRule struct {
 	CollectConditions *bool `json:"collectConditions,omitempty"`
 
 	// +optional
-	// [NOT IMPLEMENTED] Specifies to collect additionalPrinterColumns from the CRD with the specified priority or higher.
+	// +kubebuilder:validation:Minimum=0
+	// Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
+	// the specified value. Priority 0 collects only the most important columns; higher values include
+	// progressively more columns.
+	// For example, if collectAdditionalPrinterColumns is 5 for a specified CRD, additionalPrinterColumns of
+	// priority 0 through 5 will be collected.
 	CollectAdditionalPrinterColumnsPriority *int `json:"collectAdditionalPrinterColumnsPriority,omitempty"`
 }
 

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -151,7 +151,7 @@ type CollectionRule struct {
 	// Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
 	// the specified value. Priority 0 collects only the most important columns; higher values include
 	// progressively more columns.
-	// For example, if collectAdditionalPrinterColumns is 5 for a specified CRD, additionalPrinterColumns of
+	// For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
 	// priority 0 through 5 will be collected.
 	CollectAdditionalPrinterColumnsPriority *int `json:"collectAdditionalPrinterColumnsPriority,omitempty"`
 }

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -153,7 +153,7 @@ type CollectionRule struct {
 	// progressively more columns.
 	// For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
 	// priority 0 through 5 will be collected.
-	// Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+	// Omitting this field or setting to -1 after having been set will disable collection for the matched resource.
 	CollectAdditionalPrinterColumnsPriority *int `json:"collectAdditionalPrinterColumnsPriority,omitempty"`
 }
 

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -147,12 +147,13 @@ type CollectionRule struct {
 	CollectConditions *bool `json:"collectConditions,omitempty"`
 
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=-1
 	// Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
 	// the specified value. Priority 0 collects only the most important columns; higher values include
 	// progressively more columns.
 	// For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
 	// priority 0 through 5 will be collected.
+	// Set to -1 to disable additionalPrinterColumns collection for the matched resources.
 	CollectAdditionalPrinterColumnsPriority *int `json:"collectAdditionalPrinterColumnsPriority,omitempty"`
 }
 

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -158,11 +158,11 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 		}
 
 		// Validate CollectAdditionalPrinterColumnsPriority if present
-		if rule.CollectAdditionalPrinterColumnsPriority != nil && *rule.CollectAdditionalPrinterColumnsPriority < 0 {
+		if rule.CollectAdditionalPrinterColumnsPriority != nil && *rule.CollectAdditionalPrinterColumnsPriority < -1 {
 			allErrs = append(allErrs, field.Invalid(
 				rulePath.Child("collectAdditionalPrinterColumnsPriority"),
 				*rule.CollectAdditionalPrinterColumnsPriority,
-				"must be >= 0",
+				"must be >= -1 (-1 disables collection)",
 			))
 		}
 

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -157,6 +157,15 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 			}
 		}
 
+		// Validate CollectAdditionalPrinterColumnsPriority if present
+		if rule.CollectAdditionalPrinterColumnsPriority != nil && *rule.CollectAdditionalPrinterColumnsPriority < 0 {
+			allErrs = append(allErrs, field.Invalid(
+				rulePath.Child("collectAdditionalPrinterColumnsPriority"),
+				*rule.CollectAdditionalPrinterColumnsPriority,
+				"must be >= 0",
+			))
+		}
+
 		// Validate FieldSuffix if present
 		if rule.FieldSuffix != "" {
 			if !isValidFieldSuffix(rule.FieldSuffix) {

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -338,6 +338,49 @@ func TestRejectCollectConditionsWithoutApiGroups(t *testing.T) {
 	assert.Contains(t, err.Error(), "must specify at least one apiGroup")
 }
 
+// Accept collectAdditionalPrinterColumnsPriority with a specific kind and no fields.
+func TestAcceptCollectPrinterColumnsWithKind(t *testing.T) {
+	priority := 0
+	c := validConfig()
+	c.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority = &priority
+	c.Spec.CollectionRules[0].Fields = nil
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Accept collectAdditionalPrinterColumnsPriority with wildcard kind.
+func TestAcceptCollectPrinterColumnsWithWildcardKind(t *testing.T) {
+	priority := 5
+	c := validConfig()
+	c.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority = &priority
+	c.Spec.CollectionRules[0].ResourceSelector.Kinds = []string{"*"}
+	c.Spec.CollectionRules[0].Fields = nil
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Accept collectAdditionalPrinterColumnsPriority combined with fields and collectConditions.
+func TestAcceptCollectPrinterColumnsWithFieldsAndConditions(t *testing.T) {
+	priority := 1
+	collectConditions := true
+	c := validConfig()
+	c.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority = &priority
+	c.Spec.CollectionRules[0].CollectConditions = &collectConditions
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Reject negative collectAdditionalPrinterColumnsPriority.
+func TestRejectCollectPrinterColumnsNegative(t *testing.T) {
+	priority := -1
+	c := validConfig()
+	c.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority = &priority
+	c.Spec.CollectionRules[0].Fields = nil
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be >= 0")
+}
+
 // --- Webhook protection tests ---
 
 func ctxWithUser(username string) context.Context {

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -370,15 +370,25 @@ func TestAcceptCollectPrinterColumnsWithFieldsAndConditions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// Reject negative collectAdditionalPrinterColumnsPriority.
-func TestRejectCollectPrinterColumnsNegative(t *testing.T) {
+// Accept collectAdditionalPrinterColumnsPriority of -1 (disables collection).
+func TestAcceptCollectPrinterColumnsDisabled(t *testing.T) {
 	priority := -1
 	c := validConfig()
 	c.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority = &priority
 	c.Spec.CollectionRules[0].Fields = nil
 	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Reject collectAdditionalPrinterColumnsPriority below -1.
+func TestRejectCollectPrinterColumnsBelowNegativeOne(t *testing.T) {
+	priority := -2
+	c := validConfig()
+	c.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority = &priority
+	c.Spec.CollectionRules[0].Fields = nil
+	_, err := c.ValidateCreate(context.Background(), c)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "must be >= 0")
+	assert.Contains(t, err.Error(), "must be >= -1 (-1 disables collection)")
 }
 
 // --- Webhook protection tests ---

--- a/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
@@ -130,7 +130,7 @@ spec:
                         progressively more columns.
                         For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
                         priority 0 through 5 will be collected.
-                        Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+                        Omitting this field or setting to -1 after having been set will disable collection for the matched resource.
                       minimum: -1
                       type: integer
                     collectAnnotations:

--- a/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
@@ -124,8 +124,13 @@ spec:
                       - exclude
                       type: string
                     collectAdditionalPrinterColumnsPriority:
-                      description: '[NOT IMPLEMENTED] Specifies to collect additionalPrinterColumns
-                        from the CRD with the specified priority or higher.'
+                      description: |-
+                        Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
+                        the specified value. Priority 0 collects only the most important columns; higher values include
+                        progressively more columns.
+                        For example, if collectAdditionalPrinterColumns is 5 for a specified CRD, additionalPrinterColumns of
+                        priority 0 through 5 will be collected.
+                      minimum: 0
                       type: integer
                     collectAnnotations:
                       description: '[NOT IMPLEMENTED] Specifies to collect annotations

--- a/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
@@ -128,9 +128,10 @@ spec:
                         Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
                         the specified value. Priority 0 collects only the most important columns; higher values include
                         progressively more columns.
-                        For example, if collectAdditionalPrinterColumns is 5 for a specified CRD, additionalPrinterColumns of
+                        For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
                         priority 0 through 5 will be collected.
-                      minimum: 0
+                        Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+                      minimum: -1
                       type: integer
                     collectAnnotations:
                       description: '[NOT IMPLEMENTED] Specifies to collect annotations

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -130,7 +130,7 @@ spec:
                         progressively more columns.
                         For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
                         priority 0 through 5 will be collected.
-                        Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+                        Omitting this field or setting to -1 after having been set will disable collection for the matched resource.
                       minimum: -1
                       type: integer
                     collectAnnotations:

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -130,7 +130,8 @@ spec:
                         progressively more columns.
                         For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
                         priority 0 through 5 will be collected.
-                      minimum: 0
+                        Set to -1 to disable additionalPrinterColumns collection for the matched resources.
+                      minimum: -1
                       type: integer
                     collectAnnotations:
                       description: '[NOT IMPLEMENTED] Specifies to collect annotations

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -124,8 +124,13 @@ spec:
                       - exclude
                       type: string
                     collectAdditionalPrinterColumnsPriority:
-                      description: '[NOT IMPLEMENTED] Specifies to collect additionalPrinterColumns
-                        from the CRD with the specified priority or higher.'
+                      description: |-
+                        Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
+                        the specified value. Priority 0 collects only the most important columns; higher values include
+                        progressively more columns.
+                        For example, if collectAdditionalPrinterColumns is 5 for a specified CRD, additionalPrinterColumns of
+                        priority 0 through 5 will be collected.
+                      minimum: 0
                       type: integer
                     collectAnnotations:
                       description: '[NOT IMPLEMENTED] Specifies to collect annotations

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -128,7 +128,7 @@ spec:
                         Specifies to collect additionalPrinterColumns from the CRD with priority up to and including
                         the specified value. Priority 0 collects only the most important columns; higher values include
                         progressively more columns.
-                        For example, if collectAdditionalPrinterColumns is 5 for a specified CRD, additionalPrinterColumns of
+                        For example, if collectAdditionalPrinterColumnsPriority is 5 for a specified CRD, additionalPrinterColumns of
                         priority 0 through 5 will be collected.
                       minimum: 0
                       type: integer

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -432,6 +432,80 @@ func TestMerge_UserDeleted(t *testing.T) {
 	assert.Nil(t, merged.Spec.CollectNamespaces)
 }
 
+func TestMerge_CollectAdditionalPrinterColumnsPropagated(t *testing.T) {
+	priority := 5
+	instance := newSearchInstance()
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:                                  searchv1alpha1.ActionInclude,
+				ResourceSelector:                        searchv1alpha1.ResourceSelector{APIGroups: []string{"monitoring.coreos.com"}, Kinds: []string{"*"}},
+				CollectAdditionalPrinterColumnsPriority: &priority,
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{""}, Kinds: []string{"Secret"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 2)
+	// Integration rule with printer columns priority is propagated.
+	assert.NotNil(t, merged.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority)
+	assert.Equal(t, 5, *merged.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority)
+	// User rule has no printer columns priority.
+	assert.Nil(t, merged.Spec.CollectionRules[1].CollectAdditionalPrinterColumnsPriority)
+}
+
+func TestMerge_CollectAdditionalPrinterColumnsPriorityCollision(t *testing.T) {
+	teamPriority := 10
+	userPriority := 0
+	instance := newSearchInstance()
+	teamA := newIntegrationTeamConfig("team-a-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:                                  searchv1alpha1.ActionInclude,
+				ResourceSelector:                        searchv1alpha1.ResourceSelector{APIGroups: []string{"monitoring.coreos.com"}, Kinds: []string{"Alertmanager"}},
+				CollectAdditionalPrinterColumnsPriority: &teamPriority,
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:                                  searchv1alpha1.ActionInclude,
+				ResourceSelector:                        searchv1alpha1.ResourceSelector{APIGroups: []string{"monitoring.coreos.com"}, Kinds: []string{"Alertmanager"}},
+				CollectAdditionalPrinterColumnsPriority: &userPriority,
+			},
+		},
+	})
+	r := setupReconciler(instance, teamA, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	// Both rules are preserved — integration first, user second.
+	assert.Len(t, merged.Spec.CollectionRules, 2)
+	assert.Equal(t, 10, *merged.Spec.CollectionRules[0].CollectAdditionalPrinterColumnsPriority,
+		"Integration team rule should have priority 10")
+	assert.Equal(t, 0, *merged.Spec.CollectionRules[1].CollectAdditionalPrinterColumnsPriority,
+		"User rule should have priority 0")
+}
+
 func TestMerge_OwnerReference(t *testing.T) {
 	instance := newSearchInstance()
 	r := setupReconciler(instance)


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-32738

### Description of changes
- Added webhook, tests, and CRD documentation for collection of additionalPrinterColumns
- Collector PR https://github.com/stolostron/search-collector/pull/885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified the `collectAdditionalPrinterColumnsPriority` behavior in the `CollectorConfig` CRD/chart, including priority cutoff semantics and an example.
  * Enforced valid values via the webhook: `-1` disables collecting `additionalPrinterColumns`; values less than `-1` are rejected.

* **Tests**
  * Expanded webhook and merge unit test coverage for acceptance/rejection rules, propagation into merged configs, and priority handling when multiple rules apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->