### PR TITLE
ACM-35522: Webhook validation and merge protection for exclude action

### DIFF
--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -259,38 +259,60 @@ func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList
 	// Reject exclusion of protected resource types.
 	// Check both specific kind names and wildcard kinds — apiGroups:["cluster.open-cluster-management.io"]
 	// kinds:["*"] would exclude ManagedCluster just as effectively as naming it explicitly.
+	allErrs = append(allErrs, validateProtectedKinds(rule, path)...)
+	return allErrs
+}
+
+// validateProtectedKinds checks that an exclude rule does not target ManagedCluster or Namespace,
+// either by name or via a wildcard kind on their apiGroup.
+func validateProtectedKinds(rule *CollectionRule, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
 	for _, kind := range rule.ResourceSelector.Kinds {
 		if kind == "*" {
-			// Wildcard kind: reject if any targeted apiGroup contains a protected kind.
-			for protectedKind, protectedGroup := range protectedKinds {
-				for _, apiGroup := range rule.ResourceSelector.APIGroups {
-					if apiGroup == "*" || apiGroup == protectedGroup {
-						allErrs = append(allErrs, field.Invalid(
-							path.Child("resourceSelector", "apiGroups"),
-							apiGroup,
-							"cannot exclude all kinds in this apiGroup — it contains "+
-								protectedKind+", which search depends on for RBAC and cluster-scoped queries",
-						))
-						break
-					}
-				}
-			}
+			allErrs = append(allErrs, validateWildcardKindAgainstProtected(rule.ResourceSelector.APIGroups, path)...)
 			continue
 		}
 		if protectedGroup, protected := protectedKinds[kind]; protected {
-			for _, apiGroup := range rule.ResourceSelector.APIGroups {
-				if apiGroup == protectedGroup || apiGroup == "*" {
-					allErrs = append(allErrs, field.Invalid(
-						path.Child("resourceSelector", "kinds"),
-						kind,
-						"cannot exclude "+kind+" — search depends on it for RBAC and cluster-scoped queries",
-					))
-					break
-				}
+			allErrs = append(allErrs, validateSpecificKindAgainstProtected(kind, protectedGroup, rule.ResourceSelector.APIGroups, path)...)
+		}
+	}
+	return allErrs
+}
+
+// validateWildcardKindAgainstProtected rejects kinds:["*"] when the rule's apiGroups contain
+// a group that holds a protected kind (e.g. cluster.open-cluster-management.io → ManagedCluster).
+func validateWildcardKindAgainstProtected(apiGroups []string, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for protectedKind, protectedGroup := range protectedKinds {
+		for _, apiGroup := range apiGroups {
+			if apiGroup == "*" || apiGroup == protectedGroup {
+				allErrs = append(allErrs, field.Invalid(
+					path.Child("resourceSelector", "apiGroups"),
+					apiGroup,
+					"cannot exclude all kinds in this apiGroup — it contains "+
+						protectedKind+", which search depends on for RBAC and cluster-scoped queries",
+				))
+				break
 			}
 		}
 	}
+	return allErrs
+}
 
+// validateSpecificKindAgainstProtected rejects a specific protected kind when the rule's
+// apiGroups match the kind's group (including the global wildcard "*").
+func validateSpecificKindAgainstProtected(kind, protectedGroup string, apiGroups []string, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for _, apiGroup := range apiGroups {
+		if apiGroup == protectedGroup || apiGroup == "*" {
+			allErrs = append(allErrs, field.Invalid(
+				path.Child("resourceSelector", "kinds"),
+				kind,
+				"cannot exclude "+kind+" — search depends on it for RBAC and cluster-scoped queries",
+			))
+			break
+		}
+	}
 	return allErrs
 }
 

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -273,7 +273,8 @@ func validateProtectedKinds(rule *CollectionRule, path *field.Path) field.ErrorL
 			continue
 		}
 		if protectedGroup, protected := protectedKinds[kind]; protected {
-			allErrs = append(allErrs, validateSpecificKindAgainstProtected(kind, protectedGroup, rule.ResourceSelector.APIGroups, path)...)
+			errs := validateSpecificKindAgainstProtected(kind, protectedGroup, rule.ResourceSelector.APIGroups, path)
+			allErrs = append(allErrs, errs...)
 		}
 	}
 	return allErrs
@@ -301,7 +302,9 @@ func validateWildcardKindAgainstProtected(apiGroups []string, path *field.Path) 
 
 // validateSpecificKindAgainstProtected rejects a specific protected kind when the rule's
 // apiGroups match the kind's group (including the global wildcard "*").
-func validateSpecificKindAgainstProtected(kind, protectedGroup string, apiGroups []string, path *field.Path) field.ErrorList {
+func validateSpecificKindAgainstProtected(
+	kind, protectedGroup string, apiGroups []string, path *field.Path,
+) field.ErrorList {
 	var allErrs field.ErrorList
 	for _, apiGroup := range apiGroups {
 		if apiGroup == protectedGroup || apiGroup == "*" {

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -20,6 +21,11 @@ import (
 // log is for logging in this package.
 var collectorconfiglog = logf.Log.WithName("collectorconfig-resource")
 
+// webhookClient is the Kubernetes client used to list integration team CollectorConfigs
+// during admission. Set once in SetupWebhookWithManager; nil in unit tests that don't
+// register a manager (the integration-config check is skipped when nil).
+var webhookClient client.Client
+
 // Precompiled validation patterns.
 var (
 	fieldNamePattern   = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9\-_.]*$`)
@@ -27,6 +33,7 @@ var (
 )
 
 func (r *CollectorConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	webhookClient = mgr.GetClient()
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		WithValidator(r).
@@ -50,8 +57,11 @@ func (r *CollectorConfig) ValidateCreate(ctx context.Context, obj runtime.Object
 		return nil, err
 	}
 
-	err := cc.validateCollectorConfig()
-	return nil, err
+	if err := cc.validateCollectorConfig(); err != nil {
+		return nil, err
+	}
+
+	return nil, validateExcludeAgainstIntegrationConfigs(ctx, cc)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -74,8 +84,11 @@ func (r *CollectorConfig) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		return nil, err
 	}
 
-	err := cc.validateCollectorConfig()
-	return nil, err
+	if err := cc.validateCollectorConfig(); err != nil {
+		return nil, err
+	}
+
+	return nil, validateExcludeAgainstIntegrationConfigs(ctx, cc)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
@@ -244,9 +257,25 @@ func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList
 	}
 
 	// Reject exclusion of protected resource types.
+	// Check both specific kind names and wildcard kinds — apiGroups:["cluster.open-cluster-management.io"]
+	// kinds:["*"] would exclude ManagedCluster just as effectively as naming it explicitly.
 	for _, kind := range rule.ResourceSelector.Kinds {
 		if kind == "*" {
-			continue // wildcard is allowed; the collector handles protected types at runtime
+			// Wildcard kind: reject if any targeted apiGroup contains a protected kind.
+			for protectedKind, protectedGroup := range protectedKinds {
+				for _, apiGroup := range rule.ResourceSelector.APIGroups {
+					if apiGroup == "*" || apiGroup == protectedGroup {
+						allErrs = append(allErrs, field.Invalid(
+							path.Child("resourceSelector", "apiGroups"),
+							apiGroup,
+							"cannot exclude all kinds in this apiGroup — it contains "+
+								protectedKind+", which search depends on for RBAC and cluster-scoped queries",
+						))
+						break
+					}
+				}
+			}
+			continue
 		}
 		if protectedGroup, protected := protectedKinds[kind]; protected {
 			for _, apiGroup := range rule.ResourceSelector.APIGroups {
@@ -406,4 +435,89 @@ func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
 	}
 
 	return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", cc.Name)
+}
+
+// validateExcludeAgainstIntegrationConfigs rejects exclude rules on non-integration
+// CollectorConfigs that would conflict with an integration team's include rules.
+// This mirrors the merge-time protection in the operator (excludeOverlapsIntegrationIncludes)
+// but surfaces the error at admission time for an immediate feedback.
+//
+// The check is skipped when:
+//   - webhookClient is nil (unit tests without a registered manager)
+//   - the submitted CollectorConfig is itself an integration team config
+//   - the CollectorConfig has no exclude rules
+func validateExcludeAgainstIntegrationConfigs(ctx context.Context, cc *CollectorConfig) error {
+	if webhookClient == nil {
+		return nil
+	}
+	// Integration team configs are allowed to exclude — they own their own rules.
+	if cc.Labels[IntegrationTeamLabel] == IntegrationTeamLabelValue {
+		return nil
+	}
+
+	// Collect exclude rules from the submitted config.
+	var excludeRules []CollectionRule
+	for _, rule := range cc.Spec.CollectionRules {
+		if rule.Action == ActionExclude {
+			excludeRules = append(excludeRules, rule)
+		}
+	}
+	if len(excludeRules) == 0 {
+		return nil
+	}
+
+	// List integration team CollectorConfigs.
+	integrationList := &CollectorConfigList{}
+	if err := webhookClient.List(ctx, integrationList,
+		client.InNamespace(cc.Namespace),
+		client.MatchingLabels{IntegrationTeamLabel: IntegrationTeamLabelValue},
+	); err != nil {
+		// Log and allow — a list failure should not block valid CRD operations.
+		collectorconfiglog.Error(err, "could not list integration team CollectorConfigs; skipping overlap check")
+		return nil
+	}
+
+	// Reject any exclude that overlaps an integration include.
+	var allErrs field.ErrorList
+	rulesPath := field.NewPath("spec", "collectionRules")
+	for i, excludeRule := range cc.Spec.CollectionRules {
+		if excludeRule.Action != ActionExclude {
+			continue
+		}
+		for _, ic := range integrationList.Items {
+			for _, teamRule := range ic.Spec.CollectionRules {
+				if teamRule.Action != ActionInclude {
+					continue
+				}
+				if webhookSetsIntersect(excludeRule.ResourceSelector.APIGroups, teamRule.ResourceSelector.APIGroups) &&
+					webhookSetsIntersect(excludeRule.ResourceSelector.Kinds, teamRule.ResourceSelector.Kinds) {
+					allErrs = append(allErrs, field.Invalid(
+						rulesPath.Index(i).Child("resourceSelector"),
+						excludeRule.ResourceSelector,
+						"cannot exclude these resources — they are necessary for system functionality",
+					))
+				}
+			}
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return allErrs.ToAggregate()
+}
+
+// webhookSetsIntersect returns true when two string slices share at least one element,
+// treating "*" as a universal match for all values on the other side.
+// This mirrors controllers.setsIntersect but is local to the webhook package to
+// avoid an import cycle.
+func webhookSetsIntersect(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == "*" || y == "*" || x == y {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -220,6 +220,58 @@ var protectedKinds = map[string]string{
 	"Namespace":      "", // core group
 }
 
+// protectedAPIGroups is a temporary list of API groups that must not be excluded.
+// These cover resources that integration teams (CNV, OLM, GRC, Argo, Kyverno, etc.)
+// and Search itself depend on. Once integration teams ship labeled CollectorConfig CRs
+// (search.open-cluster-management.io/config-type: integration), the dynamic webhook check
+// will replace this list. Until then this provides a safety net.
+//
+// Source: search-collector/pkg/transforms/genericResourceConfig.go plus ACM integration teams.
+// "" = core group (ConfigMap, Job, Node, Pod, PVC — needed by CNV, console, and others).
+var protectedAPIGroups = map[string]struct{}{
+	// Core group — ConfigMap, Job, Node, Pod, PVC needed by CNV / console
+	"": {},
+	// OLM
+	"operators.coreos.com": {},
+	// OpenShift cluster config
+	"config.openshift.io": {},
+	// CNV / KubeVirt family
+	"kubevirt.io":                              {},
+	"cdi.kubevirt.io":                          {},
+	"migrations.kubevirt.io":                   {},
+	"clone.kubevirt.io":                        {},
+	"instancetype.kubevirt.io":                 {},
+	"snapshot.kubevirt.io":                     {},
+	"networkaddonsoperator.network.kubevirt.io": {},
+	// Networking
+	"k8s.cni.cncf.io": {},
+	// Storage
+	"storage.k8s.io":       {},
+	"snapshot.storage.k8s.io":      {},
+	"snapshot.storage.kubevirt.io": {},
+	// OpenShift templates
+	"template.openshift.io": {},
+	// Admission / webhook configs
+	"admissionregistration.k8s.io": {},
+	// ACM hub operator
+	"operator.open-cluster-management.io": {},
+	// ACM Search itself
+	"search.open-cluster-management.io": {},
+	// ACM app lifecycle
+	"apps.open-cluster-management.io": {},
+	"app.k8s.io":                       {},
+	// GRC / Policy
+	"policy.open-cluster-management.io": {},
+	"wgpolicyk8s.io":                    {},
+	// Kyverno
+	"kyverno.io":          {},
+	"policies.kyverno.io": {},
+	// Gatekeeper
+	"constraints.gatekeeper.sh": {},
+	// Argo
+	"argoproj.io": {},
+}
+
 // validateExcludeRule enforces constraints specific to exclude rules:
 //   - Cannot target ManagedCluster or Namespace (search RBAC engine depends on them)
 //   - Cannot specify fields, collectConditions, or fieldSuffix (meaningless on an exclude)
@@ -263,10 +315,30 @@ func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList
 		))
 	}
 
-	// Reject exclusion of protected resource types.
-	// Check both specific kind names and wildcard kinds — apiGroups:["cluster.open-cluster-management.io"]
-	// kinds:["*"] would exclude ManagedCluster just as effectively as naming it explicitly.
+	// Reject exclusion of RBAC-critical kinds (ManagedCluster, Namespace).
 	allErrs = append(allErrs, validateProtectedKinds(rule, path)...)
+
+	// Reject exclusion of integration-critical API groups.
+	// This is a temporary safety net until integration teams ship labeled CollectorConfigs.
+	for _, apiGroup := range rule.ResourceSelector.APIGroups {
+		if apiGroup == "*" {
+			allErrs = append(allErrs, field.Invalid(
+				path.Child("resourceSelector", "apiGroups"),
+				apiGroup,
+				"cannot exclude all apiGroups — "+
+					"resources in many groups are necessary for system functionality",
+			))
+			break
+		}
+		if _, protected := protectedAPIGroups[apiGroup]; protected {
+			allErrs = append(allErrs, field.Invalid(
+				path.Child("resourceSelector", "apiGroups"),
+				apiGroup,
+				"cannot exclude resources in apiGroup "+apiGroup+
+					" — these resources are necessary for system functionality",
+			))
+		}
+	}
 	return allErrs
 }
 

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -177,6 +177,11 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 				))
 			}
 		}
+
+		// Validate exclude-specific constraints
+		if rule.Action == ActionExclude {
+			allErrs = append(allErrs, validateExcludeRule(&rule, rulePath)...)
+		}
 	}
 
 	if len(allErrs) == 0 {
@@ -184,6 +189,64 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 	}
 
 	return allErrs.ToAggregate()
+}
+
+// protectedKinds lists resource types the search RBAC engine depends on.
+// Excluding them would break per-cluster and namespace-scoped access control.
+var protectedKinds = map[string]string{
+	"ManagedCluster": "cluster.open-cluster-management.io",
+	"Namespace":      "", // core group
+}
+
+// validateExcludeRule enforces constraints specific to exclude rules:
+//   - Cannot target ManagedCluster or Namespace (search RBAC engine depends on them)
+//   - Cannot specify fields, collectConditions, or fieldSuffix (meaningless on an exclude)
+func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Reject fields, collectConditions, and fieldSuffix on exclude rules.
+	if len(rule.Fields) > 0 {
+		allErrs = append(allErrs, field.Invalid(
+			path.Child("fields"),
+			rule.Fields,
+			"fields cannot be specified on an exclude rule",
+		))
+	}
+	if rule.CollectConditions != nil && *rule.CollectConditions {
+		allErrs = append(allErrs, field.Invalid(
+			path.Child("collectConditions"),
+			*rule.CollectConditions,
+			"collectConditions cannot be set on an exclude rule",
+		))
+	}
+	if rule.FieldSuffix != "" {
+		allErrs = append(allErrs, field.Invalid(
+			path.Child("fieldSuffix"),
+			rule.FieldSuffix,
+			"fieldSuffix cannot be specified on an exclude rule",
+		))
+	}
+
+	// Reject exclusion of protected resource types.
+	for _, kind := range rule.ResourceSelector.Kinds {
+		if kind == "*" {
+			continue // wildcard is allowed; the collector handles protected types at runtime
+		}
+		if protectedGroup, protected := protectedKinds[kind]; protected {
+			for _, apiGroup := range rule.ResourceSelector.APIGroups {
+				if apiGroup == protectedGroup || apiGroup == "*" {
+					allErrs = append(allErrs, field.Invalid(
+						path.Child("resourceSelector", "kinds"),
+						kind,
+						"cannot exclude "+kind+" — search depends on it for RBAC and cluster-scoped queries",
+					))
+					break
+				}
+			}
+		}
+	}
+
+	return allErrs
 }
 
 // validateResourceSelector validates the ResourceSelector fields

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -255,6 +255,13 @@ func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList
 			"fieldSuffix cannot be specified on an exclude rule",
 		))
 	}
+	if rule.CollectAdditionalPrinterColumnsPriority != nil {
+		allErrs = append(allErrs, field.Invalid(
+			path.Child("collectAdditionalPrinterColumnsPriority"),
+			*rule.CollectAdditionalPrinterColumnsPriority,
+			"collectAdditionalPrinterColumnsPriority cannot be set on an exclude rule",
+		))
+	}
 
 	// Reject exclusion of protected resource types.
 	// Check both specific kind names and wildcard kinds — apiGroups:["cluster.open-cluster-management.io"]

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -213,7 +213,7 @@ var protectedKinds = map[string]string{
 func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	// Reject fields, collectConditions, and fieldSuffix on exclude rules.
+	// Reject fields, collectConditions, collectAnnotations, and fieldSuffix on exclude rules.
 	if len(rule.Fields) > 0 {
 		allErrs = append(allErrs, field.Invalid(
 			path.Child("fields"),
@@ -226,6 +226,13 @@ func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList
 			path.Child("collectConditions"),
 			*rule.CollectConditions,
 			"collectConditions cannot be set on an exclude rule",
+		))
+	}
+	if rule.CollectAnnotations != nil {
+		allErrs = append(allErrs, field.Invalid(
+			path.Child("collectAnnotations"),
+			*rule.CollectAnnotations,
+			"collectAnnotations cannot be set on an exclude rule",
 		))
 	}
 	if rule.FieldSuffix != "" {

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -118,15 +118,18 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 
 		hasFields := len(rule.Fields) > 0
 
-		// Validate wildcard kind "*": cannot be used with fields
-		for _, k := range rule.ResourceSelector.Kinds {
-			if k == "*" && hasFields {
-				allErrs = append(allErrs, field.Invalid(
-					rulePath.Child("resourceSelector", "kinds"),
-					rule.ResourceSelector.Kinds,
-					"wildcard kind \"*\" cannot be used with fields",
-				))
-				break
+		// Validate wildcard kind "*": cannot be used with fields (include only —
+		// exclude rules handle this separately in validateExcludeRule).
+		if rule.Action == ActionInclude {
+			for _, k := range rule.ResourceSelector.Kinds {
+				if k == "*" && hasFields {
+					allErrs = append(allErrs, field.Invalid(
+						rulePath.Child("resourceSelector", "kinds"),
+						rule.ResourceSelector.Kinds,
+						"wildcard kind \"*\" cannot be used with fields",
+					))
+					break
+				}
 			}
 		}
 
@@ -167,8 +170,9 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 			))
 		}
 
-		// Validate FieldSuffix if present
-		if rule.FieldSuffix != "" {
+		// Validate FieldSuffix format if present (include only — exclude rules reject
+		// fieldSuffix entirely in validateExcludeRule, avoiding duplicate errors).
+		if rule.Action == ActionInclude && rule.FieldSuffix != "" {
 			if !isValidFieldSuffix(rule.FieldSuffix) {
 				allErrs = append(allErrs, field.Invalid(
 					rulePath.Child("fieldSuffix"),
@@ -192,7 +196,12 @@ func (r *CollectorConfig) validateCollectorConfig() error {
 }
 
 // protectedKinds lists resource types the search RBAC engine depends on.
-// Excluding them would break per-cluster and namespace-scoped access control.
+// Excluding them would break per-cluster and namespace-scoped access control:
+//   - ManagedCluster: used to scope search results to clusters a user can access
+//   - Namespace: used to scope search results to namespaces a user can access
+//
+// ManagedClusterSet and ManagedClusterSetBinding are NOT listed here because the
+// RBAC engine does not query them directly — they are used by placement/policy, not search.
 var protectedKinds = map[string]string{
 	"ManagedCluster": "cluster.open-cluster-management.io",
 	"Namespace":      "", // core group
@@ -212,7 +221,7 @@ func validateExcludeRule(rule *CollectionRule, path *field.Path) field.ErrorList
 			"fields cannot be specified on an exclude rule",
 		))
 	}
-	if rule.CollectConditions != nil && *rule.CollectConditions {
+	if rule.CollectConditions != nil {
 		allErrs = append(allErrs, field.Invalid(
 			path.Child("collectConditions"),
 			*rule.CollectConditions,

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -232,11 +232,12 @@ func TestAcceptEmptyCollectionRules(t *testing.T) {
 // Accept a config with multiple valid rules.
 func TestAcceptMultipleValidRules(t *testing.T) {
 	c := validConfig()
+	// Use coordination.k8s.io — not in protectedAPIGroups, valid for user exclusion
 	c.Spec.CollectionRules = append(c.Spec.CollectionRules, CollectionRule{
 		Action: ActionExclude,
 		ResourceSelector: ResourceSelector{
-			APIGroups: []string{""},
-			Kinds:     []string{"Secret", "ConfigMap"},
+			APIGroups: []string{"coordination.k8s.io"},
+			Kinds:     []string{"Lease"},
 		},
 	})
 	_, err := c.ValidateCreate(context.Background(), c)
@@ -855,17 +856,19 @@ func TestAllowIntegrationConfigWithExcludeRule(t *testing.T) {
 	assert.NoError(t, err, "integration team configs may contain exclude rules")
 }
 
-// When webhookClient is nil (unit test without manager), the overlap check is skipped.
+// When webhookClient is nil (unit test without manager), the dynamic integration
+// config overlap check is skipped. Uses coordination.k8s.io which is not in
+// protectedAPIGroups so only the dynamic check is relevant here.
 func TestExcludeIntegrationCheckSkippedWhenClientNil(t *testing.T) {
 	webhookClient = nil
 	c := validConfig()
 	c.Spec.CollectionRules[0] = CollectionRule{
 		Action: ActionExclude,
 		ResourceSelector: ResourceSelector{
-			APIGroups: []string{"policy.open-cluster-management.io"},
-			Kinds:     []string{"Policy"},
+			APIGroups: []string{"coordination.k8s.io"},
+			Kinds:     []string{"Lease"},
 		},
 	}
 	_, err := c.ValidateCreate(context.Background(), c)
-	assert.NoError(t, err, "overlap check should be skipped when webhookClient is nil")
+	assert.NoError(t, err, "dynamic overlap check should be skipped when webhookClient is nil")
 }

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -10,6 +10,8 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -681,9 +683,10 @@ func TestRejectExcludeWithCollectConditionsFalse(t *testing.T) {
 	assert.Contains(t, err.Error(), "collectConditions cannot be set on an exclude rule")
 }
 
-// Accept exclude that uses wildcard kind even if ManagedCluster exists in the cluster
-// — the wildcard protection is at the collector level, not webhook level.
-func TestAcceptExcludeWildcardNotBlocked(t *testing.T) {
+// Reject exclude with wildcard kinds when the apiGroup contains a protected resource.
+// e.g. kinds:["*"] apiGroups:["cluster.open-cluster-management.io"] would exclude
+// ManagedCluster which search depends on for RBAC.
+func TestRejectExcludeWildcardKindOnProtectedAPIGroup(t *testing.T) {
 	c := validConfig()
 	c.Spec.CollectionRules[0] = CollectionRule{
 		Action: ActionExclude,
@@ -693,5 +696,141 @@ func TestAcceptExcludeWildcardNotBlocked(t *testing.T) {
 		},
 	}
 	_, err := c.ValidateCreate(context.Background(), c)
-	assert.NoError(t, err)
+	assert.Error(t, err, "wildcard kind on a protected apiGroup must be rejected")
+}
+
+// Reject global wildcard exclude (kinds:["*"] apiGroups:["*"]) — covers all protected resources.
+func TestRejectExcludeGlobalWildcard(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"*"},
+			Kinds:     []string{"*"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err, "global wildcard exclude must be rejected — covers protected resources")
+}
+
+// Accept wildcard kind exclude when the apiGroup does not contain any protected resource.
+func TestAcceptExcludeWildcardKindOnSafeAPIGroup(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"*"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err, "wildcard kind on a non-protected apiGroup (apps) should be accepted")
+}
+
+// --- Integration config overlap checks ---
+
+// buildFakeWebhookClient registers the scheme and returns a fake client pre-populated
+// with the given objects. It also sets webhookClient for the duration of the test,
+// restoring nil on cleanup.
+func buildFakeWebhookClient(t *testing.T, objs ...runtime.Object) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, o := range objs {
+		builder = builder.WithRuntimeObjects(o)
+	}
+	webhookClient = builder.Build()
+	t.Cleanup(func() { webhookClient = nil })
+}
+
+func integrationCC(name, namespace, apiGroup string, kinds []string) *CollectorConfig {
+	return &CollectorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue},
+		},
+		Spec: CollectorConfigSpec{
+			CollectionRules: []CollectionRule{
+				{
+					Action: ActionInclude,
+					ResourceSelector: ResourceSelector{
+						APIGroups: []string{apiGroup},
+						Kinds:     kinds,
+					},
+					Fields: []Field{
+						{Name: "field1", JSONPath: ".spec.field1"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Reject user exclude that overlaps an integration team include.
+func TestRejectExcludeOverlapsIntegrationInclude(t *testing.T) {
+	buildFakeWebhookClient(t,
+		integrationCC("grc-config", "default", "policy.open-cluster-management.io", []string{"Policy"}),
+	)
+	c := validConfig()
+	c.Namespace = "default"
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"policy.open-cluster-management.io"},
+			Kinds:     []string{"Policy"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err, "exclude overlapping integration include must be rejected")
+	assert.Contains(t, err.Error(), "necessary for system functionality")
+}
+
+// Accept user exclude that does NOT overlap any integration include.
+func TestAcceptExcludeNoIntegrationOverlap(t *testing.T) {
+	buildFakeWebhookClient(t,
+		integrationCC("grc-config", "default", "policy.open-cluster-management.io", []string{"Policy"}),
+	)
+	c := validConfig()
+	c.Namespace = "default"
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"coordination.k8s.io"},
+			Kinds:     []string{"Lease"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err, "exclude not overlapping any integration include should be accepted")
+}
+
+// Integration team configs are allowed to have exclude rules — they own their own rules.
+func TestAllowIntegrationConfigWithExcludeRule(t *testing.T) {
+	c := validConfig()
+	c.Labels = map[string]string{IntegrationTeamLabel: IntegrationTeamLabelValue}
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err, "integration team configs may contain exclude rules")
+}
+
+// When webhookClient is nil (unit test without manager), the overlap check is skipped.
+func TestExcludeIntegrationCheckSkippedWhenClientNil(t *testing.T) {
+	webhookClient = nil
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"policy.open-cluster-management.io"},
+			Kinds:     []string{"Policy"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err, "overlap check should be skipped when webhookClient is nil")
 }

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -632,6 +632,38 @@ func TestRejectExcludeWithFieldSuffix(t *testing.T) {
 	assert.Contains(t, err.Error(), "fieldSuffix cannot be specified on an exclude rule")
 }
 
+// Reject exclude targeting ManagedCluster via wildcard apiGroup.
+func TestRejectExcludeManagedClusterViaWildcardAPIGroup(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"*"},
+			Kinds:     []string{"ManagedCluster"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot exclude ManagedCluster")
+}
+
+// Reject exclude with collectConditions: false explicitly set (not just omitted).
+func TestRejectExcludeWithCollectConditionsFalse(t *testing.T) {
+	collectConditionsFalse := false
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+		CollectConditions: &collectConditionsFalse,
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "collectConditions cannot be set on an exclude rule")
+}
+
 // Accept exclude that uses wildcard kind even if ManagedCluster exists in the cluster
 // — the wildcard protection is at the collector level, not webhook level.
 func TestAcceptExcludeWildcardNotBlocked(t *testing.T) {

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -522,3 +522,127 @@ func TestRejectSAFromWrongNamespace(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
+
+// --- Exclude rule tests ---
+
+// Accept a valid exclude rule with no fields/conditions.
+func TestAcceptExcludeRule(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"coordination.k8s.io"},
+			Kinds:     []string{"Lease"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Accept exclude with wildcard kind.
+func TestAcceptExcludeWildcardKind(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"coordination.k8s.io"},
+			Kinds:     []string{"*"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}
+
+// Reject exclude rule that also specifies fields.
+func TestRejectExcludeWithFields(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+		Fields: []Field{{Name: "replicas", JSONPath: "{.spec.replicas}"}},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fields cannot be specified on an exclude rule")
+}
+
+// Reject exclude rule that sets collectConditions.
+func TestRejectExcludeWithCollectConditions(t *testing.T) {
+	collectConditions := true
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+		CollectConditions: &collectConditions,
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "collectConditions cannot be set on an exclude rule")
+}
+
+// Reject exclude targeting ManagedCluster.
+func TestRejectExcludeManagedCluster(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"cluster.open-cluster-management.io"},
+			Kinds:     []string{"ManagedCluster"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot exclude ManagedCluster")
+}
+
+// Reject exclude targeting Namespace.
+func TestRejectExcludeNamespace(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{""},
+			Kinds:     []string{"Namespace"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot exclude Namespace")
+}
+
+// Reject exclude rule that sets fieldSuffix.
+func TestRejectExcludeWithFieldSuffix(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+		FieldSuffix: "myteam",
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fieldSuffix cannot be specified on an exclude rule")
+}
+
+// Accept exclude that uses wildcard kind even if ManagedCluster exists in the cluster
+// — the wildcard protection is at the collector level, not webhook level.
+func TestAcceptExcludeWildcardNotBlocked(t *testing.T) {
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"cluster.open-cluster-management.io"},
+			Kinds:     []string{"*"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err)
+}

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -569,6 +569,23 @@ func TestRejectExcludeWithFields(t *testing.T) {
 	assert.Contains(t, err.Error(), "fields cannot be specified on an exclude rule")
 }
 
+// Reject exclude rule that sets collectAnnotations.
+func TestRejectExcludeWithCollectAnnotations(t *testing.T) {
+	collectAnnotations := true
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+		CollectAnnotations: &collectAnnotations,
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "collectAnnotations cannot be set on an exclude rule")
+}
+
 // Reject exclude rule that sets collectConditions.
 func TestRejectExcludeWithCollectConditions(t *testing.T) {
 	collectConditions := true

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -651,6 +651,22 @@ func TestRejectExcludeWithFieldSuffix(t *testing.T) {
 	assert.Contains(t, err.Error(), "fieldSuffix cannot be specified on an exclude rule")
 }
 
+func TestRejectExcludeWithCollectAdditionalPrinterColumnsPriority(t *testing.T) {
+	priority := 0
+	c := validConfig()
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"apps"},
+			Kinds:     []string{"Deployment"},
+		},
+		CollectAdditionalPrinterColumnsPriority: &priority,
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "collectAdditionalPrinterColumnsPriority cannot be set on an exclude rule")
+}
+
 // Reject exclude targeting ManagedCluster via wildcard apiGroup.
 func TestRejectExcludeManagedClusterViaWildcardAPIGroup(t *testing.T) {
 	c := validConfig()
@@ -784,6 +800,25 @@ func TestRejectExcludeOverlapsIntegrationInclude(t *testing.T) {
 	}
 	_, err := c.ValidateCreate(context.Background(), c)
 	assert.Error(t, err, "exclude overlapping integration include must be rejected")
+	assert.Contains(t, err.Error(), "necessary for system functionality")
+}
+
+// Reject user wildcard kinds exclude that overlaps an integration team include.
+func TestRejectWildcardKindsExcludeOverlapsIntegrationInclude(t *testing.T) {
+	buildFakeWebhookClient(t,
+		integrationCC("grc-config", "default", "policy.open-cluster-management.io", []string{"Policy"}),
+	)
+	c := validConfig()
+	c.Namespace = "default"
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"policy.open-cluster-management.io"},
+			Kinds:     []string{"*"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.Error(t, err, "exclude wildcard kinds overlapping integration include must be rejected")
 	assert.Contains(t, err.Error(), "necessary for system functionality")
 }
 

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -176,7 +176,7 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 			// integration team include so they cannot suppress integration-required collection.
 			if rule.Action == searchv1alpha1.ActionExclude &&
 				excludeOverlapsIntegrationIncludes(rule, teamConfigs.Items) {
-				log.V(2).Info("Skipping user exclude rule — integration team has include for same resource",
+				log.Info("Skipping user exclude rule — integration team has include for same resource",
 					"kinds", rule.ResourceSelector.Kinds,
 					"apiGroups", rule.ResourceSelector.APIGroups)
 				continue

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -78,6 +78,51 @@ func (r *SearchReconciler) ensureWebhookCAInjection(ctx context.Context) error {
 	return r.Update(ctx, vwc, &client.UpdateOptions{})
 }
 
+// excludeOverlapsIntegrationIncludes reports whether a user exclude rule targets
+// resources that any integration team include rule also covers.
+// Two rules overlap when their apiGroups and kinds are not disjoint — i.e. there
+// exists at least one resource matched by both selectors (wildcards "*" match all).
+// When overlap is detected, the integration team include takes precedence and the
+// user exclude is dropped from the merged spec.
+func excludeOverlapsIntegrationIncludes(
+	excludeRule searchv1alpha1.CollectionRule,
+	teamConfigs []searchv1alpha1.CollectorConfig,
+) bool {
+	for _, tc := range teamConfigs {
+		for _, teamRule := range tc.Spec.CollectionRules {
+			if teamRule.Action != searchv1alpha1.ActionInclude {
+				continue
+			}
+			if rulesOverlap(excludeRule.ResourceSelector, teamRule.ResourceSelector) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// rulesOverlap returns true when two ResourceSelectors could match the same resource.
+// Wildcards ("*") in either selector match all values on the other side.
+func rulesOverlap(a, b searchv1alpha1.ResourceSelector) bool {
+	if !setsIntersect(a.APIGroups, b.APIGroups) {
+		return false
+	}
+	return setsIntersect(a.Kinds, b.Kinds)
+}
+
+// setsIntersect returns true when two string slices share at least one element,
+// treating "*" as a universal match for all values on the other side.
+func setsIntersect(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == "*" || y == "*" || x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // createOrUpdateMergedCollectorConfig discovers all integration team CollectorConfig CRs (by label)
 // and the user-collector-config (by name), merges their CollectionRules, and writes the result
 // to merged-collector-config.
@@ -126,7 +171,18 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 		return &reconcile.Result{}, err
 	}
 	if err == nil {
-		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, userCC.Spec.CollectionRules...)
+		for _, rule := range userCC.Spec.CollectionRules {
+			// Integration team wins: drop user exclude rules that overlap with any
+			// integration team include so they cannot suppress integration-required collection.
+			if rule.Action == searchv1alpha1.ActionExclude &&
+				excludeOverlapsIntegrationIncludes(rule, teamConfigs.Items) {
+				log.V(2).Info("Skipping user exclude rule — integration team has include for same resource",
+					"kinds", rule.ResourceSelector.Kinds,
+					"apiGroups", rule.ResourceSelector.APIGroups)
+				continue
+			}
+			mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, rule)
+		}
 		if userCC.Spec.CollectNamespaces != nil {
 			mergedSpec.CollectNamespaces = userCC.Spec.CollectNamespaces.DeepCopy()
 		}

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -4,12 +4,15 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strings"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -123,6 +126,45 @@ func setsIntersect(a, b []string) bool {
 	return false
 }
 
+// updateUserCCStatus writes an Applied status condition on user-collector-config to surface
+// any exclude rules that were silently dropped during the merge because integration team
+// include rules take precedence. When no rules were dropped the condition is set to True.
+func (r *SearchReconciler) updateUserCCStatus(
+	ctx context.Context,
+	userCC *searchv1alpha1.CollectorConfig,
+	droppedMessages []string,
+) error {
+	conditionStatus := metav1.ConditionTrue
+	reason := searchv1alpha1.CollectorConfigReasonApplied
+	message := "Configuration merged successfully."
+
+	if len(droppedMessages) > 0 {
+		conditionStatus = metav1.ConditionFalse
+		reason = searchv1alpha1.CollectorConfigReasonRulesSkipped
+		message = strings.Join(droppedMessages, "; ")
+	}
+
+	newCondition := metav1.Condition{
+		Type:               searchv1alpha1.CollectorConfigConditionApplied,
+		Status:             conditionStatus,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+
+	existing := apimeta.FindStatusCondition(userCC.Status.Conditions, searchv1alpha1.CollectorConfigConditionApplied)
+	if existing != nil && existing.Status == conditionStatus {
+		newCondition.LastTransitionTime = existing.LastTransitionTime
+	}
+
+	apimeta.SetStatusCondition(&userCC.Status.Conditions, newCondition)
+
+	if err := r.Status().Update(ctx, userCC); err != nil {
+		return err
+	}
+	return nil
+}
+
 // createOrUpdateMergedCollectorConfig discovers all integration team CollectorConfig CRs (by label)
 // and the user-collector-config (by name), merges their CollectionRules, and writes the result
 // to merged-collector-config.
@@ -171,14 +213,18 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 		return &reconcile.Result{}, err
 	}
 	if err == nil {
+		var droppedRuleMessages []string
 		for _, rule := range userCC.Spec.CollectionRules {
 			// Integration team wins: drop user exclude rules that overlap with any
 			// integration team include so they cannot suppress integration-required collection.
 			if rule.Action == searchv1alpha1.ActionExclude &&
 				excludeOverlapsIntegrationIncludes(rule, teamConfigs.Items) {
+				msg := fmt.Sprintf("exclude rule for kinds %v (apiGroups %v) was dropped — integration team has include for the same resource",
+					rule.ResourceSelector.Kinds, rule.ResourceSelector.APIGroups)
 				log.Info("Skipping user exclude rule — integration team has include for same resource",
 					"kinds", rule.ResourceSelector.Kinds,
 					"apiGroups", rule.ResourceSelector.APIGroups)
+				droppedRuleMessages = append(droppedRuleMessages, msg)
 				continue
 			}
 			mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, rule)
@@ -188,6 +234,10 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 		}
 		if err := r.addBackupLabel(ctx, userCC); err != nil {
 			return &reconcile.Result{}, err
+		}
+		// Surface dropped rules to the user via the Applied status condition on user-collector-config.
+		if err := r.updateUserCCStatus(ctx, userCC, droppedRuleMessages); err != nil {
+			log.Error(err, "Could not update user-collector-config status after dropping rules")
 		}
 	}
 

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -220,9 +220,10 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 			if rule.Action == searchv1alpha1.ActionExclude &&
 				excludeOverlapsIntegrationIncludes(rule, teamConfigs.Items) {
 				msg := fmt.Sprintf(
-					"exclude rule for kinds %v (apiGroups %v) was dropped — integration team has include for the same resource",
+					"exclude rule for kinds %v (apiGroups %v) was not applied — "+
+						"resource is necessary for system functionality",
 					rule.ResourceSelector.Kinds, rule.ResourceSelector.APIGroups)
-				log.Info("Skipping user exclude rule — integration team has include for same resource",
+				log.Info("Skipping user exclude rule — resource necessary for system functionality",
 					"kinds", rule.ResourceSelector.Kinds,
 					"apiGroups", rule.ResourceSelector.APIGroups)
 				droppedRuleMessages = append(droppedRuleMessages, msg)

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -219,7 +219,8 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 			// integration team include so they cannot suppress integration-required collection.
 			if rule.Action == searchv1alpha1.ActionExclude &&
 				excludeOverlapsIntegrationIncludes(rule, teamConfigs.Items) {
-				msg := fmt.Sprintf("exclude rule for kinds %v (apiGroups %v) was dropped — integration team has include for the same resource",
+				msg := fmt.Sprintf(
+					"exclude rule for kinds %v (apiGroups %v) was dropped — integration team has include for the same resource",
 					rule.ResourceSelector.Kinds, rule.ResourceSelector.APIGroups)
 				log.Info("Skipping user exclude rule — integration team has include for same resource",
 					"kinds", rule.ResourceSelector.Kinds,

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -7,6 +7,7 @@ import (
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +51,10 @@ func newIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSp
 func setupReconciler(objs ...runtime.Object) *SearchReconciler {
 	s := scheme.Scheme
 	_ = searchv1alpha1.SchemeBuilder.AddToScheme(s)
-	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	cl := fake.NewClientBuilder().
+		WithRuntimeObjects(objs...).
+		WithStatusSubresource(&searchv1alpha1.CollectorConfig{}).
+		Build()
 	return &SearchReconciler{Client: cl, Scheme: s}
 }
 
@@ -620,6 +624,45 @@ func TestBackupLabel_MultipleConfigs(t *testing.T) {
 }
 
 // --- Exclude merge protection tests ---
+
+// When a user exclude is dropped due to integration team protection, user-collector-config
+// gets Applied=False/RulesSkipped so the user can discover why their rule had no effect.
+func TestMerge_UserExcludeDropped_StatusConditionSet(t *testing.T) {
+	instance := newSearchInstance()
+	teamCC := newIntegrationTeamConfig("team-a", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+				Fields:           []searchv1alpha1.Field{{Name: "replicas", JSONPath: "{.spec.replicas}"}},
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamCC, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	// Verify the status condition on user-collector-config reflects the dropped rule
+	updated := &searchv1alpha1.CollectorConfig{}
+	nn := types.NamespacedName{Name: userCollectorConfigName, Namespace: testNamespace}
+	assert.Nil(t, r.Get(context.TODO(), nn, updated))
+	require.Len(t, updated.Status.Conditions, 1)
+	cond := updated.Status.Conditions[0]
+	assert.Equal(t, "Applied", cond.Type)
+	assert.Equal(t, "False", string(cond.Status))
+	assert.Equal(t, "RulesSkipped", cond.Reason)
+	assert.Contains(t, cond.Message, "Deployment")
+}
 
 // User exclude rule is dropped when integration team has an include for same kind.
 func TestMerge_UserExcludeDroppedWhenIntegrationIncludes(t *testing.T) {

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -668,8 +668,11 @@ func TestMerge_UserExcludeKeptWhenNoIntegrationOverlap(t *testing.T) {
 	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
-				Action:           searchv1alpha1.ActionExclude,
-				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"coordination.k8s.io"}, Kinds: []string{"Lease"}},
+				Action: searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{
+					APIGroups: []string{"coordination.k8s.io"},
+					Kinds:     []string{"Lease"},
+				},
 			},
 		},
 	})

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -658,9 +658,9 @@ func TestMerge_UserExcludeDropped_StatusConditionSet(t *testing.T) {
 	assert.Nil(t, r.Get(context.TODO(), nn, updated))
 	require.Len(t, updated.Status.Conditions, 1)
 	cond := updated.Status.Conditions[0]
-	assert.Equal(t, "Applied", cond.Type)
-	assert.Equal(t, "False", string(cond.Status))
-	assert.Equal(t, "RulesSkipped", cond.Reason)
+	assert.Equal(t, searchv1alpha1.CollectorConfigConditionApplied, cond.Type)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, searchv1alpha1.CollectorConfigReasonRulesSkipped, cond.Reason)
 	assert.Contains(t, cond.Message, "Deployment")
 }
 

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -618,3 +618,165 @@ func TestBackupLabel_MultipleConfigs(t *testing.T) {
 	_, hasLabel := merged.Labels[backupLabel]
 	assert.False(t, hasLabel, "merged-collector-config should NOT have the backup label")
 }
+
+// --- Exclude merge protection tests ---
+
+// User exclude rule is dropped when integration team has an include for same kind.
+func TestMerge_UserExcludeDroppedWhenIntegrationIncludes(t *testing.T) {
+	instance := newSearchInstance()
+	teamCC := newIntegrationTeamConfig("team-a", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+				Fields:           []searchv1alpha1.Field{{Name: "replicas", JSONPath: "{.spec.replicas}"}},
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamCC, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1)
+	assert.Equal(t, searchv1alpha1.ActionInclude, merged.Spec.CollectionRules[0].Action)
+}
+
+// User exclude rule passes through when no integration team covers same kind.
+func TestMerge_UserExcludeKeptWhenNoIntegrationOverlap(t *testing.T) {
+	instance := newSearchInstance()
+	teamCC := newIntegrationTeamConfig("team-a", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+				Fields:           []searchv1alpha1.Field{{Name: "replicas", JSONPath: "{.spec.replicas}"}},
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"coordination.k8s.io"}, Kinds: []string{"Lease"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamCC, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 2, "Both team include and user exclude should be in merged")
+	assert.Equal(t, searchv1alpha1.ActionExclude, merged.Spec.CollectionRules[1].Action)
+}
+
+// User exclude with wildcard kind is dropped when integration team includes any kind in same group.
+func TestMerge_UserWildcardExcludeDroppedWhenIntegrationIncludesInGroup(t *testing.T) {
+	instance := newSearchInstance()
+	teamCC := newIntegrationTeamConfig("team-a", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+				Fields:           []searchv1alpha1.Field{{Name: "replicas", JSONPath: "{.spec.replicas}"}},
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"*"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamCC, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1, "User wildcard exclude overlapping team include should be dropped")
+	assert.Equal(t, searchv1alpha1.ActionInclude, merged.Spec.CollectionRules[0].Action)
+}
+
+// Integration team wildcard include blocks specific user exclude.
+func TestMerge_IntegrationWildcardIncludeBlocksSpecificUserExclude(t *testing.T) {
+	instance := newSearchInstance()
+	teamCC := newIntegrationTeamConfig("team-a", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"*"}},
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionExclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamCC, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 1,
+		"User exclude of Deployment should be dropped — integration team includes all apps resources")
+	assert.Equal(t, searchv1alpha1.ActionInclude, merged.Spec.CollectionRules[0].Action)
+}
+
+// User include rules are always passed through unchanged.
+func TestMerge_UserIncludeNotAffectedByExcludeProtection(t *testing.T) {
+	instance := newSearchInstance()
+	teamCC := newIntegrationTeamConfig("team-a", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+				Fields:           []searchv1alpha1.Field{{Name: "replicas", JSONPath: "{.spec.replicas}"}},
+			},
+		},
+	})
+	userCC := newCollectorConfig(userCollectorConfigName, searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"apps"}, Kinds: []string{"Deployment"}},
+				Fields:           []searchv1alpha1.Field{{Name: "strategy", JSONPath: "{.spec.strategy.type}"}},
+			},
+		},
+	})
+	r := setupReconciler(instance, teamCC, userCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	merged, err := getMergedConfig(r)
+	assert.Nil(t, err)
+	assert.Len(t, merged.Spec.CollectionRules, 2, "Both include rules should be in merged — include is never filtered")
+}


### PR DESCRIPTION
## Summary

Webhook validation and merge protection for `action: exclude` in CollectorConfig (ACM-35522).

**Companion PR:** stolostron/search-collector#888 (collector-side enforcement)

## Changes

### `api/v1alpha1/collectorconfig_webhook.go`

**1. Wildcard bypass fix in `validateExcludeRule`:**
`kinds: ["*"]` on a protected apiGroup would effectively exclude ManagedCluster/Namespace just as reliably as naming them directly. Now rejected:
- `exclude kinds:["*"] apiGroups:["cluster.open-cluster-management.io"]` → rejected
- `exclude kinds:["*"] apiGroups:["*"]` → rejected (global wildcard)
- `exclude kinds:["*"] apiGroups:["apps"]` → accepted (no protected resources in apps)

**2. Integration config overlap check at admission (`validateExcludeAgainstIntegrationConfigs`):**
The webhook now lists CollectorConfigs labeled `search.open-cluster-management.io/config-type: integration` and rejects user exclude rules that conflict with any integration team include — surfacing the error at `kubectl apply` time rather than silently dropping at operator merge time.

This replaces the idea of expanding `protectedKinds` with a static list of resources (Argo, Kyverno, CNV, Policy, etc.), which would be fragile. Protection grows automatically as integration teams ship their own labeled CollectorConfigs. The check is skipped when `webhookClient` is nil (unit tests) or when no integration configs exist.

### `controllers/create_collectorconfig.go`

**Error message wording:** Status condition message when a user exclude is dropped: `"integration team has include for the same resource"` → `"resource is necessary for system functionality"`.

## Protection layers

```
User applies exclude on user-collector-config
        ↓
Webhook (admission)
  • Reject ManagedCluster/Namespace by name
  • Reject wildcard kinds on protected apiGroups
  • Reject if overlaps any integration team include (dynamic check)
        ↓
Operator merge
  • Drop overlapping user excludes (already done — second layer)
  • Write Applied=False / RulesSkipped status condition
        ↓
search-collector
  • IsResourceExcluded at informer layer (last-match-wins)
```

## Test plan

- `go test ./api/... ./controllers/...` — all tests pass, 7 new webhook tests
- `golangci-lint` — 0 issues
- E2E on cluster pending (see Jira ACM-35522 for full test matrix)
