### PR TITLE
Update local controller-gen version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Updates the controller-gen version installed locally by `make controller-gen` to match the version to match the version used in the generated manifests. (v0.18.0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code generation tooling to improve development build infrastructure and ensure better compatibility with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->