### PR TITLE
fix(trigger): compute data sizes once at top of BEGIN block

### DIFF
--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -185,9 +185,8 @@ DECLARE
     new_data_size integer;
     old_data_size integer;
 BEGIN
-    new_data_size := OCTET_LENGTH(NEW.data::text);
-    old_data_size := OCTET_LENGTH(OLD.data::text);
     IF TG_OP = 'DELETE' THEN
+        old_data_size := OCTET_LENGTH(OLD.data::text);
         new_data_json := NULL;
         IF old_data_size < 7000 THEN
             old_data_json := OLD.data;
@@ -195,6 +194,7 @@ BEGIN
             old_data_json := NULL;
         END IF;
     ELSEIF TG_OP = 'INSERT' THEN
+        new_data_size := OCTET_LENGTH(NEW.data::text);
         IF new_data_size < 7000 THEN
             new_data_json := NEW.data;
         ELSE
@@ -202,6 +202,8 @@ BEGIN
         END IF;
         old_data_json := NULL;
     ELSEIF TG_OP = 'UPDATE' THEN
+        new_data_size := OCTET_LENGTH(NEW.data::text);
+        old_data_size := OCTET_LENGTH(OLD.data::text);
         IF (new_data_size + old_data_size) < 7000 THEN
             new_data_json := NEW.data;
             old_data_json := OLD.data;

--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -185,8 +185,11 @@ DECLARE
     new_data_size integer;
     old_data_size integer;
 BEGIN
+    -- NEW is NULL for DELETE and OLD is NULL for INSERT; OCTET_LENGTH(NULL) returns NULL,
+    -- which is safe here because each branch only uses the size variable valid for its operation.
+    new_data_size := OCTET_LENGTH(NEW.data::text);
+    old_data_size := OCTET_LENGTH(OLD.data::text);
     IF TG_OP = 'DELETE' THEN
-        old_data_size := OCTET_LENGTH(OLD.data::text);
         new_data_json := NULL;
         IF old_data_size < 7000 THEN
             old_data_json := OLD.data;
@@ -194,7 +197,6 @@ BEGIN
             old_data_json := NULL;
         END IF;
     ELSEIF TG_OP = 'INSERT' THEN
-        new_data_size := OCTET_LENGTH(NEW.data::text);
         IF new_data_size < 7000 THEN
             new_data_json := NEW.data;
         ELSE
@@ -202,8 +204,6 @@ BEGIN
         END IF;
         old_data_json := NULL;
     ELSEIF TG_OP = 'UPDATE' THEN
-        new_data_size := OCTET_LENGTH(NEW.data::text);
-        old_data_size := OCTET_LENGTH(OLD.data::text);
         IF (new_data_size + old_data_size) < 7000 THEN
             new_data_json := NEW.data;
             old_data_json := OLD.data;

--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -185,8 +185,9 @@ DECLARE
     new_data_size integer;
     old_data_size integer;
 BEGIN
+    new_data_size := OCTET_LENGTH(NEW.data::text);
+    old_data_size := OCTET_LENGTH(OLD.data::text);
     IF TG_OP = 'DELETE' THEN
-        old_data_size := OCTET_LENGTH(OLD.data::text);
         new_data_json := NULL;
         IF old_data_size < 7000 THEN
             old_data_json := OLD.data;
@@ -194,7 +195,6 @@ BEGIN
             old_data_json := NULL;
         END IF;
     ELSEIF TG_OP = 'INSERT' THEN
-        new_data_size := OCTET_LENGTH(NEW.data::text);
         IF new_data_size < 7000 THEN
             new_data_json := NEW.data;
         ELSE
@@ -202,8 +202,6 @@ BEGIN
         END IF;
         old_data_json := NULL;
     ELSEIF TG_OP = 'UPDATE' THEN
-        new_data_size := OCTET_LENGTH(NEW.data::text);
-        old_data_size := OCTET_LENGTH(OLD.data::text);
         IF (new_data_size + old_data_size) < 7000 THEN
             new_data_json := NEW.data;
             old_data_json := OLD.data;


### PR DESCRIPTION
## Summary

Addresses review comment from @smcavey on #737.

`new_data_size` and `old_data_size` were being assigned redundantly inside each `TG_OP` branch (INSERT, UPDATE, and DELETE each had their own `OCTET_LENGTH` call). This PR moves both assignments to the top of `BEGIN`, which:

- Eliminates the duplication
- Matches the pattern in [search-v2-api's listenerTrigger.sql](https://github.com/stolostron/search-v2-api/blob/main/pkg/database/listenerTrigger.sql#L21-L22)
- Keeps the two files consistent

## Changes

**`controllers/create_pgconfigmap.go`**
- Move `new_data_size := OCTET_LENGTH(NEW.data::text)` and `old_data_size := OCTET_LENGTH(OLD.data::text)` to immediately after `BEGIN`, before any `TG_OP` branching
- Remove the per-branch duplicate assignments

## Testing

`ok  github.com/stolostron/search-v2-operator/controllers`

## Jira

[ACM-35503](https://redhat.atlassian.net/browse/ACM-35503)

[ACM-35503]: https://redhat.atlassian.net/browse/ACM-35503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource change notifications by ensuring data size information is calculated consistently for inserts, updates, and deletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->