### PR TITLE
[release-2.13] ACM-37648 - Update Go to 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.25-linux
+  tag: go1.26-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ catalog-push: ## Push a catalog image.
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.4.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 	gosec ./...
 

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -6,7 +6,7 @@
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.4.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 	gosec ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/search-v2-operator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cloudflare/cfssl v1.6.5


### PR DESCRIPTION
- go.mod: 1.25.0 → 1.26.0
- Dockerfile: go1.25-linux → go1.26-linux
- Dockerfile.rhtap: rhel_9_1.25 → rhel_9_1.26
- .ci-operator.yaml: go1.25-linux → go1.26-linux
- Makefile, Makefile.prow: golangci-lint v2.4.0 → v2.9.0

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-37648

### Description of changes
- Added ...
