### PR TITLE
ACM-36012 - delete orphaned collector configs

### DIFF
--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -538,19 +538,19 @@ func rejectIfProtected(ctx context.Context, cc *CollectorConfig, operation Webho
 		return fmt.Errorf("could not extract admission request: %v", err)
 	}
 
-	// Allow any service account in the resource's namespace.
-	// Only the operator namespace should have write RBAC for CollectorConfigs,
-	// so namespace-scoped SA check is sufficient.
-	expectedPrefix := fmt.Sprintf("system:serviceaccount:%s:", req.Namespace)
-	if strings.HasPrefix(req.UserInfo.Username, expectedPrefix) {
-		return nil
-	}
-
 	// Allow the Kubernetes garbage collector to delete orphaned operator-owned configs.
 	// When the Search CR is deleted and recreated, the old merged-collector-config retains
 	// an ownerReference with the previous UID. The GC must be able to clean it up.
 	if req.UserInfo.Username == "system:serviceaccount:kube-system:generic-garbage-collector" &&
 		operation == WebhookOperationDelete {
+		return nil
+	}
+
+	// Allow any service account in the resource's namespace.
+	// Only the operator namespace should have write RBAC for CollectorConfigs,
+	// so namespace-scoped SA check is sufficient.
+	expectedPrefix := fmt.Sprintf("system:serviceaccount:%s:", req.Namespace)
+	if strings.HasPrefix(req.UserInfo.Username, expectedPrefix) {
 		return nil
 	}
 

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -538,6 +538,13 @@ func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
 		return nil
 	}
 
+	// Allow the Kubernetes garbage collector to delete orphaned operator-owned configs.
+	// When the Search CR is deleted and recreated, the old merged-collector-config retains
+	// an ownerReference with the previous UID. The GC must be able to clean it up.
+	if req.UserInfo.Username == "system:serviceaccount:kube-system:generic-garbage-collector" {
+		return nil
+	}
+
 	return fmt.Errorf("%s is managed by the search operator and cannot be modified directly", cc.Name)
 }
 

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -45,6 +45,14 @@ func (r *CollectorConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.CustomValidator = &CollectorConfig{}
 
+type WebhookOperation string
+
+const (
+	WebhookOperationCreate WebhookOperation = "CREATE"
+	WebhookOperationUpdate WebhookOperation = "UPDATE"
+	WebhookOperationDelete WebhookOperation = "DELETE"
+)
+
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (r *CollectorConfig) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cc, ok := obj.(*CollectorConfig)
@@ -53,7 +61,7 @@ func (r *CollectorConfig) ValidateCreate(ctx context.Context, obj runtime.Object
 	}
 	collectorconfiglog.Info("validate create", "name", cc.Name)
 
-	if err := rejectIfProtected(ctx, cc); err != nil {
+	if err := rejectIfProtected(ctx, cc, WebhookOperationCreate); err != nil {
 		return nil, err
 	}
 
@@ -77,10 +85,10 @@ func (r *CollectorConfig) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	collectorconfiglog.Info("validate update", "name", cc.Name)
 
 	// Check both old and new objects — prevents stripping the owner reference to bypass protection.
-	if err := rejectIfProtected(ctx, cc); err != nil {
+	if err := rejectIfProtected(ctx, cc, WebhookOperationUpdate); err != nil {
 		return nil, err
 	}
-	if err := rejectIfProtected(ctx, oldCC); err != nil {
+	if err := rejectIfProtected(ctx, oldCC, WebhookOperationUpdate); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +107,7 @@ func (r *CollectorConfig) ValidateDelete(ctx context.Context, obj runtime.Object
 	}
 	collectorconfiglog.Info("validate delete", "name", cc.Name)
 
-	if err := rejectIfProtected(ctx, cc); err != nil {
+	if err := rejectIfProtected(ctx, cc, WebhookOperationDelete); err != nil {
 		return nil, err
 	}
 
@@ -520,7 +528,7 @@ func isOperatorOwned(cc *CollectorConfig) bool {
 
 // rejectIfProtected returns an error if the config has a controller owner reference
 // and the caller is not a service account in the same namespace (i.e., not the operator).
-func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
+func rejectIfProtected(ctx context.Context, cc *CollectorConfig, operation WebhookOperation) error {
 	if !isOperatorOwned(cc) {
 		return nil
 	}
@@ -541,7 +549,8 @@ func rejectIfProtected(ctx context.Context, cc *CollectorConfig) error {
 	// Allow the Kubernetes garbage collector to delete orphaned operator-owned configs.
 	// When the Search CR is deleted and recreated, the old merged-collector-config retains
 	// an ownerReference with the previous UID. The GC must be able to clean it up.
-	if req.UserInfo.Username == "system:serviceaccount:kube-system:generic-garbage-collector" {
+	if req.UserInfo.Username == "system:serviceaccount:kube-system:generic-garbage-collector" &&
+		operation == WebhookOperationDelete {
 		return nil
 	}
 

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -517,6 +517,14 @@ func TestAllowOperatorDeleteOwned(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Kubernetes garbage collector deleting an orphaned owned config → allowed.
+func TestAllowGarbageCollectorDeleteOwned(t *testing.T) {
+	gcCtx := ctxWithUser("system:serviceaccount:kube-system:generic-garbage-collector")
+	c := ownedConfig()
+	_, err := c.ValidateDelete(gcCtx, c)
+	assert.NoError(t, err)
+}
+
 // SA from wrong namespace acting on an owned config → rejected.
 func TestRejectSAFromWrongNamespace(t *testing.T) {
 	wrongNsCtx := ctxWithUser("system:serviceaccount:attacker-ns:search-v2-operator")


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-36012

### Description of changes
- Permit kubernetes garbage collector serviceaccount through collector-config webhook DELETE path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Allowed the Kubernetes garbage-collector service account to delete operator-owned `CollectorConfig` resources during orphan cleanup.
  * Admission validation now applies protections separately for create, update, and delete, while continuing to block other unauthorized modifications.
* **Tests**
  * Added a webhook protection test to verify garbage-collector can delete an owned `CollectorConfig` without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->