### PR TITLE
ACM-33145 - openapiv3 data type alignment

### DIFF
--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -9,15 +9,15 @@ import (
 // Important: Run the "make manifests" command to regenerate the manifests after you modify this file.
 
 // DataType represents the data type of a collected field
-// +kubebuilder:validation:Enum=bytes;slice;string;number;mapString
+// +kubebuilder:validation:Enum=bytes;string;integer;float;boolean
 type DataType string
 
 const (
-	DataTypeBytes     DataType = "bytes"
-	DataTypeSlice     DataType = "slice"
-	DataTypeString    DataType = "string"
-	DataTypeNumber    DataType = "number"
-	DataTypeMapString DataType = "mapString"
+	DataTypeBytes   DataType = "bytes"
+	DataTypeString  DataType = "string"
+	DataTypeInteger DataType = "integer"
+	DataTypeFloat   DataType = "float"
+	DataTypeBoolean DataType = "boolean"
 )
 
 // ActionType represents the action to take for a collection rule

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -236,17 +236,17 @@ var protectedAPIGroups = map[string]struct{}{
 	// OpenShift cluster config
 	"config.openshift.io": {},
 	// CNV / KubeVirt family
-	"kubevirt.io":                              {},
-	"cdi.kubevirt.io":                          {},
-	"migrations.kubevirt.io":                   {},
-	"clone.kubevirt.io":                        {},
-	"instancetype.kubevirt.io":                 {},
-	"snapshot.kubevirt.io":                     {},
+	"kubevirt.io":                               {},
+	"cdi.kubevirt.io":                           {},
+	"migrations.kubevirt.io":                    {},
+	"clone.kubevirt.io":                         {},
+	"instancetype.kubevirt.io":                  {},
+	"snapshot.kubevirt.io":                      {},
 	"networkaddonsoperator.network.kubevirt.io": {},
 	// Networking
 	"k8s.cni.cncf.io": {},
 	// Storage
-	"storage.k8s.io":       {},
+	"storage.k8s.io":               {},
 	"snapshot.storage.k8s.io":      {},
 	"snapshot.storage.kubevirt.io": {},
 	// OpenShift templates
@@ -259,7 +259,7 @@ var protectedAPIGroups = map[string]struct{}{
 	"search.open-cluster-management.io": {},
 	// ACM app lifecycle
 	"apps.open-cluster-management.io": {},
-	"app.k8s.io":                       {},
+	"app.k8s.io":                      {},
 	// GRC / Policy
 	"policy.open-cluster-management.io": {},
 	"wgpolicyk8s.io":                    {},
@@ -445,10 +445,10 @@ func (r *CollectorConfig) validateField(customField *Field, path *field.Path) fi
 	if customField.Type != "" {
 		validTypes := []string{
 			string(DataTypeString),
-			string(DataTypeNumber),
+			string(DataTypeInteger),
+			string(DataTypeFloat),
 			string(DataTypeBytes),
-			string(DataTypeSlice),
-			string(DataTypeMapString),
+			string(DataTypeBoolean),
 		}
 		if !contains(validTypes, string(customField.Type)) {
 			allErrs = append(allErrs, field.NotSupported(

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -136,7 +136,7 @@ func TestRejectInvalidJSONPathEmptyInner(t *testing.T) {
 // Reject a field with an unsupported type value.
 func TestRejectInvalidFieldType(t *testing.T) {
 	c := validConfig()
-	c.Spec.CollectionRules[0].Fields = []Field{{Name: "status", JSONPath: "{.status}", Type: "boolean"}}
+	c.Spec.CollectionRules[0].Fields = []Field{{Name: "status", JSONPath: "{.status}", Type: "invalid"}}
 	_, err := c.ValidateCreate(context.Background(), c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unsupported value")
@@ -198,7 +198,7 @@ func TestAcceptValidFieldSuffix(t *testing.T) {
 func TestAcceptValidConfigWithFieldsAndSuffix(t *testing.T) {
 	c := validConfig()
 	c.Spec.CollectionRules[0].Fields = []Field{
-		{Name: "replicas", JSONPath: "{.status.replicas}", Type: DataTypeNumber},
+		{Name: "replicas", JSONPath: "{.status.replicas}", Type: DataTypeInteger},
 		{Name: "image-name", JSONPath: "{.spec.containers[0].image}", Type: DataTypeString},
 	}
 	c.Spec.CollectionRules[0].FieldSuffix = "custom"

--- a/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/bundle/manifests/search.open-cluster-management.io_collectorconfigs.yaml
@@ -170,10 +170,10 @@ spec:
                               by Search Collectors. Default is a string.
                             enum:
                             - bytes
-                            - slice
                             - string
-                            - number
-                            - mapString
+                            - integer
+                            - float
+                            - boolean
                             type: string
                         required:
                         - jsonPath

--- a/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
+++ b/config/crd/bases/search.open-cluster-management.io_collectorconfigs.yaml
@@ -170,10 +170,10 @@ spec:
                               by Search Collectors. Default is a string.
                             enum:
                             - bytes
-                            - slice
                             - string
-                            - number
-                            - mapString
+                            - integer
+                            - float
+                            - boolean
                             type: string
                         required:
                         - jsonPath


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-33145

### Description of changes
- Removed number, slice, and mapString from collectorconfig supported datatypes.
- Added boolean, integer, and float to collectorconfig supported datatypes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supported field types for collection rules to a clearer set of values.
  * Improved validation so only the newly supported types are accepted.
  * Existing configurations using removed type values will no longer validate.
* **Tests**
  * Adjusted validation tests to cover the updated allowed and disallowed field types.
* **Chores**
  * Synced schema and published manifests with the new type list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->