### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# search-v2-operator
+
+Kubernetes operator (kubebuilder/controller-runtime) that deploys and manages all ACM Search components: PostgreSQL, search-indexer, search-v2-api, and search-collector.
+
+For system architecture, data flows, and module layout, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Commands
+
+```bash
+make build          # Build manager binary to bin/manager
+make run            # Run controller locally against current kubeconfig cluster
+make test           # Run unit tests (downloads envtest assets to bin/ on first run — slow)
+make lint           # Run golangci-lint + gosec (downloads golangci-lint if not present)
+make manifests      # Regenerate CRD/RBAC manifests (run after editing api/v1alpha1/ types)
+make generate       # Regenerate DeepCopy methods (run after editing api/v1alpha1/ types)
+make install        # Install CRDs into the cluster (~/.kube/config)
+make uninstall      # Remove CRDs from the cluster
+make deploy         # Deploy the controller to the cluster
+make undeploy       # Remove the controller from the cluster
+make docker-build   # Build Docker image (also runs tests)
+make clean          # Remove bin/ directory
+```
+
+After any change to `api/v1alpha1/` types, run **both** `make manifests` and `make generate`.
+
+## Local run setup
+
+`make run` requires these environment variables (get values from an active cluster with `make setup`):
+
+```bash
+export WATCH_NAMESPACE=open-cluster-management
+export POSTGRES_IMAGE=<from cluster>
+export COLLECTOR_IMAGE=<from cluster>
+export API_IMAGE=<from cluster>
+export INDEXER_IMAGE=<from cluster>
+```
+
+`make setup` prints the exact `kubectl` commands to extract these from a live cluster.
+
+## Non-obvious conventions
+
+- **`make test` is slow on first run** — it downloads the kubebuilder envtest binary and Kubernetes API assets to `bin/`. Subsequent runs are fast.
+- **`make run` triggers code generation** — it depends on `manifests generate fmt vet`, which downloads `controller-gen` to `bin/` if absent. Use `go run ./main.go` directly to skip this.
+- **Single `Search` CR** — the operator is hardcoded to reconcile a CR named `search-v2-operator` (`OperatorName` constant in `controllers/search_controller.go`). There is exactly one per cluster.
+- **Pause reconciliation** — annotate the `Search` CR with `search-pause: true` to halt reconciliation without deleting resources (e.g. during maintenance).
+- **`make docker-build` runs tests first** — it depends on the `test` target.
+- **`make manifests` and `make generate` are separate** — one regenerates CRD/RBAC YAML, the other regenerates Go DeepCopy methods. Both are needed after API type changes.
+- **`docs/RBAC.md`** documents the RBAC roles and bindings created by the operator.
+
+## Personal configuration
+
+Read personal config at the start of any task that needs an assignee, email, or project key.
+Use the tool-aware fallback chain: `~/.config/opencode/user.local.md` (OpenCode),
+`.claude/user.local.md` (Claude Code), or `.cursor/rules/user.local.mdc` (Cursor, already in context).
+If none exist, fall back to agent memory (`user-config`), then placeholders.
+Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
+
+## Fleet Engineering Skills
+
+All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ export API_IMAGE=<from cluster>
 export INDEXER_IMAGE=<from cluster>
 ```
 
-`make setup` prints the exact `kubectl` commands to extract these from a live cluster.
+`make setup` prints ready-to-run `export` statements with the resolved image values (it uses `$(shell kubectl ...)` substitution, not raw kubectl commands).
 
 ## Non-obvious conventions
 
@@ -47,6 +47,10 @@ export INDEXER_IMAGE=<from cluster>
 - **`make manifests` and `make generate` are separate** — one regenerates CRD/RBAC YAML, the other regenerates Go DeepCopy methods. Both are needed after API type changes.
 - **`docs/RBAC.md`** documents the RBAC roles and bindings created by the operator.
 
+## Fleet Engineering Skills
+
+All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.
+
 ## Personal configuration
 
 Read personal config at the start of any task that needs an assignee, email, or project key.
@@ -55,6 +59,3 @@ Use the tool-aware fallback chain: `~/.config/opencode/user.local.md` (OpenCode)
 If none exist, fall back to agent memory (`user-config`), then placeholders.
 Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
 
-## Fleet Engineering Skills
-
-All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# search-v2-operator Architecture
+
+## Overview
+
+search-v2-operator is a Kubernetes operator built with kubebuilder/controller-runtime. It owns the full lifecycle of ACM Search infrastructure on the hub cluster: it provisions and configures PostgreSQL, search-indexer, search-v2-api, and search-collector from a single `Search` custom resource.
+
+```text
+Search CR (search-v2-operator)
+        │
+        ▼
+  SearchReconciler
+        │
+        ├──► PostgreSQL Deployment + Service + Secret + ConfigMap + PVC
+        ├──► search-indexer  Deployment + Service + ConfigMap
+        ├──► search-v2-api   Deployment + Service
+        ├──► search-collector Deployment + Service
+        ├──► RBAC (ClusterRole, ClusterRoleBinding, ServiceAccount)
+        ├──► ServiceMonitors (Prometheus)
+        ├──► CollectorConfig (merged from user + integration configs)
+        └──► Addon framework (ManagedClusterAddon CSR approval)
+```
+
+## Packages
+
+| Package | Responsibility |
+|---|---|
+| `main` | Bootstrap: register schemes (search, monitoring, OCM cluster, admission), create manager, register `SearchReconciler` and `CollectorConfig` webhook, start health probes |
+| `controllers` | All reconciliation logic. One controller (`SearchReconciler`) handles the `Search` CR. Each Kubernetes resource type has its own `create_*.go` file. `defaults.go` holds resource request/limit constants. |
+| `api/v1alpha1` | CRD type definitions (`Search`, `CollectorConfig`). `CollectorConfig` has a defaulting/validating webhook. Changes here require `make manifests` + `make generate`. |
+| `addon` | OCM addon integration. `CreateAddonOnce` runs once per process lifetime to register the search-collector addon and handle `CertificateSigningRequest` approval for managed clusters. |
+
+## CRD: Search
+
+The `Search` CR is a singleton named `search-v2-operator` (hardcoded — only one exists per cluster).
+
+Key spec fields:
+
+| Field | Effect |
+|---|---|
+| `spec.deployments` | Per-component resource requests, limits, replica counts, node selectors, tolerations, and env var overrides |
+| `spec.dbStorage.storageClassName` | If set, provisions a PVC for PostgreSQL instead of using emptyDir |
+| `spec.dbConfig` | ConfigMap name with PostgreSQL parameter overrides |
+| `metadata.annotations["search-pause: true"]` | Halts reconciliation without deleting resources |
+
+## CRD: CollectorConfig
+
+Allows integration teams and users to customize search-collector behaviour (resource limits, collection intervals, excluded resources). The operator merges all `CollectorConfig` objects into a single authoritative config that drives the collector deployment.
+
+- User config: CR named by `userCollectorConfigName` constant
+- Integration team configs: CRs with label `search.open-cluster-management.io/integration-team: true`
+- Operator-managed output: CR named `mergedCollectorConfigName` (skip-reconcile guard prevents loops)
+
+The webhook (`api/v1alpha1/collectorconfig_webhook.go`) sets defaults and validates on admission.
+
+## Reconcile flow
+
+Each reconcile call processes the `Search` CR in a fixed sequence:
+
+1. **Addon setup** (`once.Do`) — registers the OCM addon framework once per process.
+2. **Status update** (pod events only) — updates `Search.Status` with pod readiness; skips full reconcile.
+3. **Finalizer** — adds/removes `search.open-cluster-management.io/finalizer`; on deletion, cleans up cluster-scoped resources (ClusterRole, ClusterRoleBinding, ManagedServiceAccount, ClusterManagementAddon owner refs).
+4. **Pause check** — if `search-pause: true` annotation is present, returns immediately.
+5. **PVC** — if `spec.dbStorage.storageClassName` is set and PVC is absent, creates it; retries in 10s if not ready.
+6. **RBAC** — ServiceAccount, ClusterRoles, ClusterRoleBindings.
+7. **CollectorConfig merge** — merges user + integration configs into the authoritative merged config.
+8. **PostgreSQL** — Secret, Service, Deployment, ConfigMap.
+9. **Component services** — Indexer, API, Collector Services.
+10. **ServiceMonitors** — Prometheus ServiceMonitors for indexer, api, collector.
+11. **Component deployments** — Collector, Indexer, API Deployments.
+12. **ConfigMaps** — Indexer ConfigMap, Postgres ConfigMap, Search CA cert.
+13. **Feature configurations** — Global search, fine-grained RBAC, virtual machine integration.
+14. **Prometheus alert rules** — PVC usage alert.
+15. **One-time migrations** (`cleanOnce.Do`) — removes legacy serviceMonitor setup from `openshift-monitoring` (introduced ACM 2.9) and removes Search ownerRef from ClusterManagementAddon (introduced ACM 2.10).
+
+## Watch sources
+
+The controller re-queues on changes from multiple sources:
+
+| Source | Condition | Action |
+|---|---|---|
+| `Search` CR | Any change | Full reconcile |
+| `Deployment` | Owned by Search CR | Full reconcile |
+| `Secret` | Owned by Search CR | Full reconcile |
+| `ConfigMap` | Owned by Search CR, or named `SEARCH_GLOBAL_CONFIG` | Full reconcile |
+| `Pod` | Has search labels | Status-only reconcile |
+| `ClusterRole` | Matches search role name | Full reconcile |
+| `ManagedCluster` | Is a managed hub (has `hub.open-cluster-management.io` cluster claim) | Full reconcile (global search setup) |
+| `CollectorConfig` | Named `userCollectorConfigName` or has integration team label | Full reconcile |
+
+## Feature configurations
+
+Three optional setup passes run during each reconcile:
+
+- **Global search** (`reconcileGlobalSearch`): When a `MulticlusterGlobalHub` or managed-hub `ManagedCluster` is detected, wires up federated search config for `search-v2-api`.
+- **Fine-grained RBAC** (`reconcileFineGrainedRBACConfiguration`): Configures `ManagedServiceAccount` and `ClusterPermission` resources to enable per-resource-type RBAC enforcement in the API.
+- **Virtual machine integration** (`reconcileVirtualMachineConfiguration`): Enables VM-specific resource collection and display when KubeVirt / CNV is detected.
+
+## Code generation
+
+This repo uses kubebuilder code generation. Two steps are independent:
+
+| Command | What it regenerates | When to run |
+|---|---|---|
+| `make manifests` | `config/crd/bases/*.yaml`, RBAC manifests | After editing structs/markers in `api/v1alpha1/` |
+| `make generate` | `api/v1alpha1/zz_generated.deepcopy.go` | After adding/removing fields in `api/v1alpha1/` |
+
+Both download `controller-gen` to `bin/` on first run if absent.
+
+## Testing
+
+`make test` uses `controller-runtime`'s `envtest` (real Kubernetes API server binary, no etcd). Assets are downloaded to `bin/` by `setup-envtest` on first run — this can take a minute. The `KUBEBUILDER_ASSETS` env var points the test binary at the downloaded assets.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,9 +46,9 @@ Key spec fields:
 
 Allows integration teams and users to customize search-collector behaviour (resource limits, collection intervals, excluded resources). The operator merges all `CollectorConfig` objects into a single authoritative config that drives the collector deployment.
 
-- User config: CR named by `userCollectorConfigName` constant
-- Integration team configs: CRs with label `search.open-cluster-management.io/integration-team: true`
-- Operator-managed output: CR named `mergedCollectorConfigName` (skip-reconcile guard prevents loops)
+- Integration team configs: CRs with label `search.open-cluster-management.io/config-type: integration`, merged first (sorted by name)
+- User config: CR named `user-collector-config` (`userCollectorConfigName`), overlaid last
+- Operator-managed output: CR named `merged-collector-config` (`mergedCollectorConfigName`) — the controller watch skips this name to prevent reconcile loops
 
 The webhook (`api/v1alpha1/collectorconfig_webhook.go`) sets defaults and validates on admission.
 
@@ -85,15 +85,15 @@ The controller re-queues on changes from multiple sources:
 | `Pod` | Has search labels | Status-only reconcile |
 | `ClusterRole` | Matches search role name | Full reconcile |
 | `ManagedCluster` | Is a managed hub (has `hub.open-cluster-management.io` cluster claim) | Full reconcile (global search setup) |
-| `CollectorConfig` | Named `userCollectorConfigName` or has integration team label | Full reconcile |
+| `CollectorConfig` | Named `user-collector-config` or has label `search.open-cluster-management.io/config-type: integration` | Full reconcile |
 
 ## Feature configurations
 
 Three optional setup passes run during each reconcile:
 
-- **Global search** (`reconcileGlobalSearch`): When a `MulticlusterGlobalHub` or managed-hub `ManagedCluster` is detected, wires up federated search config for `search-v2-api`.
-- **Fine-grained RBAC** (`reconcileFineGrainedRBACConfiguration`): Configures `ManagedServiceAccount` and `ClusterPermission` resources to enable per-resource-type RBAC enforcement in the API.
-- **Virtual machine integration** (`reconcileVirtualMachineConfiguration`): Enables VM-specific resource collection and display when KubeVirt / CNV is detected.
+- **Global search** (`reconcileGlobalSearch`): Gated by the `global-search-preview` feature. Detects managed-hub clusters via `ManagedCluster.status.clusterClaims` and toggles `FEATURE_FEDERATED_SEARCH` on the search-api deployment accordingly.
+- **Fine-grained RBAC** (`reconcileFineGrainedRBACConfiguration`): Toggles `FEATURE_FINE_GRAINED_RBAC` on the search-api deployment and updates a status condition. Does not create `ManagedServiceAccount` or `ClusterPermission` resources.
+- **Virtual machine integration** (`reconcileVirtualMachineConfiguration`): Gated by the `virtual-machine-preview` feature. Creates `ManagedServiceAccount` and `ClusterPermission` resources for all managed clusters to enable VM resource access. KubeVirt/CNV detection is not yet implemented (noted as `FUTURE` in the code).
 
 ## Code generation
 


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with verified `make`-based commands, local run setup instructions (required env vars from `make setup`), and non-obvious conventions (slow first `make test`, single `Search` CR name, pause annotation, two-step code generation)
- Add `docs/ARCHITECTURE.md` with operator overview, CRD descriptions (`Search`, `CollectorConfig`), full reconcile sequence (15 steps), watch sources table, feature configurations (global search, fine-grained RBAC, VM integration), code generation notes, and testing approach

## Test plan

- [x] Verify `make` commands in `CLAUDE.md` match the `Makefile` targets
- [x] Review `docs/ARCHITECTURE.md` reconcile sequence against `controllers/search_controller.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added developer documentation for the search-v2-operator: setup steps, make targets, required environment variables for local runs, and development conventions (including pause annotation and personalization workflow).
  * Added comprehensive architecture docs: operator responsibilities, component orchestration, CRD semantics, reconciliation workflow, and testing methodology with local test/run guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->