### PR TITLE
feat(rbac): provision read-only PostgreSQL roles for search-v2-api and search-mcp-server

### DIFF
--- a/controllers/create_apideployment.go
+++ b/controllers/create_apideployment.go
@@ -21,7 +21,7 @@ func (r *SearchReconciler) APIDeployment(instance *searchv1alpha1.Search) *appsv
 		Env: []corev1.EnvVar{
 			newSecretEnvVar("DB_USER", "database-user", apiReadonlySecretName),
 			newSecretEnvVar("DB_PASS", "database-password", apiReadonlySecretName),
-			newSecretEnvVar("DB_NAME", "database-name", "search-postgres"),
+			newSecretEnvVar("DB_NAME", "database-name", apiReadonlySecretName),
 			newEnvVar("DB_HOST", "search-postgres."+instance.Namespace+".svc"),
 			newEnvVar("POD_NAMESPACE", instance.Namespace),
 		},

--- a/controllers/create_apideployment.go
+++ b/controllers/create_apideployment.go
@@ -19,8 +19,8 @@ func (r *SearchReconciler) APIDeployment(instance *searchv1alpha1.Search) *appsv
 		Name:  deploymentName,
 		Image: image_sha,
 		Env: []corev1.EnvVar{
-			newSecretEnvVar("DB_USER", "database-user", "search-postgres"),
-			newSecretEnvVar("DB_PASS", "database-password", "search-postgres"),
+			newSecretEnvVar("DB_USER", "database-user", apiReadonlySecretName),
+			newSecretEnvVar("DB_PASS", "database-password", apiReadonlySecretName),
 			newSecretEnvVar("DB_NAME", "database-name", "search-postgres"),
 			newEnvVar("DB_HOST", "search-postgres."+instance.Namespace+".svc"),
 			newEnvVar("POD_NAMESPACE", instance.Namespace),

--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -82,6 +82,41 @@ psql -d search -U searchuser -f /opt/app-root/src/postgresql-start/postgresql.sq
 
 	work_memquery := "psql -d search -U searchuser -c \"ALTER ROLE searchuser set work_mem='" + work_mem + "'\""
 	data[startScript] = data[startScript] + work_memquery
+	// Provision read-only roles for search-v2-api and search-mcp-server.
+	// Passwords are supplied via env vars mounted from the readonly Secrets.
+	// The psql -v flag passes them as psql variables (:'name') to avoid shell injection.
+	// Runs as the postgres superuser (peer auth) since CREATE ROLE requires elevated privilege.
+	data[startScript] = data[startScript] + `
+psql -d search -U postgres \
+  -v "READONLY_API_PASSWORD=$READONLY_API_PASSWORD" \
+  -v "READONLY_MCP_PASSWORD=$READONLY_MCP_PASSWORD" << 'EOSQL'
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_api_ro') THEN
+    CREATE ROLE search_api_ro WITH LOGIN PASSWORD :'READONLY_API_PASSWORD';
+  ELSE
+    ALTER ROLE search_api_ro WITH PASSWORD :'READONLY_API_PASSWORD';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_mcp_ro') THEN
+    CREATE ROLE search_mcp_ro WITH LOGIN PASSWORD :'READONLY_MCP_PASSWORD';
+  ELSE
+    ALTER ROLE search_mcp_ro WITH PASSWORD :'READONLY_MCP_PASSWORD';
+  END IF;
+END $$;
+GRANT USAGE ON SCHEMA search TO search_api_ro, search_mcp_ro;
+GRANT SELECT ON search.resources TO search_api_ro, search_mcp_ro;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT FROM information_schema.tables
+    WHERE table_schema = 'search' AND table_name = 'edges'
+  ) THEN
+    EXECUTE 'GRANT SELECT ON search.edges TO search_api_ro, search_mcp_ro';
+  END IF;
+END $$;
+ALTER DEFAULT PRIVILEGES IN SCHEMA search GRANT SELECT ON TABLES TO search_api_ro, search_mcp_ro;
+EOSQL
+`
 	data["postgresql.sql"] = `CREATE OR REPLACE FUNCTION search.intercluster_edges()
   RETURNS TRIGGER AS
 $BODY$
@@ -133,6 +168,70 @@ DROP TRIGGER IF EXISTS resources_upsert on search.resources;
 CREATE TRIGGER resources_upsert AFTER INSERT OR UPDATE ON search.resources FOR EACH ROW WHEN (NEW.data->>'kind' = 'Subscription') EXECUTE PROCEDURE search.intercluster_edges();
 DROP TRIGGER IF EXISTS resources_delete on search.resources;
 CREATE TRIGGER resources_delete AFTER DELETE ON search.resources FOR EACH ROW WHEN (OLD.data->>'kind' = 'Subscription') EXECUTE PROCEDURE search.intercluster_edges();
+-- LISTEN/NOTIFY trigger for search-v2-api WebSocket subscription support.
+-- Provisioned here so search-v2-api can connect with a read-only role (search_api_ro)
+-- and does not require CREATE TRIGGER privilege on search.resources.
+DROP TRIGGER IF EXISTS search_resources_notify_trigger ON search.resources;
+DROP FUNCTION IF EXISTS search.notify_resources_change();
+CREATE OR REPLACE FUNCTION search.notify_resources_change()
+RETURNS trigger AS $$
+DECLARE
+    notification_payload json;
+    new_data_json json;
+    old_data_json json;
+    new_data_size integer;
+    old_data_size integer;
+BEGIN
+    new_data_size := OCTET_LENGTH(NEW.data::text);
+    old_data_size := OCTET_LENGTH(OLD.data::text);
+    IF TG_OP = 'DELETE' THEN
+        new_data_json := NULL;
+        IF old_data_size < 7000 THEN
+            old_data_json := OLD.data;
+        ELSE
+            old_data_json := NULL;
+        END IF;
+    ELSEIF TG_OP = 'INSERT' THEN
+        IF new_data_size < 7000 THEN
+            new_data_json := NEW.data;
+        ELSE
+            new_data_json := NULL;
+        END IF;
+        old_data_json := NULL;
+    ELSEIF TG_OP = 'UPDATE' THEN
+        IF (new_data_size + old_data_size) < 7000 THEN
+            new_data_json := NEW.data;
+            old_data_json := OLD.data;
+        ELSEIF old_data_size < 7000 THEN
+            new_data_json := NULL;
+            old_data_json := OLD.data;
+        ELSE
+            new_data_json := NULL;
+            old_data_json := NULL;
+        END IF;
+    END IF;
+    notification_payload := json_build_object(
+        'operation', TG_OP,
+        'uid', COALESCE(NEW.uid, OLD.uid),
+        'cluster', COALESCE(NEW.cluster, OLD.cluster),
+        'newData', new_data_json,
+        'oldData', old_data_json,
+        'timestamp', NOW()
+    );
+    IF OCTET_LENGTH(notification_payload::text) < 7500 THEN
+        PERFORM pg_notify('search_resources_notify', notification_payload::text);
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    ELSE
+        RETURN NEW;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER search_resources_notify_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON search.resources
+    FOR EACH ROW
+    EXECUTE FUNCTION search.notify_resources_change();
 `
 	cm.Data = data
 	log.V(2).Info("Postgres configmap data populated")

--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -86,23 +86,26 @@ psql -d search -U searchuser -f /opt/app-root/src/postgresql-start/postgresql.sq
 	// Passwords are supplied via env vars mounted from the readonly Secrets.
 	// The psql -v flag passes them as psql variables (:'name') to avoid shell injection.
 	// Runs as the postgres superuser (peer auth) since CREATE ROLE requires elevated privilege.
+	// psql variable substitution (:'varname') works in plain SQL statements but NOT inside
+	// PL/pgSQL DO $$ blocks (the server receives the literal colon-prefixed string).
+	// Use \if / \else / \endif psql meta-commands with plain CREATE/ALTER ROLE statements
+	// so that :'varname' is substituted by the psql client before sending to the server.
 	data[startScript] = data[startScript] + `
 psql -d search -U postgres \
   -v "READONLY_API_PASSWORD=$READONLY_API_PASSWORD" \
   -v "READONLY_MCP_PASSWORD=$READONLY_MCP_PASSWORD" << 'EOSQL'
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_api_ro') THEN
-    CREATE ROLE search_api_ro WITH LOGIN PASSWORD :'READONLY_API_PASSWORD';
-  ELSE
-    ALTER ROLE search_api_ro WITH PASSWORD :'READONLY_API_PASSWORD';
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_mcp_ro') THEN
-    CREATE ROLE search_mcp_ro WITH LOGIN PASSWORD :'READONLY_MCP_PASSWORD';
-  ELSE
-    ALTER ROLE search_mcp_ro WITH PASSWORD :'READONLY_MCP_PASSWORD';
-  END IF;
-END $$;
+SELECT NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_api_ro') AS create_api_role \gset
+\if :create_api_role
+  CREATE ROLE search_api_ro WITH LOGIN PASSWORD :'READONLY_API_PASSWORD';
+\else
+  ALTER ROLE search_api_ro WITH PASSWORD :'READONLY_API_PASSWORD';
+\endif
+SELECT NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_mcp_ro') AS create_mcp_role \gset
+\if :create_mcp_role
+  CREATE ROLE search_mcp_ro WITH LOGIN PASSWORD :'READONLY_MCP_PASSWORD';
+\else
+  ALTER ROLE search_mcp_ro WITH PASSWORD :'READONLY_MCP_PASSWORD';
+\endif
 GRANT USAGE ON SCHEMA search TO search_api_ro, search_mcp_ro;
 GRANT SELECT ON search.resources TO search_api_ro, search_mcp_ro;
 DO $$
@@ -182,9 +185,8 @@ DECLARE
     new_data_size integer;
     old_data_size integer;
 BEGIN
-    new_data_size := OCTET_LENGTH(NEW.data::text);
-    old_data_size := OCTET_LENGTH(OLD.data::text);
     IF TG_OP = 'DELETE' THEN
+        old_data_size := OCTET_LENGTH(OLD.data::text);
         new_data_json := NULL;
         IF old_data_size < 7000 THEN
             old_data_json := OLD.data;
@@ -192,6 +194,7 @@ BEGIN
             old_data_json := NULL;
         END IF;
     ELSEIF TG_OP = 'INSERT' THEN
+        new_data_size := OCTET_LENGTH(NEW.data::text);
         IF new_data_size < 7000 THEN
             new_data_json := NEW.data;
         ELSE
@@ -199,6 +202,8 @@ BEGIN
         END IF;
         old_data_json := NULL;
     ELSEIF TG_OP = 'UPDATE' THEN
+        new_data_size := OCTET_LENGTH(NEW.data::text);
+        old_data_size := OCTET_LENGTH(OLD.data::text);
         IF (new_data_size + old_data_size) < 7000 THEN
             new_data_json := NEW.data;
             old_data_json := OLD.data;

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -31,6 +31,8 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 			newSecretEnvVar("POSTGRESQL_USER", "database-user", "search-postgres"),
 			newSecretEnvVar("POSTGRESQL_PASSWORD", "database-password", "search-postgres"),
 			newSecretEnvVar("POSTGRESQL_DATABASE", "database-name", "search-postgres"),
+			newSecretEnvVar("READONLY_API_PASSWORD", "database-password", apiReadonlySecretName),
+			newSecretEnvVar("READONLY_MCP_PASSWORD", "database-password", mcpReadonlySecretName),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/controllers/create_pgsecret.go
+++ b/controllers/create_pgsecret.go
@@ -13,6 +13,11 @@ import (
 
 const DBNAME = "search"
 
+const (
+	apiReadonlySecretName = "search-postgres-api-readonly" // #nosec G101 - False positive, this is a secret name, not a password
+	mcpReadonlySecretName = "search-postgres-mcp-readonly" // #nosec G101 - False positive, this is a secret name, not a password
+)
+
 func (r *SearchReconciler) PGSecret(instance *searchv1alpha1.Search) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -30,6 +35,46 @@ func (r *SearchReconciler) PGSecret(instance *searchv1alpha1.Search) *corev1.Sec
 	err := controllerutil.SetControllerReference(instance, secret, r.Scheme)
 	if err != nil {
 		log.V(2).Info("Could not set control for search-postgres secret")
+	}
+	return secret
+}
+
+func (r *SearchReconciler) APIReadonlySecret(instance *searchv1alpha1.Search) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apiReadonlySecretName,
+			Namespace: instance.GetNamespace(),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	secret.StringData = map[string]string{
+		"database-user":     "search_api_ro",
+		"database-password": generatePass(16),
+		"database-name":     DBNAME,
+	}
+	err := controllerutil.SetControllerReference(instance, secret, r.Scheme)
+	if err != nil {
+		log.V(2).Info("Could not set control for search-postgres-api-readonly secret")
+	}
+	return secret
+}
+
+func (r *SearchReconciler) MCPReadonlySecret(instance *searchv1alpha1.Search) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mcpReadonlySecretName,
+			Namespace: instance.GetNamespace(),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	secret.StringData = map[string]string{
+		"database-user":     "search_mcp_ro",
+		"database-password": generatePass(16),
+		"database-name":     DBNAME,
+	}
+	err := controllerutil.SetControllerReference(instance, secret, r.Scheme)
+	if err != nil {
+		log.V(2).Info("Could not set control for search-postgres-mcp-readonly secret")
 	}
 	return secret
 }

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -181,6 +181,16 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "Postgres Secret setup failed")
 		return *result, err
 	}
+	result, err = r.createSecret(ctx, r.APIReadonlySecret(instance))
+	if result != nil {
+		log.Error(err, "Postgres API readonly Secret setup failed")
+		return *result, err
+	}
+	result, err = r.createSecret(ctx, r.MCPReadonlySecret(instance))
+	if result != nil {
+		log.Error(err, "Postgres MCP readonly Secret setup failed")
+		return *result, err
+	}
 	result, err = r.createService(ctx, r.PGService(instance))
 	if result != nil {
 		log.Error(err, "Postgres Service setup failed")

--- a/plans/ACM-32474-readonly-postgres-user-plan.md
+++ b/plans/ACM-32474-readonly-postgres-user-plan.md
@@ -1,0 +1,267 @@
+# ACM-32474: Implementation Plan — Read-Only PostgreSQL Users for search-v2-api and search-mcp-server
+
+**Jira:** https://redhat.atlassian.net/browse/ACM-35503
+**Parent:** https://redhat.atlassian.net/browse/ACM-32474
+**Date:** 2026-06-15
+**Revision:** 2 — moved implementation to search-v2-operator; expanded scope to cover search-v2-api
+
+---
+
+## Problem
+
+Both `search-v2-api` and `search-mcp-server` connect to the ACM PostgreSQL database using
+the `searchuser` read-write credential from the `search-postgres` Secret. This credential
+is also used by `search-indexer` to write data.
+
+Both consumers are architecturally read-only (SELECT only), but the database-layer
+enforcement is absent. If either application were compromised, the attacker would hold
+a credential capable of arbitrary writes, deletes, and schema changes.
+
+---
+
+## Solution Architecture
+
+The `search-v2-operator` is the correct owner of this change. It already:
+- creates and owns the `search-postgres` Secret and Deployment
+- provisions the database schema, tables, indexes, and triggers via ConfigMap startup scripts
+- manages the `search-v2-api` Deployment env vars
+
+The fix adds two dedicated read-only PostgreSQL roles provisioned at database startup.
+Applications receive credentials via new Secrets. No Helm hook Jobs, no external images,
+no network policy concerns.
+
+**Roles:**
+
+| Role | Privileges | Consumer |
+|---|---|---|
+| `search_api_ro` | `USAGE ON SCHEMA search`, `SELECT ON search.resources, search.edges` | search-v2-api |
+| `search_mcp_ro` | `USAGE ON SCHEMA search`, `SELECT ON search.resources, search.edges` | search-mcp-server |
+
+**Layers of read-only enforcement after this change:**
+
+| Layer | search-v2-api | search-mcp-server |
+|---|---|---|
+| Database | `search_api_ro` role — SELECT only | `search_mcp_ro` role — SELECT only |
+| Application | SQL builder (goqu) — only generates SELECTs | `validateQuery()` — rejects all mutations |
+
+---
+
+## Repos and Files Changed
+
+### `search-v2-operator` (primary)
+
+**`controllers/create_pgsecret.go`** — add two new Secret constructors:
+
+```go
+const (
+    apiReadonlySecretName = "search-postgres-api-readonly"
+    mcpReadonlySecretName = "search-postgres-mcp-readonly"
+)
+
+func (r *SearchReconciler) APIReadonlySecret(instance *searchv1alpha1.Search) *corev1.Secret {
+    secret := &corev1.Secret{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      apiReadonlySecretName,
+            Namespace: instance.GetNamespace(),
+        },
+        Type: corev1.SecretTypeOpaque,
+    }
+    secret.StringData = map[string]string{
+        "database-user":     "search_api_ro",
+        "database-password": generatePass(16),
+        "database-name":     DBNAME,
+    }
+    controllerutil.SetControllerReference(instance, secret, r.Scheme)
+    return secret
+}
+
+func (r *SearchReconciler) MCPReadonlySecret(instance *searchv1alpha1.Search) *corev1.Secret {
+    // same pattern, name: mcpReadonlySecretName, user: search_mcp_ro
+}
+```
+
+The existing `createSecret()` helper in `common.go` only creates if not found — passwords
+are stable across reconciles (same pattern as `search-postgres`).
+
+---
+
+**`controllers/create_pgdeployment.go`** — mount new Secret passwords as env vars so the
+startup script can set the role passwords:
+
+```go
+// Add to the postgres container env:
+newSecretEnvVar("READONLY_API_PASSWORD", "database-password", apiReadonlySecretName),
+newSecretEnvVar("READONLY_MCP_PASSWORD", "database-password", mcpReadonlySecretName),
+```
+
+---
+
+**`controllers/create_pgconfigmap.go`** — two additions:
+
+**1. Append to `postgresql-start.sh`** — create roles using the postgres superuser (peer
+auth is available since the script runs as the `postgres` OS user):
+
+```bash
+# Create read-only roles
+psql -d search -U postgres <<'EOSQL'
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_api_ro') THEN
+    CREATE ROLE search_api_ro WITH LOGIN PASSWORD :'READONLY_API_PASSWORD';
+  ELSE
+    ALTER ROLE search_api_ro WITH PASSWORD :'READONLY_API_PASSWORD';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'search_mcp_ro') THEN
+    CREATE ROLE search_mcp_ro WITH LOGIN PASSWORD :'READONLY_MCP_PASSWORD';
+  ELSE
+    ALTER ROLE search_mcp_ro WITH PASSWORD :'READONLY_MCP_PASSWORD';
+  END IF;
+END $$;
+GRANT USAGE ON SCHEMA search TO search_api_ro, search_mcp_ro;
+GRANT SELECT ON search.resources TO search_api_ro, search_mcp_ro;
+GRANT SELECT ON search.edges TO search_api_ro, search_mcp_ro;
+ALTER DEFAULT PRIVILEGES IN SCHEMA search
+  GRANT SELECT ON TABLES TO search_api_ro, search_mcp_ro;
+EOSQL
+```
+
+> **Note:** `:'READONLY_API_PASSWORD'` is a psql variable reference, set via `-v` flag or
+> environment. The passwords must be passed to psql without appearing in shell arguments
+> (to avoid exposure via `/proc/PID/cmdline`). The `PGPASSWORD` pattern or psql `\set`
+> from env is the safe approach — exact technique to be finalized during implementation.
+
+> **Note on `GRANT SELECT ON search.edges`:** The `search.edges` table may not exist on
+> older clusters. Wrap in a `DO $$ IF EXISTS ...` block or handle the error gracefully.
+
+**2. Append NOTIFY trigger to `postgresql.sql`** — move the content of
+`search-v2-api/pkg/database/listenerTrigger.sql` here, so the operator creates the trigger
+at database startup. The API no longer needs to create it (and therefore no longer needs
+`CREATE TRIGGER` privilege on `search.resources`):
+
+```sql
+-- LISTEN/NOTIFY trigger for search-v2-api subscription support
+DROP TRIGGER IF EXISTS search_resources_notify_trigger ON search.resources;
+DROP FUNCTION IF EXISTS search.notify_resources_change();
+CREATE OR REPLACE FUNCTION search.notify_resources_change()
+  RETURNS trigger AS $$ ... $$ LANGUAGE plpgsql;
+CREATE TRIGGER search_resources_notify_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON search.resources
+  FOR EACH ROW EXECUTE FUNCTION search.notify_resources_change();
+```
+
+---
+
+**`controllers/search_controller.go`** — call `createSecret` for the two new Secrets
+before the postgres Deployment is created/updated (following the existing pattern at line
+179):
+
+```go
+result, err = r.createSecret(ctx, r.APIReadonlySecret(instance))
+// handle result/err
+result, err = r.createSecret(ctx, r.MCPReadonlySecret(instance))
+// handle result/err
+```
+
+---
+
+**`controllers/create_apideployment.go`** — change `DB_USER` and `DB_PASS` to reference
+the new read-only Secret (lines 22–23):
+
+```go
+// before
+newSecretEnvVar("DB_USER", "database-user", "search-postgres"),
+newSecretEnvVar("DB_PASS", "database-password", "search-postgres"),
+
+// after
+newSecretEnvVar("DB_USER", "database-user", apiReadonlySecretName),
+newSecretEnvVar("DB_PASS", "database-password", apiReadonlySecretName),
+```
+
+`DB_NAME` remains pointing to `search-postgres` (database name is not a credential).
+
+---
+
+### `search-v2-api` (secondary)
+
+**`pkg/database/listener.go`** — remove the trigger/function setup SQL. The trigger now
+exists from database startup (provisioned by the operator). The listener only needs to
+`LISTEN search_resources_notify`, which requires no special privilege.
+
+The `listenerTrigger.sql` file can be removed or kept as documentation of what the
+operator installs.
+
+---
+
+### `search-mcp-server` (minor)
+
+**`helm/acm-mcp-server/templates/secret.yaml`** — change the auto-discovery lookup to use
+the read-only Secret keys instead of the admin Secret:
+
+```yaml
+# before
+{{- $searchSecret := lookup "v1" "Secret" $acmNamespace "search-postgres" }}
+{{- $dbUser := index $searchSecret.data "database-user" | b64dec }}
+{{- $dbPass := index $searchSecret.data "database-password" | b64dec }}
+
+# after
+{{- $mcpSecret := lookup "v1" "Secret" $acmNamespace "search-postgres-mcp-readonly" }}
+{{- $dbUser := index $mcpSecret.data "database-user" | b64dec }}
+{{- $dbPass := index $mcpSecret.data "database-password" | b64dec }}
+```
+
+`$dbName` and `$dbHost` remain derived from `search-postgres` (non-credential fields).
+
+No Go code changes in search-mcp-server.
+
+---
+
+## Upgrade Path
+
+On upgrade from an existing installation:
+
+1. Operator reconcile runs — new Secrets (`search-postgres-api-readonly`,
+   `search-postgres-mcp-readonly`) are created first (before Deployment update).
+2. Postgres Deployment is updated to add `READONLY_API_PASSWORD` and `READONLY_MCP_PASSWORD`
+   env vars — postgres pod restarts.
+3. `postgresql-start.sh` runs on restart — creates the new roles idempotently.
+4. `search-v2-api` Deployment is updated to reference the new read-only Secret — API pod
+   restarts with the new credentials.
+5. `search-mcp-server` Helm chart is upgraded — picks up the new `search-postgres-mcp-readonly`
+   Secret.
+
+`search-indexer` is unaffected — it continues using the admin `search-postgres` Secret.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `search_api_ro` and `search_mcp_ro` roles created idempotently on each postgres pod restart
+- [ ] Both roles have `USAGE ON SCHEMA search`, `SELECT ON search.resources/edges`, and `ALTER DEFAULT PRIVILEGES` for future tables
+- [ ] `search-v2-api` pod connects as `search_api_ro` (verified via `SELECT current_user`)
+- [ ] `search-mcp-server` pod connects as `search_mcp_ro`
+- [ ] `search-indexer` still connects as `searchuser` (unaffected)
+- [ ] Admin credentials (`searchuser`) are not mounted in either read-only application pod
+- [ ] LISTEN/NOTIFY subscription feature continues to work in `search-v2-api` (trigger pre-created by operator)
+- [ ] `make test` passes in `search-v2-operator`
+- [ ] `make test-race` passes in `search-v2-api` and `search-mcp-server`
+
+---
+
+## Risks and Open Questions
+
+| Risk / Question | Notes |
+|---|---|
+| `search.edges` may not exist on all clusters | Wrap GRANT in a conditional; investigate whether all target clusters have this table |
+| psql variable syntax for passwords | Use `psql -v READONLY_API_PASSWORD="$READONLY_API_PASSWORD"` or similar — confirm safe quoting to avoid shell injection |
+| Postgres peer auth availability | Confirm Red Hat UBI postgres image allows `psql -U postgres` without password from the `postgres` OS user in the startup scripts |
+| `listenerTrigger.sql` ownership | Removing trigger setup from `search-v2-api` requires coordinated release with `search-v2-operator` update; operator must ship first |
+| Clusters where `search-mcp-server` is deployed before operator upgrade | `search-postgres-mcp-readonly` Secret won't exist yet; Helm lookup will return empty and DSN will be malformed — add guard in `secret.yaml` |
+
+---
+
+## Out of Scope
+
+- Password rotation for `search_api_ro` / `search_mcp_ro`
+- Row-level security or column-level restrictions
+- Removing `validateQuery()` from search-mcp-server
+- Any changes to `search-indexer` credentials

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -1,0 +1,9 @@
+sessions:
+---
+- date: "2026-06-15"
+  title: "[search-mcp] SAR-09: Plan for creating and using a read-only PostgreSQL user"
+  jira: "ACM-35503"
+  jira_url: "https://redhat.atlassian.net/browse/ACM-35503"
+  pr: ~
+  plan: "plans/ACM-32474-readonly-postgres-user-plan.md"
+  summary: "Plan search-v2-operator changes to provision dedicated read-only PostgreSQL roles for both search-v2-api and search-mcp-server, eliminating their use of the shared read-write searchuser credential"

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -4,6 +4,6 @@ sessions:
   title: "[search-mcp] SAR-09: Plan for creating and using a read-only PostgreSQL user"
   jira: "ACM-35503"
   jira_url: "https://redhat.atlassian.net/browse/ACM-35503"
-  pr: ~
+  pr: "https://github.com/stolostron/search-v2-operator/pull/737"
   plan: "plans/ACM-32474-readonly-postgres-user-plan.md"
-  summary: "Plan search-v2-operator changes to provision dedicated read-only PostgreSQL roles for both search-v2-api and search-mcp-server, eliminating their use of the shared read-write searchuser credential"
+  summary: "Implemented search_api_ro and search_mcp_ro PostgreSQL roles provisioned by the operator at database startup, with new create-only Secrets and the NOTIFY trigger moved from search-v2-api into postgresql.sql"


### PR DESCRIPTION
## Summary

- Add `search_api_ro` and `search_mcp_ro` PostgreSQL roles provisioned at database startup, so `search-v2-api` and `search-mcp-server` no longer connect with the shared read-write `searchuser` credential
- New Secrets (`search-postgres-api-readonly`, `search-postgres-mcp-readonly`) created with stable passwords (generated once, never overwritten on reconcile)
- LISTEN/NOTIFY trigger moved from `search-v2-api` into the operator's `postgresql.sql` so the API can run as a truly read-only role without `CREATE TRIGGER` privilege

## Changes

- `controllers/create_pgsecret.go` — `APIReadonlySecret()` and `MCPReadonlySecret()` constructors
- `controllers/create_pgdeployment.go` — `READONLY_API_PASSWORD` / `READONLY_MCP_PASSWORD` env vars on postgres container
- `controllers/create_pgconfigmap.go` — role provisioning SQL in `postgresql-start.sh`; NOTIFY trigger in `postgresql.sql`
- `controllers/search_controller.go` — `createSecret` calls for both new Secrets before postgres Deployment
- `controllers/create_apideployment.go` — `DB_USER`/`DB_PASS` reference `search-postgres-api-readonly`

## Follow-up required (separate PRs)

- `search-v2-api`: remove trigger/function setup from `listener.go` (operator now pre-creates it)
- `search-mcp-server`: update `helm/acm-mcp-server/templates/secret.yaml` to look up `search-postgres-mcp-readonly`

## Test plan

- [x] `make test` passes
- [ ] Operator deployed to a live cluster — verify `search_api_ro` and `search_mcp_ro` roles exist after postgres pod restart
- [ ] `SELECT current_user` from `search-v2-api` returns `search_api_ro`
- [ ] `search-indexer` still connects as `searchuser` (unaffected)
- [ ] LISTEN/NOTIFY subscription feature works end-to-end

Jira: https://redhat.atlassian.net/browse/ACM-35503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated read-only PostgreSQL credentials for API and MCP, provisioned as separate Secrets and wired into the Postgres deployment.
  * Updated Postgres startup provisioning to create/update read-only roles (`search_api_ro`, `search_mcp_ro`) and grant schema/table (and default) SELECT permissions.
  * Switched `search.resources` edge change propagation from trigger-based maintenance to a LISTEN/NOTIFY–driven notification workflow.
* **Documentation**
  * Published and indexed an implementation plan for rolling out the read-only PostgreSQL users/roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->