### PR TITLE
update webhook kubebuilder to properly name vwc name and service name

### DIFF
--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -33,7 +33,8 @@ func (r *CollectorConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-search-open-cluster-management-io-v1alpha1-collectorconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=create;update;delete,versions=v1alpha1,name=vcollectorconfig.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhookconfiguration:mutating=false,name=search-v2-operator-validating-webhook-configuration
+//+kubebuilder:webhook:path=/validate-search-open-cluster-management-io-v1alpha1-collectorconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=create;update;delete,versions=v1alpha1,name=vcollectorconfig.kb.io,admissionReviewVersions=v1,serviceName=search-v2-operator-webhook-service
 
 var _ webhook.CustomValidator = &CollectorConfig{}
 

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -2,6 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: search-v2-operator-validating-webhook-configuration
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,13 +2,13 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: search-v2-operator-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: search-v2-operator-webhook-service
       namespace: system
       path: /validate-search-open-cluster-management-io-v1alpha1-collectorconfig
   failurePolicy: Fail


### PR DESCRIPTION
### Description of changes
- Added ValidatingWebhookConfig name and service name reference to kubebuilder config to properly reference webhook service via generated `make manifests`
- https://redhat-internal.slack.com/archives/CU63N3Y76/p1781182812900999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validating webhook configuration naming for consistency and standardization.
  * Aligned service name references across webhook configurations to follow standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->