### PR TITLE
ACM-37052: Built-in integration CollectorConfigs, seeded at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY addon/ addon/
+COPY config/ config/
 
 # Build
 RUN CGO_ENABLED=1 go build -a -o manager main.go

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -15,6 +15,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY addon/ addon/
+COPY config/ config/
 
 # Build
 RUN go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ catalog-push: ## Push a catalog image.
 lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
-	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
+	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=8m
 	gosec ./...
 
 # Setup local development environment.

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ catalog-push: ## Push a catalog image.
 lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
-	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=8m
+	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 	gosec ./...
 
 # Setup local development environment.

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -7,7 +7,7 @@
 lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
-	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
+	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=8m
 	gosec ./...
 
 .PHONY: unit-test

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -7,7 +7,7 @@
 lint:
 	GOPATH=$(go env GOPATH)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
-	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=8m
+	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=5m
 	gosec ./...
 
 .PHONY: unit-test

--- a/api/v1alpha1/collectorconfig_types.go
+++ b/api/v1alpha1/collectorconfig_types.go
@@ -40,6 +40,10 @@ const IntegrationTeamLabel = "search.open-cluster-management.io/config-type"
 // IntegrationTeamLabelValue is the expected value for IntegrationTeamLabel.
 const IntegrationTeamLabelValue = "integration"
 
+// AnnotationManualOverride, when present on an integration CollectorConfig, signals that a user
+// has intentionally customized this config and the operator must not overwrite it on restart.
+const AnnotationManualOverride = "search.open-cluster-management.io/manual-override"
+
 // Reason constants for the CollectorConfig Applied condition.
 const (
 	// CollectorConfigReasonApplied means all rules were processed and applied successfully.

--- a/api/v1alpha1/collectorconfig_webhook.go
+++ b/api/v1alpha1/collectorconfig_webhook.go
@@ -229,55 +229,28 @@ var protectedKinds = map[string]string{
 }
 
 // protectedAPIGroups is a temporary list of API groups that must not be excluded.
-// These cover resources that integration teams (CNV, OLM, GRC, Argo, Kyverno, etc.)
-// and Search itself depend on. Once integration teams ship labeled CollectorConfig CRs
-// (search.open-cluster-management.io/config-type: integration), the dynamic webhook check
-// will replace this list. Until then this provides a safety net.
+// This started as a broad safety net covering everything integration teams (CNV, OLM, GRC,
+// Argo, Kyverno, etc.) and Search itself depend on. As of ACM-37052, most of those teams now
+// have a real labeled CollectorConfig (search.open-cluster-management.io/config-type: integration,
+// shipped from config/integration_collector_configs/ — see IntegrationCollectorConfigSeeder),
+// so the dynamic check (validateExcludeAgainstIntegrationConfigs) already protects their apiGroups
+// via those configs' include rules. What remains here are groups with no single integration-team
+// owner, or that Search itself depends on directly.
 //
-// Source: search-collector/pkg/transforms/genericResourceConfig.go plus ACM integration teams.
-// "" = core group (ConfigMap, Job, Node, Pod, PVC — needed by CNV, console, and others).
+// "" = core group (ConfigMap, Job, Node, Pod, PVC — needed by CNV, console, and others; no single owner).
 var protectedAPIGroups = map[string]struct{}{
-	// Core group — ConfigMap, Job, Node, Pod, PVC needed by CNV / console
+	// Core group — ConfigMap, Job, Node, Pod, PVC needed by CNV / console / multiple consumers.
 	"": {},
-	// OLM
-	"operators.coreos.com": {},
-	// OpenShift cluster config
+	// OpenShift cluster config — no single integration-team owner.
 	"config.openshift.io": {},
-	// CNV / KubeVirt family
-	"kubevirt.io":                               {},
-	"cdi.kubevirt.io":                           {},
-	"migrations.kubevirt.io":                    {},
-	"clone.kubevirt.io":                         {},
-	"instancetype.kubevirt.io":                  {},
-	"snapshot.kubevirt.io":                      {},
-	"networkaddonsoperator.network.kubevirt.io": {},
-	// Networking
-	"k8s.cni.cncf.io": {},
-	// Storage
-	"storage.k8s.io":               {},
-	"snapshot.storage.k8s.io":      {},
-	"snapshot.storage.kubevirt.io": {},
-	// OpenShift templates
+	// OpenShift templates — no single integration-team owner.
 	"template.openshift.io": {},
-	// Admission / webhook configs
+	// Admission / webhook configs — no single integration-team owner.
 	"admissionregistration.k8s.io": {},
-	// ACM hub operator
+	// ACM hub operator — Search itself depends on this.
 	"operator.open-cluster-management.io": {},
-	// ACM Search itself
+	// ACM Search itself.
 	"search.open-cluster-management.io": {},
-	// ACM app lifecycle
-	"apps.open-cluster-management.io": {},
-	"app.k8s.io":                      {},
-	// GRC / Policy
-	"policy.open-cluster-management.io": {},
-	"wgpolicyk8s.io":                    {},
-	// Kyverno
-	"kyverno.io":          {},
-	"policies.kyverno.io": {},
-	// Gatekeeper
-	"constraints.gatekeeper.sh": {},
-	// Argo
-	"argoproj.io": {},
 }
 
 // validateExcludeRule enforces constraints specific to exclude rules:

--- a/api/v1alpha1/collectorconfig_webhook_test.go
+++ b/api/v1alpha1/collectorconfig_webhook_test.go
@@ -4,6 +4,7 @@ package v1alpha1
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,9 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -534,6 +537,29 @@ func TestRejectSAFromWrongNamespace(t *testing.T) {
 	assert.Contains(t, err.Error(), "managed by the search operator")
 }
 
+// A human/cluster-admin user (not a service account at all) trying to delete a CollectorConfig
+// that has an ownerReference — e.g. a tester who copied a sample that included one — is rejected
+// the same way a wrong-namespace SA is. This is the exact scenario a QE tester hit: a manually
+// applied test CollectorConfig carried an ownerReferences section pointing at the Search CR, so
+// it was treated as operator-managed and couldn't be deleted directly. See ACM-35522 test notes.
+func TestRejectHumanUserDeleteOwnedConfig(t *testing.T) {
+	humanCtx := ctxWithUser("kube:admin")
+	c := ownedConfig()
+	_, err := c.ValidateDelete(humanCtx, c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
+// Same scenario via ValidateUpdate — a human user cannot edit an operator-owned config either.
+func TestRejectHumanUserUpdateOwnedConfig(t *testing.T) {
+	humanCtx := ctxWithUser("kube:admin")
+	old := ownedConfig()
+	updated := old.DeepCopy()
+	_, err := updated.ValidateUpdate(humanCtx, old, updated)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by the search operator")
+}
+
 // --- Exclude rule tests ---
 
 // Accept a valid exclude rule with no fields/conditions.
@@ -752,6 +778,73 @@ func TestAcceptExcludeWildcardKindOnSafeAPIGroup(t *testing.T) {
 	assert.NoError(t, err, "wildcard kind on a non-protected apiGroup (apps) should be accepted")
 }
 
+// Groups that used to be in the static protectedAPIGroups safety net before ACM-37052 shipped
+// real integration CollectorConfigs for them (kubevirt.io -> CNV, argoproj.io -> Argo, etc).
+// Without a fake webhookClient, the dynamic integration-overlap check is skipped (see
+// TestExcludeIntegrationCheckSkippedWhenClientNil), so these should now be accepted.
+func TestAcceptExcludeFormerlyStaticProtectedGroupsNowIntegrationOwned(t *testing.T) {
+	formerlyProtected := []string{
+		"operators.coreos.com",              // OLM
+		"kubevirt.io",                       // CNV
+		"cdi.kubevirt.io",                   // CNV
+		"argoproj.io",                       // Argo
+		"policy.open-cluster-management.io", // GRC
+		"wgpolicyk8s.io",                    // GRC
+		"kyverno.io",                        // Kyverno
+		"policies.kyverno.io",               // Kyverno
+		"constraints.gatekeeper.sh",         // Gatekeeper
+		"apps.open-cluster-management.io",   // ACM app lifecycle
+		"app.k8s.io",                        // ACM app lifecycle
+		"storage.k8s.io",                    // CNV (storage)
+		"k8s.cni.cncf.io",                   // CNV (networking)
+	}
+	for _, apiGroup := range formerlyProtected {
+		t.Run(apiGroup, func(t *testing.T) {
+			c := validConfig()
+			c.Spec.CollectionRules[0] = CollectionRule{
+				Action: ActionExclude,
+				ResourceSelector: ResourceSelector{
+					APIGroups: []string{apiGroup},
+					Kinds:     []string{"*"},
+				},
+			}
+			_, err := c.ValidateCreate(context.Background(), c)
+			assert.NoError(t, err, apiGroup+" is no longer in the static protectedAPIGroups list")
+		})
+	}
+}
+
+// Groups with no single integration-team owner (or that Search itself depends on) remain in the
+// static protectedAPIGroups safety net after ACM-37052.
+func TestRejectExcludeStillStaticProtectedGroups(t *testing.T) {
+	stillProtected := []string{
+		"",                                    // core group — ConfigMap/Job/Node/Pod/PVC, multiple owners
+		"config.openshift.io",                 // no single integration-team owner
+		"template.openshift.io",               // no single integration-team owner
+		"admissionregistration.k8s.io",        // no single integration-team owner
+		"operator.open-cluster-management.io", // ACM hub operator — Search depends on this
+		"search.open-cluster-management.io",   // Search itself
+	}
+	for _, apiGroup := range stillProtected {
+		name := apiGroup
+		if name == "" {
+			name = "core"
+		}
+		t.Run(name, func(t *testing.T) {
+			c := validConfig()
+			c.Spec.CollectionRules[0] = CollectionRule{
+				Action: ActionExclude,
+				ResourceSelector: ResourceSelector{
+					APIGroups: []string{apiGroup},
+					Kinds:     []string{"*"},
+				},
+			}
+			_, err := c.ValidateCreate(context.Background(), c)
+			assert.Error(t, err, apiGroup+" must remain protected")
+		})
+	}
+}
+
 // --- Integration config overlap checks ---
 
 // buildFakeWebhookClient registers the scheme and returns a fake client pre-populated
@@ -766,6 +859,22 @@ func buildFakeWebhookClient(t *testing.T, objs ...runtime.Object) {
 		builder = builder.WithRuntimeObjects(o)
 	}
 	webhookClient = builder.Build()
+	t.Cleanup(func() { webhookClient = nil })
+}
+
+// buildFailingListWebhookClient sets webhookClient to one whose List call always fails, to
+// exercise the "log and allow" fallback in validateExcludeAgainstIntegrationConfigs — a List
+// failure should never block an otherwise-valid CollectorConfig operation.
+func buildFailingListWebhookClient(t *testing.T) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	webhookClient = interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			return errors.New("simulated API server error")
+		},
+	})
 	t.Cleanup(func() { webhookClient = nil })
 }
 
@@ -879,4 +988,21 @@ func TestExcludeIntegrationCheckSkippedWhenClientNil(t *testing.T) {
 	}
 	_, err := c.ValidateCreate(context.Background(), c)
 	assert.NoError(t, err, "dynamic overlap check should be skipped when webhookClient is nil")
+}
+
+// A List failure when discovering integration team CollectorConfigs must not block an otherwise
+// valid exclude — it's logged and treated as "no integration configs found" rather than rejected.
+func TestExcludeAllowedWhenIntegrationListFails(t *testing.T) {
+	buildFailingListWebhookClient(t)
+	c := validConfig()
+	c.Namespace = "default"
+	c.Spec.CollectionRules[0] = CollectionRule{
+		Action: ActionExclude,
+		ResourceSelector: ResourceSelector{
+			APIGroups: []string{"coordination.k8s.io"},
+			Kinds:     []string{"Lease"},
+		},
+	}
+	_, err := c.ValidateCreate(context.Background(), c)
+	assert.NoError(t, err, "a List failure should be logged and allowed, not rejected")
 }

--- a/config/integration_collector_configs/app-lifecycle.yaml
+++ b/config/integration_collector_configs/app-lifecycle.yaml
@@ -1,0 +1,22 @@
+# Integration CollectorConfig for ACM Application Lifecycle (multicloud-operators subscription
+# stack: Channel, Deployable, HelmRelease, PlacementBinding, Subscription, and the upstream
+# sig-application "Application" kind). Populated from resources already hard-coded in
+# search-collector's typed transforms (channel.go, appdeployable.go, helmrelease.go,
+# placementbinding.go, subscription.go, application.go) before this CollectorConfig existed.
+# See ACM-37052.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: app-lifecycle-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - apps.open-cluster-management.io
+          - app.k8s.io
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/app-lifecycle.yaml
+++ b/config/integration_collector_configs/app-lifecycle.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/app-lifecycle.yaml
+++ b/config/integration_collector_configs/app-lifecycle.yaml
@@ -4,6 +4,9 @@
 # sig-application "Application" kind). Populated from resources already hard-coded in
 # search-collector's typed transforms (channel.go, appdeployable.go, helmrelease.go,
 # placementbinding.go, subscription.go, application.go) before this CollectorConfig existed.
+#
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/app-lifecycle.yaml
+++ b/config/integration_collector_configs/app-lifecycle.yaml
@@ -1,14 +1,13 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for ACM Application Lifecycle (multicloud-operators subscription
 # stack: Channel, Deployable, HelmRelease, PlacementBinding, Subscription, and the upstream
 # sig-application "Application" kind). Populated from resources already hard-coded in
 # search-collector's typed transforms (channel.go, appdeployable.go, helmrelease.go,
 # placementbinding.go, subscription.go, application.go) before this CollectorConfig existed.
-# See ACM-37052.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: app-lifecycle-integration-collector-config
-  namespace: open-cluster-management
+  name: app-lifecycle-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/argo.yaml
+++ b/config/integration_collector_configs/argo.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/argo.yaml
+++ b/config/integration_collector_configs/argo.yaml
@@ -1,0 +1,18 @@
+# Integration CollectorConfig for Argo CD / OpenShift GitOps. Populated from resources already
+# hard-coded in search-collector/pkg/transforms/argoapplication.go and transformer.go before
+# this CollectorConfig existed. See ACM-37052.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: argo-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - argoproj.io
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/argo.yaml
+++ b/config/integration_collector_configs/argo.yaml
@@ -1,11 +1,11 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for Argo CD / OpenShift GitOps. Populated from resources already
 # hard-coded in search-collector/pkg/transforms/argoapplication.go and transformer.go before
-# this CollectorConfig existed. See ACM-37052.
+# this CollectorConfig existed.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: argo-integration-collector-config
-  namespace: open-cluster-management
+  name: argo-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/argo.yaml
+++ b/config/integration_collector_configs/argo.yaml
@@ -2,6 +2,9 @@
 # Integration CollectorConfig for Argo CD / OpenShift GitOps. Populated from resources already
 # hard-coded in search-collector/pkg/transforms/argoapplication.go and transformer.go before
 # this CollectorConfig existed.
+#
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -1,0 +1,34 @@
+# Integration CollectorConfig for CNV (Container Native Virtualization / KubeVirt) and the
+# storage resources it depends on. Populated from resources already hard-coded in
+# search-collector/pkg/transforms/genericResourceConfig.go and transformer.go before this
+# CollectorConfig existed. See ACM-37052.
+#
+# This config is created by the search-v2-operator if not already present on the cluster
+# (config-hash annotation tracks the shipped version — see docs/ARCHITECTURE.md). Once created,
+# CNV is free to edit it directly; the operator will only overwrite it again if a future
+# release ships an updated default AND this object hasn't been locally customized since.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: cnv-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - kubevirt.io
+          - cdi.kubevirt.io
+          - migrations.kubevirt.io
+          - clone.kubevirt.io
+          - instancetype.kubevirt.io
+          - snapshot.kubevirt.io
+          - networkaddonsoperator.network.kubevirt.io
+          - k8s.cni.cncf.io
+          - storage.k8s.io
+          - snapshot.storage.k8s.io
+          - snapshot.storage.kubevirt.io
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -3,10 +3,11 @@
 # search-collector/pkg/transforms/genericResourceConfig.go and transformer.go before this
 # CollectorConfig existed. See ACM-37052.
 #
-# This config is created by the search-v2-operator if not already present on the cluster
-# (config-hash annotation tracks the shipped version — see docs/ARCHITECTURE.md). Once created,
-# CNV is free to edit it directly; the operator will only overwrite it again if a future
-# release ships an updated default AND this object hasn't been locally customized since.
+# This config is created by the search-v2-operator once per process, at startup, and reset to
+# this shipped default on every restart/upgrade — see docs/ARCHITECTURE.md. CNV can edit it
+# directly and the edit will persist until the next restart, but to make a change survive
+# restarts before it's officially shipped here, create a differently-named CollectorConfig
+# (e.g. cnv-integration-collector-config-2) instead — the operator only manages this exact name.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -4,11 +4,8 @@
 # search-collector/pkg/transforms/genericResourceConfig.go and transformer.go before this
 # CollectorConfig existed.
 #
-# This config is created by the search-v2-operator once per process, at startup, and reset to
-# this shipped default on every restart/upgrade — see docs/ARCHITECTURE.md. CNV can edit it
-# directly and the edit will persist until the next restart, but to make a change survive
-# restarts before it's officially shipped here, create a differently-named CollectorConfig
-# (e.g. cnv-integration-2) instead — the operator only manages this exact name.
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -1,18 +1,18 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for CNV (Container Native Virtualization / KubeVirt) and the
 # storage resources it depends on. Populated from resources already hard-coded in
 # search-collector/pkg/transforms/genericResourceConfig.go and transformer.go before this
-# CollectorConfig existed. See ACM-37052.
+# CollectorConfig existed.
 #
 # This config is created by the search-v2-operator once per process, at startup, and reset to
 # this shipped default on every restart/upgrade — see docs/ARCHITECTURE.md. CNV can edit it
 # directly and the edit will persist until the next restart, but to make a change survive
 # restarts before it's officially shipped here, create a differently-named CollectorConfig
-# (e.g. cnv-integration-collector-config-2) instead — the operator only manages this exact name.
+# (e.g. cnv-integration-2) instead — the operator only manages this exact name.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: cnv-integration-collector-config
-  namespace: open-cluster-management
+  name: cnv-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/gatekeeper.yaml
+++ b/config/integration_collector_configs/gatekeeper.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/gatekeeper.yaml
+++ b/config/integration_collector_configs/gatekeeper.yaml
@@ -1,0 +1,18 @@
+# Integration CollectorConfig for Gatekeeper. Populated from resources already hard-coded in
+# search-collector/pkg/transforms/gatekeeperconstraint.go and transformer.go before this
+# CollectorConfig existed. See ACM-37052.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: gatekeeper-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - constraints.gatekeeper.sh
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/gatekeeper.yaml
+++ b/config/integration_collector_configs/gatekeeper.yaml
@@ -2,6 +2,9 @@
 # Integration CollectorConfig for Gatekeeper. Populated from resources already hard-coded in
 # search-collector/pkg/transforms/gatekeeperconstraint.go and transformer.go before this
 # CollectorConfig existed.
+#
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/gatekeeper.yaml
+++ b/config/integration_collector_configs/gatekeeper.yaml
@@ -1,11 +1,11 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for Gatekeeper. Populated from resources already hard-coded in
 # search-collector/pkg/transforms/gatekeeperconstraint.go and transformer.go before this
-# CollectorConfig existed. See ACM-37052.
+# CollectorConfig existed.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: gatekeeper-integration-collector-config
-  namespace: open-cluster-management
+  name: gatekeeper-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/grc.yaml
+++ b/config/integration_collector_configs/grc.yaml
@@ -1,0 +1,19 @@
+# Integration CollectorConfig for GRC (Governance, Risk, and Compliance / Policy). Populated
+# from resources already hard-coded in search-collector/pkg/transforms/transformer.go and
+# policy.go/policyreport.go before this CollectorConfig existed. See ACM-37052.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: grc-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - policy.open-cluster-management.io
+          - wgpolicyk8s.io
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/grc.yaml
+++ b/config/integration_collector_configs/grc.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/grc.yaml
+++ b/config/integration_collector_configs/grc.yaml
@@ -1,11 +1,11 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for GRC (Governance, Risk, and Compliance / Policy). Populated
 # from resources already hard-coded in search-collector/pkg/transforms/transformer.go and
-# policy.go/policyreport.go before this CollectorConfig existed. See ACM-37052.
+# policy.go/policyreport.go before this CollectorConfig existed.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: grc-integration-collector-config
-  namespace: open-cluster-management
+  name: grc-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/grc.yaml
+++ b/config/integration_collector_configs/grc.yaml
@@ -2,6 +2,9 @@
 # Integration CollectorConfig for GRC (Governance, Risk, and Compliance / Policy). Populated
 # from resources already hard-coded in search-collector/pkg/transforms/transformer.go and
 # policy.go/policyreport.go before this CollectorConfig existed.
+#
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/kyverno.yaml
+++ b/config/integration_collector_configs/kyverno.yaml
@@ -1,0 +1,19 @@
+# Integration CollectorConfig for Kyverno. Populated from resources already hard-coded in
+# search-collector/pkg/transforms/kyverno.go and transformer.go before this CollectorConfig
+# existed. See ACM-37052.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: kyverno-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - kyverno.io
+          - policies.kyverno.io
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/kyverno.yaml
+++ b/config/integration_collector_configs/kyverno.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/kyverno.yaml
+++ b/config/integration_collector_configs/kyverno.yaml
@@ -2,6 +2,9 @@
 # Integration CollectorConfig for Kyverno. Populated from resources already hard-coded in
 # search-collector/pkg/transforms/kyverno.go and transformer.go before this CollectorConfig
 # existed.
+#
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/kyverno.yaml
+++ b/config/integration_collector_configs/kyverno.yaml
@@ -1,11 +1,11 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for Kyverno. Populated from resources already hard-coded in
 # search-collector/pkg/transforms/kyverno.go and transformer.go before this CollectorConfig
-# existed. See ACM-37052.
+# existed.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: kyverno-integration-collector-config
-  namespace: open-cluster-management
+  name: kyverno-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/olm.yaml
+++ b/config/integration_collector_configs/olm.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: open-cluster-management
   labels:
     search.open-cluster-management.io/config-type: integration
+    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/olm.yaml
+++ b/config/integration_collector_configs/olm.yaml
@@ -1,0 +1,18 @@
+# Integration CollectorConfig for OLM (Operator Lifecycle Manager). Populated from resources
+# already hard-coded in search-collector/pkg/transforms/genericResourceConfig.go before this
+# CollectorConfig existed. See ACM-37052.
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: olm-integration-collector-config
+  namespace: open-cluster-management
+  labels:
+    search.open-cluster-management.io/config-type: integration
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups:
+          - operators.coreos.com
+        kinds:
+          - "*"

--- a/config/integration_collector_configs/olm.yaml
+++ b/config/integration_collector_configs/olm.yaml
@@ -1,11 +1,11 @@
+# Copyright Contributors to the Open Cluster Management project
 # Integration CollectorConfig for OLM (Operator Lifecycle Manager). Populated from resources
 # already hard-coded in search-collector/pkg/transforms/genericResourceConfig.go before this
-# CollectorConfig existed. See ACM-37052.
+# CollectorConfig existed.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
-  name: olm-integration-collector-config
-  namespace: open-cluster-management
+  name: olm-integration
   labels:
     search.open-cluster-management.io/config-type: integration
     cluster.open-cluster-management.io/backup: ""

--- a/config/integration_collector_configs/olm.yaml
+++ b/config/integration_collector_configs/olm.yaml
@@ -2,6 +2,9 @@
 # Integration CollectorConfig for OLM (Operator Lifecycle Manager). Populated from resources
 # already hard-coded in search-collector/pkg/transforms/genericResourceConfig.go before this
 # CollectorConfig existed.
+#
+# Managed by the operator — reset to this default on restart unless annotated with
+# search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integrationconfigs.go
+++ b/config/integrationconfigs.go
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Cluster Management project
+
+// Package integrationconfigs embeds the initial integration team CollectorConfig manifests
+// shipped in integration_collector_configs/. See ACM-37052.
+//
+// Integration teams (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle) contribute a
+// plain CollectorConfig YAML file to that directory instead of writing Go code. The operator
+// embeds these files at build time and creates/updates the corresponding CRs on the cluster —
+// see controllers/create_integration_collectorconfigs.go for the reconcile logic.
+package integrationconfigs
+
+import "embed"
+
+//go:embed integration_collector_configs/*.yaml
+var FS embed.FS
+
+// Dir is the embedded directory name, used by callers to build paths into FS.
+const Dir = "integration_collector_configs"

--- a/config/integrationconfigs.go
+++ b/config/integrationconfigs.go
@@ -1,7 +1,7 @@
 // Copyright Contributors to the Open Cluster Management project
 
 // Package integrationconfigs embeds the initial integration team CollectorConfig manifests
-// shipped in integration_collector_configs/. See ACM-37052.
+// shipped in integration_collector_configs/.
 //
 // Integration teams (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle) contribute a
 // plain CollectorConfig YAML file to that directory instead of writing Go code. The operator

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -13,8 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -34,15 +36,18 @@ import (
 //
 // Reads from the real embedded config/integration_collector_configs/ directory; see
 // applyIntegrationCollectorConfigsFrom for the testable, FS-injectable version.
-func applyIntegrationCollectorConfigs(ctx context.Context, c client.Client, namespace string) error {
-	return applyIntegrationCollectorConfigsFrom(ctx, c, namespace, integrationconfigs.FS, integrationconfigs.Dir)
+func applyIntegrationCollectorConfigs(
+	ctx context.Context, c client.Client, scheme *runtime.Scheme, owner *searchv1alpha1.Search,
+) error {
+	return applyIntegrationCollectorConfigsFrom(ctx, c, scheme, owner, integrationconfigs.FS, integrationconfigs.Dir)
 }
 
 // applyIntegrationCollectorConfigsFrom is applyIntegrationCollectorConfigs with the filesystem and
 // directory injected, so tests can exercise malformed-manifest and read-error paths with a
 // fstest.MapFS instead of editing the real embedded YAMLs.
 func applyIntegrationCollectorConfigsFrom(
-	ctx context.Context, c client.Client, namespace string, fsys fs.FS, dir string,
+	ctx context.Context, c client.Client, scheme *runtime.Scheme, owner *searchv1alpha1.Search,
+	fsys fs.FS, dir string,
 ) error {
 	entries, err := fs.ReadDir(fsys, dir)
 	if err != nil {
@@ -53,22 +58,31 @@ func applyIntegrationCollectorConfigsFrom(
 	// Sort for deterministic, readable logs (fs.ReadDir is already sorted, but be explicit).
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 
+	namespace := owner.Namespace
+	var firstErr error
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-		if err := applyOneIntegrationCollectorConfig(ctx, c, namespace, fsys, dir, entry.Name()); err != nil {
-			return err
+		if err := applyOneIntegrationCollectorConfig(ctx, c, scheme, owner, namespace, fsys, dir, entry.Name()); err != nil {
+			// Log and continue — one bad or temporarily broken config must not prevent the
+			// remaining integrations from being applied. The seeder retries the whole batch on
+			// the next interval, so a transient failure here is self-healing.
+			log.Error(err, "Failed to apply integration CollectorConfig, continuing with the rest", "file", entry.Name())
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
-	return nil
+	return firstErr
 }
 
 // applyOneIntegrationCollectorConfig unconditionally creates or overwrites a single embedded
 // integration CollectorConfig manifest — no diffing, no hash comparison. See
 // applyIntegrationCollectorConfigsFrom for why an unconditional overwrite is safe here.
 func applyOneIntegrationCollectorConfig(
-	ctx context.Context, c client.Client, namespace string, fsys fs.FS, dir, filename string,
+	ctx context.Context, c client.Client, scheme *runtime.Scheme, owner *searchv1alpha1.Search,
+	namespace string, fsys fs.FS, dir, filename string,
 ) error {
 	raw, err := fs.ReadFile(fsys, dir+"/"+filename)
 	if err != nil {
@@ -105,6 +119,14 @@ func applyOneIntegrationCollectorConfig(
 			cc.Labels = map[string]string{}
 		}
 		cc.Labels[searchv1alpha1.IntegrationTeamLabel] = searchv1alpha1.IntegrationTeamLabelValue
+		// Set the Search CR as controller-owner so this config is garbage-collected when
+		// Search is torn down, consistent with other operator-managed resources.
+		if scheme != nil && owner != nil && owner.UID != "" {
+			if err := controllerutil.SetControllerReference(owner, cc, scheme); err != nil {
+				log.Error(err, "Could not set ownerReference on integration CollectorConfig", "name", cc.Name)
+				return err
+			}
+		}
 		if err := c.Create(ctx, cc); err != nil {
 			log.Error(err, "Could not create integration CollectorConfig", "name", cc.Name)
 			return err
@@ -117,8 +139,9 @@ func applyOneIntegrationCollectorConfig(
 	}
 
 	hasIntegrationLabel := found.Labels[searchv1alpha1.IntegrationTeamLabel] == searchv1alpha1.IntegrationTeamLabelValue
-	if hasIntegrationLabel && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
-		// Already matches the currently shipped default and correctly labeled — skip the write.
+	hasOwnerRef := hasControllerOwnerRef(found, owner)
+	if hasIntegrationLabel && hasOwnerRef && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
+		// Already matches the currently shipped default, correctly labeled, and owned — skip.
 		return nil
 	}
 	found.Spec = desired.Spec
@@ -129,10 +152,31 @@ func applyOneIntegrationCollectorConfig(
 	// without it would otherwise be invisible to the webhook's integration-overlap check and to
 	// the merge step's label-based discovery, silently letting conflicting user excludes through.
 	found.Labels[searchv1alpha1.IntegrationTeamLabel] = searchv1alpha1.IntegrationTeamLabelValue
+	// Ensure ownerReference is set for GC when Search is torn down.
+	if scheme != nil && owner != nil && owner.UID != "" && !hasOwnerRef {
+		if err := controllerutil.SetControllerReference(owner, found, scheme); err != nil {
+			log.Error(err, "Could not set ownerReference on integration CollectorConfig", "name", desired.Name)
+			return err
+		}
+	}
 	if err := c.Update(ctx, found); err != nil {
 		log.Error(err, "Could not overwrite integration CollectorConfig", "name", desired.Name)
 		return err
 	}
 	log.Info("Overwrote integration CollectorConfig with the currently shipped default", "name", desired.Name)
 	return nil
+}
+
+// hasControllerOwnerRef returns true if obj already has a controller ownerReference pointing to
+// the given owner. Used to avoid redundant updates.
+func hasControllerOwnerRef(obj metav1.Object, owner *searchv1alpha1.Search) bool {
+	if owner == nil || owner.UID == "" {
+		return true // no owner to check against — treat as "already set" to avoid forcing updates in tests.
+	}
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == owner.UID {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -116,11 +116,19 @@ func applyOneIntegrationCollectorConfig(
 		return err
 	}
 
-	if equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
-		// Already matches the currently shipped default — skip the write.
+	hasIntegrationLabel := found.Labels[searchv1alpha1.IntegrationTeamLabel] == searchv1alpha1.IntegrationTeamLabelValue
+	if hasIntegrationLabel && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
+		// Already matches the currently shipped default and correctly labeled — skip the write.
 		return nil
 	}
 	found.Spec = desired.Spec
+	if found.Labels == nil {
+		found.Labels = map[string]string{}
+	}
+	// Always (re-)set the label, even when only the spec differed — a pre-existing config found
+	// without it would otherwise be invisible to the webhook's integration-overlap check and to
+	// the merge step's label-based discovery, silently letting conflicting user excludes through.
+	found.Labels[searchv1alpha1.IntegrationTeamLabel] = searchv1alpha1.IntegrationTeamLabelValue
 	if err := c.Update(ctx, found); err != nil {
 		log.Error(err, "Could not overwrite integration CollectorConfig", "name", desired.Name)
 		return err

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -1,0 +1,130 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"io/fs"
+	"sort"
+
+	integrationconfigs "github.com/stolostron/search-v2-operator/config"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// applyIntegrationCollectorConfigs creates or overwrites the initial integration team
+// CollectorConfig CRs (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle, etc.) from
+// the manifests embedded in config/integration_collector_configs/. See ACM-37052.
+//
+// Integration teams contribute a plain CollectorConfig YAML file to that directory instead of
+// writing Go code. This runs exactly once per operator process, at startup (see
+// IntegrationCollectorConfigSeeder) — not on every reconcile. That is what lets a team edit their
+// config directly and have it persist for the life of that pod: the canonical, fixed name always
+// gets reset to whatever's currently embedded on the next pod start, but is left alone in
+// between. A team that wants a change to survive across restarts before it ships officially
+// creates a differently-named CollectorConfig (still carrying the integration label) instead of
+// editing the canonical one — the merge step already discovers integration configs by label, not
+// name, so it picks up any number of them automatically.
+//
+// Reads from the real embedded config/integration_collector_configs/ directory; see
+// applyIntegrationCollectorConfigsFrom for the testable, FS-injectable version.
+func applyIntegrationCollectorConfigs(ctx context.Context, c client.Client, namespace string) error {
+	return applyIntegrationCollectorConfigsFrom(ctx, c, namespace, integrationconfigs.FS, integrationconfigs.Dir)
+}
+
+// applyIntegrationCollectorConfigsFrom is applyIntegrationCollectorConfigs with the filesystem and
+// directory injected, so tests can exercise malformed-manifest and read-error paths with a
+// fstest.MapFS instead of editing the real embedded YAMLs.
+func applyIntegrationCollectorConfigsFrom(
+	ctx context.Context, c client.Client, namespace string, fsys fs.FS, dir string,
+) error {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		log.Error(err, "Could not read embedded integration_collector_configs directory")
+		return err
+	}
+
+	// Sort for deterministic, readable logs (fs.ReadDir is already sorted, but be explicit).
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if err := applyOneIntegrationCollectorConfig(ctx, c, namespace, fsys, dir, entry.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyOneIntegrationCollectorConfig unconditionally creates or overwrites a single embedded
+// integration CollectorConfig manifest — no diffing, no hash comparison. See
+// applyIntegrationCollectorConfigsFrom for why an unconditional overwrite is safe here.
+func applyOneIntegrationCollectorConfig(
+	ctx context.Context, c client.Client, namespace string, fsys fs.FS, dir, filename string,
+) error {
+	raw, err := fs.ReadFile(fsys, dir+"/"+filename)
+	if err != nil {
+		log.Error(err, "Could not read embedded integration CollectorConfig", "file", filename)
+		return err
+	}
+
+	desired := &searchv1alpha1.CollectorConfig{}
+	if err := yaml.Unmarshal(raw, desired); err != nil {
+		log.Error(err, "Could not parse embedded integration CollectorConfig", "file", filename)
+		return err
+	}
+	if desired.Name == "" {
+		log.Info("Skipping embedded integration CollectorConfig with no metadata.name", "file", filename)
+		return nil
+	}
+
+	found := &searchv1alpha1.CollectorConfig{}
+	err = c.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: namespace}, found)
+	if errors.IsNotFound(err) {
+		cc := &searchv1alpha1.CollectorConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CollectorConfig",
+				APIVersion: searchv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      desired.Name,
+				Namespace: namespace,
+				Labels:    desired.Labels,
+			},
+			Spec: desired.Spec,
+		}
+		if cc.Labels == nil {
+			cc.Labels = map[string]string{}
+		}
+		cc.Labels[searchv1alpha1.IntegrationTeamLabel] = searchv1alpha1.IntegrationTeamLabelValue
+		if err := c.Create(ctx, cc); err != nil {
+			log.Error(err, "Could not create integration CollectorConfig", "name", cc.Name)
+			return err
+		}
+		log.Info("Created integration CollectorConfig", "name", cc.Name)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
+		// Already matches the currently shipped default — skip the write.
+		return nil
+	}
+	found.Spec = desired.Spec
+	if err := c.Update(ctx, found); err != nil {
+		log.Error(err, "Could not overwrite integration CollectorConfig", "name", desired.Name)
+		return err
+	}
+	log.Info("Overwrote integration CollectorConfig with the currently shipped default", "name", desired.Name)
+	return nil
+}

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -22,7 +22,7 @@ import (
 
 // applyIntegrationCollectorConfigs creates or overwrites the initial integration team
 // CollectorConfig CRs (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle, etc.) from
-// the manifests embedded in config/integration_collector_configs/. See ACM-37052.
+// the manifests embedded in config/integration_collector_configs/.
 //
 // Integration teams contribute a plain CollectorConfig YAML file to that directory instead of
 // writing Go code. This runs exactly once per operator process, at startup (see
@@ -138,9 +138,9 @@ func applyOneIntegrationCollectorConfig(
 		return err
 	}
 
-	hasIntegrationLabel := found.Labels[searchv1alpha1.IntegrationTeamLabel] == searchv1alpha1.IntegrationTeamLabelValue
+	hasAllLabels := hasDesiredLabels(found, desired)
 	hasOwnerRef := hasControllerOwnerRef(found, owner)
-	if hasIntegrationLabel && hasOwnerRef && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
+	if hasAllLabels && hasOwnerRef && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
 		// Already matches the currently shipped default, correctly labeled, and owned — skip.
 		return nil
 	}
@@ -148,9 +148,13 @@ func applyOneIntegrationCollectorConfig(
 	if found.Labels == nil {
 		found.Labels = map[string]string{}
 	}
-	// Always (re-)set the label, even when only the spec differed — a pre-existing config found
-	// without it would otherwise be invisible to the webhook's integration-overlap check and to
-	// the merge step's label-based discovery, silently letting conflicting user excludes through.
+	// Merge all labels from the shipped YAML, then enforce the integration label on top.
+	// This makes Create and Update symmetric: the shipped YAML's labels are always the
+	// source of truth — if someone removes the backup label from a live config, the seeder
+	// restores it on the next restart.
+	for k, v := range desired.Labels {
+		found.Labels[k] = v
+	}
 	found.Labels[searchv1alpha1.IntegrationTeamLabel] = searchv1alpha1.IntegrationTeamLabelValue
 	// Ensure ownerReference is set for GC when Search is torn down.
 	if scheme != nil && owner != nil && owner.UID != "" && !hasOwnerRef {
@@ -179,4 +183,18 @@ func hasControllerOwnerRef(obj metav1.Object, owner *searchv1alpha1.Search) bool
 		}
 	}
 	return false
+}
+
+// hasDesiredLabels returns true if found already has every label from desired (including the
+// integration team label). Used to avoid redundant updates when labels already match.
+func hasDesiredLabels(found, desired *searchv1alpha1.CollectorConfig) bool {
+	if found.Labels == nil {
+		return len(desired.Labels) == 0
+	}
+	for k, v := range desired.Labels {
+		if found.Labels[k] != v {
+			return false
+		}
+	}
+	return found.Labels[searchv1alpha1.IntegrationTeamLabel] == searchv1alpha1.IntegrationTeamLabelValue
 }

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -138,6 +138,13 @@ func applyOneIntegrationCollectorConfig(
 		return err
 	}
 
+	// If the user annotated this config with manual-override, respect their customization and
+	// do not overwrite — even on restart/upgrade. The user is in control.
+	if _, overridden := found.Annotations[searchv1alpha1.AnnotationManualOverride]; overridden {
+		log.Info("Skipping integration CollectorConfig with manual-override annotation", "name", found.Name)
+		return nil
+	}
+
 	hasAllLabels := hasDesiredLabels(found, desired)
 	hasOwnerRef := hasControllerOwnerRef(found, owner)
 	if hasAllLabels && hasOwnerRef && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -1,0 +1,255 @@
+// Copyright Contributors to the Open Cluster Management project
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/fstest"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// expectedIntegrationConfigNames must match metadata.name in each file under
+// config/integration_collector_configs/. Kept explicit (rather than derived from the embedded
+// FS) so a typo in a shipped YAML's name fails a test instead of silently creating nothing.
+var expectedIntegrationConfigNames = []string{
+	"cnv-integration-collector-config",
+	"olm-integration-collector-config",
+	"grc-integration-collector-config",
+	"kyverno-integration-collector-config",
+	"gatekeeper-integration-collector-config",
+	"argo-integration-collector-config",
+	"app-lifecycle-integration-collector-config",
+}
+
+func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T) {
+	r := setupReconciler()
+
+	err := applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace)
+	require.NoError(t, err)
+
+	for _, name := range expectedIntegrationConfigNames {
+		cc := &searchv1alpha1.CollectorConfig{}
+		err := r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: testNamespace}, cc)
+		require.NoError(t, err, "expected %s to be created", name)
+		assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, cc.Labels[searchv1alpha1.IntegrationTeamLabel])
+		assert.NotEmpty(t, cc.Spec.CollectionRules, "%s should have collection rules", name)
+	}
+}
+
+func TestApplyIntegrationCollectorConfigs_NoOpWhenAlreadyUpToDate(t *testing.T) {
+	r := setupReconciler()
+
+	// First pass creates everything.
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+
+	before := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, before))
+
+	// Second pass should be a no-op — same resourceVersion, same spec.
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, after))
+	assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "unchanged config should not be updated")
+}
+
+// This is the deliberate tradeoff: applyIntegrationCollectorConfigs always resets the canonical
+// name to the currently shipped default, even if it was customized. It's only ever called once
+// per operator process at startup (see IntegrationCollectorConfigSeeder), not on every reconcile —
+// so a customization survives for the life of the pod, but is reset on the next restart/upgrade.
+// A team that wants a change to persist across restarts before it's officially shipped should use
+// a different name for their CollectorConfig instead of editing the canonical one.
+func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t *testing.T) {
+	customized := newIntegrationTeamConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action: searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{
+					APIGroups: []string{"custom.example.io"}, Kinds: []string{"*"},
+				},
+			},
+		},
+	})
+	r := setupReconciler(customized)
+
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, after))
+	assert.NotEqual(t, customized.Spec, after.Spec,
+		"canonical config is reset to the shipped default on every seeder run, regardless of customization")
+}
+
+// A differently-named CollectorConfig (the escape hatch for mid-release testing/updates) is never
+// touched by applyIntegrationCollectorConfigs — it only knows about the fixed set of names in
+// config/integration_collector_configs/.
+func TestApplyIntegrationCollectorConfigs_LeavesDifferentlyNamedConfigsAlone(t *testing.T) {
+	testConfig := newIntegrationTeamConfig("cnv-integration-collector-config-2", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action: searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{
+					APIGroups: []string{"mid-release-test.example.io"}, Kinds: []string{"*"},
+				},
+			},
+		},
+	})
+	r := setupReconciler(testConfig)
+
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config-2", Namespace: testNamespace,
+	}, after))
+	assert.Equal(t, testConfig.Spec, after.Spec, "differently-named configs are never touched")
+}
+
+// --- Edge cases exercised via an injected fstest.MapFS, since the real embedded YAMLs are
+// always well-formed and can't exercise these defensive branches on their own. ---
+
+func validCollectorConfigYAML(name string) []byte {
+	return []byte(`
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+metadata:
+  name: ` + name + `
+spec:
+  collectionRules:
+    - action: include
+      resourceSelector:
+        apiGroups: ["example.io"]
+        kinds: ["*"]
+`)
+}
+
+func TestApplyIntegrationCollectorConfigsFrom_ReadDirError(t *testing.T) {
+	r := setupReconciler()
+	fsys := fstest.MapFS{} // "configs" directory does not exist.
+
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	assert.Error(t, err)
+}
+
+func TestApplyIntegrationCollectorConfigsFrom_SkipsSubdirectories(t *testing.T) {
+	r := setupReconciler()
+	// fstest.MapFS automatically synthesizes a directory entry for "configs/subdir" because
+	// "configs/subdir/nested.yaml" exists — no need to set it explicitly. ReadDir("configs")
+	// returns both "a-real-file.yaml" and the "subdir" directory entry, exercising the
+	// entry.IsDir() skip in applyIntegrationCollectorConfigsFrom.
+	fsys := fstest.MapFS{
+		"configs/a-real-file.yaml":   &fstest.MapFile{Data: validCollectorConfigYAML("real-config")},
+		"configs/subdir/nested.yaml": &fstest.MapFile{Data: validCollectorConfigYAML("nested-config")},
+	}
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	require.NoError(t, err)
+
+	cc := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: "real-config", Namespace: testNamespace}, cc))
+	// The nested file's config should NOT have been applied, since ReadDir on "configs" only
+	// lists immediate children ("a-real-file.yaml" and the "subdir" directory itself, not
+	// "subdir/nested.yaml"), and directories are skipped.
+	err = r.Get(context.TODO(), types.NamespacedName{Name: "nested-config", Namespace: testNamespace}, &searchv1alpha1.CollectorConfig{})
+	assert.True(t, apierrors.IsNotFound(err), "nested file must not be read directly out of a subdirectory")
+}
+
+func TestApplyIntegrationCollectorConfigsFrom_StopsOnFirstFileError(t *testing.T) {
+	r := setupReconciler()
+	fsys := fstest.MapFS{
+		"configs/a-bad.yaml":  &fstest.MapFile{Data: []byte("not: valid: yaml: [")},
+		"configs/z-good.yaml": &fstest.MapFile{Data: validCollectorConfigYAML("good-config")},
+	}
+
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	assert.Error(t, err, "a malformed manifest must fail the whole pass, not be silently skipped")
+
+	// Files are processed in sorted order, so "a-bad.yaml" (alphabetically first) fails before
+	// "z-good.yaml" is ever reached.
+	err = r.Get(context.TODO(), types.NamespacedName{Name: "good-config", Namespace: testNamespace}, &searchv1alpha1.CollectorConfig{})
+	assert.True(t, apierrors.IsNotFound(err), "processing stops at the first error, later files are never applied")
+}
+
+func TestApplyOneIntegrationCollectorConfig_SkipsManifestWithNoName(t *testing.T) {
+	r := setupReconciler()
+	fsys := fstest.MapFS{
+		"configs/no-name.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: search.open-cluster-management.io/v1alpha1
+kind: CollectorConfig
+spec:
+  collectionRules: []
+`)},
+	}
+
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	assert.NoError(t, err, "a manifest with no metadata.name is skipped, not an error")
+}
+
+func TestApplyOneIntegrationCollectorConfig_MalformedYAMLReturnsError(t *testing.T) {
+	r := setupReconciler()
+	fsys := fstest.MapFS{
+		"configs/broken.yaml": &fstest.MapFile{Data: []byte("not: valid: yaml: [")},
+	}
+
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	assert.Error(t, err)
+}
+
+func TestApplyOneIntegrationCollectorConfig_GetErrorOtherThanNotFound(t *testing.T) {
+	base := setupReconciler().Client.(client.WithWatch)
+	failingClient := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			return errors.New("simulated API server error")
+		},
+	})
+
+	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testNamespace)
+	assert.Error(t, err)
+}
+
+func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
+	base := setupReconciler().Client.(client.WithWatch)
+	failingClient := interceptor.NewClient(base, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			return errors.New("simulated create failure")
+		},
+	})
+
+	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testNamespace)
+	assert.Error(t, err)
+}
+
+func TestApplyOneIntegrationCollectorConfig_UpdateError(t *testing.T) {
+	// Pre-create one config with a spec that differs from the shipped default, so the code
+	// takes the Update path rather than Create.
+	existing := newIntegrationTeamConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"stale.example.io"}, Kinds: []string{"*"}},
+			},
+		},
+	})
+	base := setupReconciler(existing).Client.(client.WithWatch)
+	failingClient := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			return errors.New("simulated update failure")
+		},
+	})
+
+	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testNamespace)
+	assert.Error(t, err)
+}

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -11,10 +11,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
+
+// testSearchOwner returns a Search CR suitable for ownerReference testing. It has an empty UID
+// which causes applyOneIntegrationCollectorConfig to skip the ownerReference logic — that's fine
+// for tests that don't specifically test the ownerRef behavior, since the fake client doesn't
+// populate UID anyway.
+func testSearchOwner() *searchv1alpha1.Search {
+	return newSearchInstance()
+}
+
+// testScheme returns the scheme used by setupReconciler, for passing to apply functions.
+func testScheme() *runtime.Scheme {
+	return setupReconciler().Scheme
+}
 
 // expectedIntegrationConfigNames must match metadata.name in each file under
 // config/integration_collector_configs/. Kept explicit (rather than derived from the embedded
@@ -32,7 +46,7 @@ var expectedIntegrationConfigNames = []string{
 func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T) {
 	r := setupReconciler()
 
-	err := applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace)
+	err := applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner())
 	require.NoError(t, err)
 
 	for _, name := range expectedIntegrationConfigNames {
@@ -48,7 +62,7 @@ func TestApplyIntegrationCollectorConfigs_NoOpWhenAlreadyUpToDate(t *testing.T) 
 	r := setupReconciler()
 
 	// First pass creates everything.
-	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
 
 	before := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -56,7 +70,7 @@ func TestApplyIntegrationCollectorConfigs_NoOpWhenAlreadyUpToDate(t *testing.T) 
 	}, before))
 
 	// Second pass should be a no-op — same resourceVersion, same spec.
-	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -84,7 +98,7 @@ func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t 
 	})
 	r := setupReconciler(customized)
 
-	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -119,7 +133,7 @@ func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlreadyMatches
 	require.Empty(t, unlabeled.Labels, "test setup: must start with no labels at all")
 	r := setupReconciler(unlabeled)
 
-	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -142,7 +156,7 @@ func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlsoDiffers(t 
 	require.Empty(t, unlabeled.Labels)
 	r := setupReconciler(unlabeled)
 
-	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -168,7 +182,7 @@ func TestApplyIntegrationCollectorConfigs_LeavesDifferentlyNamedConfigsAlone(t *
 	})
 	r := setupReconciler(testConfig)
 
-	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -199,7 +213,7 @@ func TestApplyIntegrationCollectorConfigsFrom_ReadDirError(t *testing.T) {
 	r := setupReconciler()
 	fsys := fstest.MapFS{} // "configs" directory does not exist.
 
-	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
 	assert.Error(t, err)
 }
 
@@ -213,7 +227,7 @@ func TestApplyIntegrationCollectorConfigsFrom_SkipsSubdirectories(t *testing.T) 
 		"configs/a-real-file.yaml":   &fstest.MapFile{Data: validCollectorConfigYAML("real-config")},
 		"configs/subdir/nested.yaml": &fstest.MapFile{Data: validCollectorConfigYAML("nested-config")},
 	}
-	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
 	require.NoError(t, err)
 
 	cc := &searchv1alpha1.CollectorConfig{}
@@ -227,21 +241,22 @@ func TestApplyIntegrationCollectorConfigsFrom_SkipsSubdirectories(t *testing.T) 
 	assert.True(t, apierrors.IsNotFound(err), "nested file must not be read directly out of a subdirectory")
 }
 
-func TestApplyIntegrationCollectorConfigsFrom_StopsOnFirstFileError(t *testing.T) {
+// A malformed manifest returns an error but does NOT prevent the rest from being applied.
+func TestApplyIntegrationCollectorConfigsFrom_ContinuesOnSingleFileError(t *testing.T) {
 	r := setupReconciler()
 	fsys := fstest.MapFS{
 		"configs/a-bad.yaml":  &fstest.MapFile{Data: []byte("not: valid: yaml: [")},
 		"configs/z-good.yaml": &fstest.MapFile{Data: validCollectorConfigYAML("good-config")},
 	}
 
-	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
-	assert.Error(t, err, "a malformed manifest must fail the whole pass, not be silently skipped")
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
+	assert.Error(t, err, "the first error is still returned to the caller for retry")
 
-	// Files are processed in sorted order, so "a-bad.yaml" (alphabetically first) fails before
-	// "z-good.yaml" is ever reached.
+	// Despite the error on "a-bad.yaml", "z-good.yaml" must still have been applied.
 	goodConfigKey := types.NamespacedName{Name: "good-config", Namespace: testNamespace}
-	err = r.Get(context.TODO(), goodConfigKey, &searchv1alpha1.CollectorConfig{})
-	assert.True(t, apierrors.IsNotFound(err), "processing stops at the first error, later files are never applied")
+	cc := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), goodConfigKey, cc),
+		"a failure on one file must not prevent the rest from being applied")
 }
 
 func TestApplyOneIntegrationCollectorConfig_SkipsManifestWithNoName(t *testing.T) {
@@ -255,7 +270,7 @@ spec:
 `)},
 	}
 
-	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
 	assert.NoError(t, err, "a manifest with no metadata.name is skipped, not an error")
 }
 
@@ -265,7 +280,7 @@ func TestApplyOneIntegrationCollectorConfig_MalformedYAMLReturnsError(t *testing
 		"configs/broken.yaml": &fstest.MapFile{Data: []byte("not: valid: yaml: [")},
 	}
 
-	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testNamespace, fsys, "configs")
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
 	assert.Error(t, err)
 }
 
@@ -279,7 +294,7 @@ func TestApplyOneIntegrationCollectorConfig_GetErrorOtherThanNotFound(t *testing
 		},
 	})
 
-	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testNamespace)
+	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testScheme(), testSearchOwner())
 	assert.Error(t, err)
 }
 
@@ -291,7 +306,7 @@ func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
 		},
 	})
 
-	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testNamespace)
+	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testScheme(), testSearchOwner())
 	assert.Error(t, err)
 }
 
@@ -313,6 +328,6 @@ func TestApplyOneIntegrationCollectorConfig_UpdateError(t *testing.T) {
 		},
 	})
 
-	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testNamespace)
+	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testScheme(), testSearchOwner())
 	assert.Error(t, err)
 }

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -94,6 +94,64 @@ func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t 
 		"canonical config is reset to the shipped default on every seeder run, regardless of customization")
 }
 
+// If a canonical-named CollectorConfig exists without the integration label (e.g. pre-existing
+// state from before this feature, or a bug elsewhere), the label must be added even when the spec
+// already matches the shipped default — otherwise it stays invisible to the webhook's
+// integration-overlap check and to the merge step's label-based discovery, silently allowing a
+// conflicting user exclude through.
+func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlreadyMatches(t *testing.T) {
+	unlabeled := newCollectorConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action: searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{
+					APIGroups: []string{
+						"kubevirt.io", "cdi.kubevirt.io", "migrations.kubevirt.io", "clone.kubevirt.io",
+						"instancetype.kubevirt.io", "snapshot.kubevirt.io",
+						"networkaddonsoperator.network.kubevirt.io", "k8s.cni.cncf.io",
+						"storage.k8s.io", "snapshot.storage.k8s.io", "snapshot.storage.kubevirt.io",
+					},
+					Kinds: []string{"*"},
+				},
+			},
+		},
+	})
+	require.Empty(t, unlabeled.Labels, "test setup: must start with no labels at all")
+	r := setupReconciler(unlabeled)
+
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, after))
+	assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, after.Labels[searchv1alpha1.IntegrationTeamLabel],
+		"label must be added even though the spec already matched the shipped default")
+}
+
+// Same as above, but the spec also differs — both the spec and the label must be fixed together.
+func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlsoDiffers(t *testing.T) {
+	unlabeled := newCollectorConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"stale.example.io"}, Kinds: []string{"*"}},
+			},
+		},
+	})
+	require.Empty(t, unlabeled.Labels)
+	r := setupReconciler(unlabeled)
+
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testNamespace))
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, after))
+	assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, after.Labels[searchv1alpha1.IntegrationTeamLabel])
+	assert.NotEqual(t, "stale.example.io", after.Spec.CollectionRules[0].ResourceSelector.APIGroups[0])
+}
+
 // A differently-named CollectorConfig (the escape hatch for mid-release testing/updates) is never
 // touched by applyIntegrationCollectorConfigs — it only knows about the fixed set of names in
 // config/integration_collector_configs/.
@@ -159,11 +217,13 @@ func TestApplyIntegrationCollectorConfigsFrom_SkipsSubdirectories(t *testing.T) 
 	require.NoError(t, err)
 
 	cc := &searchv1alpha1.CollectorConfig{}
-	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: "real-config", Namespace: testNamespace}, cc))
+	realConfigKey := types.NamespacedName{Name: "real-config", Namespace: testNamespace}
+	require.NoError(t, r.Get(context.TODO(), realConfigKey, cc))
 	// The nested file's config should NOT have been applied, since ReadDir on "configs" only
 	// lists immediate children ("a-real-file.yaml" and the "subdir" directory itself, not
 	// "subdir/nested.yaml"), and directories are skipped.
-	err = r.Get(context.TODO(), types.NamespacedName{Name: "nested-config", Namespace: testNamespace}, &searchv1alpha1.CollectorConfig{})
+	nestedConfigKey := types.NamespacedName{Name: "nested-config", Namespace: testNamespace}
+	err = r.Get(context.TODO(), nestedConfigKey, &searchv1alpha1.CollectorConfig{})
 	assert.True(t, apierrors.IsNotFound(err), "nested file must not be read directly out of a subdirectory")
 }
 
@@ -179,7 +239,8 @@ func TestApplyIntegrationCollectorConfigsFrom_StopsOnFirstFileError(t *testing.T
 
 	// Files are processed in sorted order, so "a-bad.yaml" (alphabetically first) fails before
 	// "z-good.yaml" is ever reached.
-	err = r.Get(context.TODO(), types.NamespacedName{Name: "good-config", Namespace: testNamespace}, &searchv1alpha1.CollectorConfig{})
+	goodConfigKey := types.NamespacedName{Name: "good-config", Namespace: testNamespace}
+	err = r.Get(context.TODO(), goodConfigKey, &searchv1alpha1.CollectorConfig{})
 	assert.True(t, apierrors.IsNotFound(err), "processing stops at the first error, later files are never applied")
 }
 
@@ -211,7 +272,9 @@ func TestApplyOneIntegrationCollectorConfig_MalformedYAMLReturnsError(t *testing
 func TestApplyOneIntegrationCollectorConfig_GetErrorOtherThanNotFound(t *testing.T) {
 	base := setupReconciler().Client.(client.WithWatch)
 	failingClient := interceptor.NewClient(base, interceptor.Funcs{
-		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+		Get: func(
+			ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption,
+		) error {
 			return errors.New("simulated API server error")
 		},
 	})

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -34,13 +34,13 @@ func testScheme() *runtime.Scheme {
 // config/integration_collector_configs/. Kept explicit (rather than derived from the embedded
 // FS) so a typo in a shipped YAML's name fails a test instead of silently creating nothing.
 var expectedIntegrationConfigNames = []string{
-	"cnv-integration-collector-config",
-	"olm-integration-collector-config",
-	"grc-integration-collector-config",
-	"kyverno-integration-collector-config",
-	"gatekeeper-integration-collector-config",
-	"argo-integration-collector-config",
-	"app-lifecycle-integration-collector-config",
+	"cnv-integration",
+	"olm-integration",
+	"grc-integration",
+	"kyverno-integration",
+	"gatekeeper-integration",
+	"argo-integration",
+	"app-lifecycle-integration",
 }
 
 func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T) {
@@ -66,7 +66,7 @@ func TestApplyIntegrationCollectorConfigs_NoOpWhenAlreadyUpToDate(t *testing.T) 
 
 	before := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, before))
 
 	// Second pass should be a no-op — same resourceVersion, same spec.
@@ -74,7 +74,7 @@ func TestApplyIntegrationCollectorConfigs_NoOpWhenAlreadyUpToDate(t *testing.T) 
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, after))
 	assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "unchanged config should not be updated")
 }
@@ -86,7 +86,7 @@ func TestApplyIntegrationCollectorConfigs_NoOpWhenAlreadyUpToDate(t *testing.T) 
 // A team that wants a change to persist across restarts before it's officially shipped should use
 // a different name for their CollectorConfig instead of editing the canonical one.
 func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t *testing.T) {
-	customized := newIntegrationTeamConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+	customized := newIntegrationTeamConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action: searchv1alpha1.ActionInclude,
@@ -102,7 +102,7 @@ func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t 
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, after))
 	assert.NotEqual(t, customized.Spec, after.Spec,
 		"canonical config is reset to the shipped default on every seeder run, regardless of customization")
@@ -114,7 +114,7 @@ func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t 
 // integration-overlap check and to the merge step's label-based discovery, silently allowing a
 // conflicting user exclude through.
 func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlreadyMatches(t *testing.T) {
-	unlabeled := newCollectorConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+	unlabeled := newCollectorConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action: searchv1alpha1.ActionInclude,
@@ -137,7 +137,7 @@ func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlreadyMatches
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, after))
 	assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, after.Labels[searchv1alpha1.IntegrationTeamLabel],
 		"label must be added even though the spec already matched the shipped default")
@@ -145,7 +145,7 @@ func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlreadyMatches
 
 // Same as above, but the spec also differs — both the spec and the label must be fixed together.
 func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlsoDiffers(t *testing.T) {
-	unlabeled := newCollectorConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+	unlabeled := newCollectorConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
@@ -160,7 +160,7 @@ func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlsoDiffers(t 
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, after))
 	assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, after.Labels[searchv1alpha1.IntegrationTeamLabel])
 	assert.NotEqual(t, "stale.example.io", after.Spec.CollectionRules[0].ResourceSelector.APIGroups[0])
@@ -170,7 +170,7 @@ func TestApplyIntegrationCollectorConfigs_AddsMissingLabelWhenSpecAlsoDiffers(t 
 // touched by applyIntegrationCollectorConfigs — it only knows about the fixed set of names in
 // config/integration_collector_configs/.
 func TestApplyIntegrationCollectorConfigs_LeavesDifferentlyNamedConfigsAlone(t *testing.T) {
-	testConfig := newIntegrationTeamConfig("cnv-integration-collector-config-2", searchv1alpha1.CollectorConfigSpec{
+	testConfig := newIntegrationTeamConfig("cnv-integration-2", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action: searchv1alpha1.ActionInclude,
@@ -186,7 +186,7 @@ func TestApplyIntegrationCollectorConfigs_LeavesDifferentlyNamedConfigsAlone(t *
 
 	after := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config-2", Namespace: testNamespace,
+		Name: "cnv-integration-2", Namespace: testNamespace,
 	}, after))
 	assert.Equal(t, testConfig.Spec, after.Spec, "differently-named configs are never touched")
 }
@@ -313,7 +313,7 @@ func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
 func TestApplyOneIntegrationCollectorConfig_UpdateError(t *testing.T) {
 	// Pre-create one config with a spec that differs from the shipped default, so the code
 	// takes the Update path rather than Create.
-	existing := newIntegrationTeamConfig("cnv-integration-collector-config", searchv1alpha1.CollectorConfigSpec{
+	existing := newIntegrationTeamConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -108,6 +108,34 @@ func TestApplyIntegrationCollectorConfigs_OverwritesCustomizedCanonicalConfig(t 
 		"canonical config is reset to the shipped default on every seeder run, regardless of customization")
 }
 
+// If a user annotates an integration CollectorConfig with the manual-override annotation, the
+// seeder must skip it entirely — even if the spec differs from the shipped default.
+func TestApplyIntegrationCollectorConfigs_SkipsManualOverrideAnnotatedConfig(t *testing.T) {
+	customized := newIntegrationTeamConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action: searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{
+					APIGroups: []string{"custom.example.io"}, Kinds: []string{"*"},
+				},
+			},
+		},
+	})
+	customized.Annotations = map[string]string{
+		searchv1alpha1.AnnotationManualOverride: "true",
+	}
+	r := setupReconciler(customized)
+
+	require.NoError(t, applyIntegrationCollectorConfigs(context.TODO(), r.Client, testScheme(), testSearchOwner()))
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration", Namespace: testNamespace,
+	}, after))
+	assert.Equal(t, customized.Spec, after.Spec,
+		"config with manual-override annotation must not be overwritten")
+}
+
 // If a canonical-named CollectorConfig exists without the integration label (e.g. pre-existing
 // state from before this feature, or a bug elsewhere), the label must be added even when the spec
 // already matches the shipped default — otherwise it stays invisible to the webhook's

--- a/controllers/integration_collectorconfig_seeder.go
+++ b/controllers/integration_collectorconfig_seeder.go
@@ -54,10 +54,16 @@ func (s *IntegrationCollectorConfigSeeder) Start(ctx context.Context) error {
 	}
 	err := wait.PollUntilContextCancel(ctx, interval, true,
 		func(ctx context.Context) (bool, error) {
-			namespace, err := s.resolveNamespace(ctx)
+			namespace, paused, err := s.resolveSearch(ctx)
 			if err != nil {
 				log.Error(err, "Could not resolve namespace for integration CollectorConfig seeding, will retry")
 				return false, nil // keep polling — the Search CR may not exist yet on a fresh install.
+			}
+			if paused {
+				// search-pause: true must halt all operator-driven writes, including this one —
+				// keep polling (so seeding still happens promptly once unpaused) without writing.
+				log.V(2).Info("Search reconciliation is paused, deferring integration CollectorConfig seeding")
+				return false, nil
 			}
 			if err := applyIntegrationCollectorConfigs(ctx, s.Client, namespace); err != nil {
 				log.Error(err, "Could not apply built-in integration CollectorConfigs, will retry")
@@ -81,23 +87,39 @@ func (s *IntegrationCollectorConfigSeeder) NeedLeaderElection() bool {
 	return true
 }
 
-// resolveNamespace returns s.Namespace if explicitly set (used by tests), otherwise finds the
-// live Search CR (there is always exactly one, named OperatorName — see search_controller.go)
-// and returns its namespace. The rest of the reconciler already gets its namespace this way
-// (from the reconciled object itself, via a cluster-wide watch), not from an env var — the
-// manager's WATCH_NAMESPACE/POD_NAMESPACE env vars are not reliably set in real deployments.
-func (s *IntegrationCollectorConfigSeeder) resolveNamespace(ctx context.Context) (string, error) {
+// resolveSearch returns the namespace and search-pause state of the live Search CR. There is
+// always supposed to be exactly one, named OperatorName (see search_controller.go) — this
+// requires exactly one match rather than returning the first one found, so a duplicate CR (a bug
+// elsewhere) causes this to keep retrying with an error instead of silently seeding an arbitrary
+// namespace. If s.Namespace is explicitly set (used by tests), it's used as-is and paused is
+// always false, since there's no Search CR to check in that case.
+//
+// The rest of the reconciler already gets its namespace this way (from the reconciled object
+// itself, via a cluster-wide watch), not from an env var — WATCH_NAMESPACE/POD_NAMESPACE are not
+// reliably set in real deployments.
+func (s *IntegrationCollectorConfigSeeder) resolveSearch(
+	ctx context.Context,
+) (namespace string, paused bool, err error) {
 	if s.Namespace != "" {
-		return s.Namespace, nil
+		return s.Namespace, false, nil
 	}
 	list := &searchv1alpha1.SearchList{}
 	if err := s.Client.List(ctx, list); err != nil {
-		return "", err
+		return "", false, err
 	}
-	for _, item := range list.Items {
-		if item.Name == OperatorName {
-			return item.Namespace, nil
+	var match *searchv1alpha1.Search
+	for i := range list.Items {
+		if list.Items[i].Name == OperatorName {
+			if match != nil {
+				return "", false, fmt.Errorf(
+					"found multiple search CRs named %q (namespaces %q and %q) — refusing to guess which one to use",
+					OperatorName, match.Namespace, list.Items[i].Namespace)
+			}
+			match = &list.Items[i]
 		}
 	}
-	return "", fmt.Errorf("search CR %q not found in any namespace", OperatorName)
+	if match == nil {
+		return "", false, fmt.Errorf("search CR %q not found in any namespace", OperatorName)
+	}
+	return match.Namespace, IsPaused(match.GetAnnotations()), nil
 }

--- a/controllers/integration_collectorconfig_seeder.go
+++ b/controllers/integration_collectorconfig_seeder.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,6 +31,7 @@ const integrationSeedRetryInterval = 10 * time.Second
 // pod start" semantics without the risk of permanently giving up on a transient early failure.
 type IntegrationCollectorConfigSeeder struct {
 	Client client.Client
+	Scheme *runtime.Scheme
 
 	// Namespace is used if non-empty. Left empty in practice — WATCH_NAMESPACE/POD_NAMESPACE
 	// are not reliably set in real deployments (observed empty on a live ACM 5.0 install), so
@@ -54,7 +56,7 @@ func (s *IntegrationCollectorConfigSeeder) Start(ctx context.Context) error {
 	}
 	err := wait.PollUntilContextCancel(ctx, interval, true,
 		func(ctx context.Context) (bool, error) {
-			namespace, paused, err := s.resolveSearch(ctx)
+			searchCR, paused, err := s.resolveSearch(ctx)
 			if err != nil {
 				log.Error(err, "Could not resolve namespace for integration CollectorConfig seeding, will retry")
 				return false, nil // keep polling — the Search CR may not exist yet on a fresh install.
@@ -65,7 +67,7 @@ func (s *IntegrationCollectorConfigSeeder) Start(ctx context.Context) error {
 				log.V(2).Info("Search reconciliation is paused, deferring integration CollectorConfig seeding")
 				return false, nil
 			}
-			if err := applyIntegrationCollectorConfigs(ctx, s.Client, namespace); err != nil {
+			if err := applyIntegrationCollectorConfigs(ctx, s.Client, s.Scheme, searchCR); err != nil {
 				log.Error(err, "Could not apply built-in integration CollectorConfigs, will retry")
 				return false, nil // keep polling — this is expected on a fresh install.
 			}
@@ -87,31 +89,34 @@ func (s *IntegrationCollectorConfigSeeder) NeedLeaderElection() bool {
 	return true
 }
 
-// resolveSearch returns the namespace and search-pause state of the live Search CR. There is
-// always supposed to be exactly one, named OperatorName (see search_controller.go) — this
-// requires exactly one match rather than returning the first one found, so a duplicate CR (a bug
-// elsewhere) causes this to keep retrying with an error instead of silently seeding an arbitrary
-// namespace. If s.Namespace is explicitly set (used by tests), it's used as-is and paused is
-// always false, since there's no Search CR to check in that case.
+// resolveSearch returns the live Search CR and its pause state. There is always supposed to be
+// exactly one, named OperatorName (see search_controller.go) — this requires exactly one match
+// rather than returning the first one found, so a duplicate CR (a bug elsewhere) causes this to
+// keep retrying with an error instead of silently seeding an arbitrary namespace. If s.Namespace
+// is explicitly set (used by tests), a minimal placeholder Search is returned since the caller
+// only needs its namespace and UID for setting ownerReferences.
 //
 // The rest of the reconciler already gets its namespace this way (from the reconciled object
 // itself, via a cluster-wide watch), not from an env var — WATCH_NAMESPACE/POD_NAMESPACE are not
 // reliably set in real deployments.
 func (s *IntegrationCollectorConfigSeeder) resolveSearch(
 	ctx context.Context,
-) (namespace string, paused bool, err error) {
+) (searchCR *searchv1alpha1.Search, paused bool, err error) {
 	if s.Namespace != "" {
-		return s.Namespace, false, nil
+		// Tests set Namespace directly — return a minimal placeholder with the namespace filled.
+		placeholder := &searchv1alpha1.Search{}
+		placeholder.Namespace = s.Namespace
+		return placeholder, false, nil
 	}
 	list := &searchv1alpha1.SearchList{}
 	if err := s.Client.List(ctx, list); err != nil {
-		return "", false, err
+		return nil, false, err
 	}
 	var match *searchv1alpha1.Search
 	for i := range list.Items {
 		if list.Items[i].Name == OperatorName {
 			if match != nil {
-				return "", false, fmt.Errorf(
+				return nil, false, fmt.Errorf(
 					"found multiple search CRs named %q (namespaces %q and %q) — refusing to guess which one to use",
 					OperatorName, match.Namespace, list.Items[i].Namespace)
 			}
@@ -119,7 +124,7 @@ func (s *IntegrationCollectorConfigSeeder) resolveSearch(
 		}
 	}
 	if match == nil {
-		return "", false, fmt.Errorf("search CR %q not found in any namespace", OperatorName)
+		return nil, false, fmt.Errorf("search CR %q not found in any namespace", OperatorName)
 	}
-	return match.Namespace, IsPaused(match.GetAnnotations()), nil
+	return match, IsPaused(match.GetAnnotations()), nil
 }

--- a/controllers/integration_collectorconfig_seeder.go
+++ b/controllers/integration_collectorconfig_seeder.go
@@ -1,0 +1,103 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// integrationSeedRetryInterval is how often IntegrationCollectorConfigSeeder retries applying the
+// embedded integration CollectorConfigs after a failed attempt (e.g. the API server or the
+// CollectorConfig webhook isn't ready yet during a fresh install).
+const integrationSeedRetryInterval = 10 * time.Second
+
+// IntegrationCollectorConfigSeeder is a controller-runtime manager.Runnable (see main.go's
+// mgr.Add call) that applies the built-in integration CollectorConfigs exactly once per operator
+// process, at manager startup — deliberately not on every reconcile. See
+// applyIntegrationCollectorConfigs for why running this only at startup (and unconditionally
+// overwriting, no diffing) is the intended behavior, not a limitation.
+//
+// This intentionally isn't a sync.Once: a plain sync.Once marks itself "done" the moment its
+// function is called, even if that call failed (e.g. the CollectorConfig webhook's CA bundle
+// hasn't been injected yet on a fresh install — a known startup race, see docs/ARCHITECTURE.md).
+// Start retries on a short interval until it succeeds once, then returns — giving "run once per
+// pod start" semantics without the risk of permanently giving up on a transient early failure.
+type IntegrationCollectorConfigSeeder struct {
+	Client client.Client
+
+	// Namespace is used if non-empty. Left empty in practice — WATCH_NAMESPACE/POD_NAMESPACE
+	// are not reliably set in real deployments (observed empty on a live ACM 5.0 install), so
+	// Start falls back to discovering the namespace from the live Search CR (named
+	// OperatorName) instead of trusting an env var passed in at construction time. Exposed as a
+	// field mainly for tests, which don't have a Search CR to discover from.
+	Namespace string
+
+	// RetryInterval overrides integrationSeedRetryInterval. Defaults to it when zero; exposed
+	// mainly so tests can exercise the retry-then-succeed path without a real 10s wait.
+	RetryInterval time.Duration
+}
+
+// Start implements manager.Runnable. It blocks (retrying on failure) until the embedded
+// integration CollectorConfigs have been successfully applied once, then returns nil. Returning
+// an error here would be treated by controller-runtime as fatal to the whole manager, so this
+// only returns when ctx is done (pod shutting down) or once it has fully succeeded.
+func (s *IntegrationCollectorConfigSeeder) Start(ctx context.Context) error {
+	interval := s.RetryInterval
+	if interval <= 0 {
+		interval = integrationSeedRetryInterval
+	}
+	err := wait.PollUntilContextCancel(ctx, interval, true,
+		func(ctx context.Context) (bool, error) {
+			namespace, err := s.resolveNamespace(ctx)
+			if err != nil {
+				log.Error(err, "Could not resolve namespace for integration CollectorConfig seeding, will retry")
+				return false, nil // keep polling — the Search CR may not exist yet on a fresh install.
+			}
+			if err := applyIntegrationCollectorConfigs(ctx, s.Client, namespace); err != nil {
+				log.Error(err, "Could not apply built-in integration CollectorConfigs, will retry")
+				return false, nil // keep polling — this is expected on a fresh install.
+			}
+			return true, nil
+		})
+	if err != nil {
+		// Only reachable if ctx was canceled (pod shutting down) before success.
+		log.V(2).Info("Stopped retrying integration CollectorConfig seeding", "reason", err)
+		return nil
+	}
+	log.Info("Finished applying built-in integration CollectorConfigs")
+	return nil
+}
+
+// NeedLeaderElection implements manager.LeaderElectionRunnable. This writes cluster state, so it
+// should only run on the elected leader when leader election is enabled — same as the
+// reconciler itself.
+func (s *IntegrationCollectorConfigSeeder) NeedLeaderElection() bool {
+	return true
+}
+
+// resolveNamespace returns s.Namespace if explicitly set (used by tests), otherwise finds the
+// live Search CR (there is always exactly one, named OperatorName — see search_controller.go)
+// and returns its namespace. The rest of the reconciler already gets its namespace this way
+// (from the reconciled object itself, via a cluster-wide watch), not from an env var — the
+// manager's WATCH_NAMESPACE/POD_NAMESPACE env vars are not reliably set in real deployments.
+func (s *IntegrationCollectorConfigSeeder) resolveNamespace(ctx context.Context) (string, error) {
+	if s.Namespace != "" {
+		return s.Namespace, nil
+	}
+	list := &searchv1alpha1.SearchList{}
+	if err := s.Client.List(ctx, list); err != nil {
+		return "", err
+	}
+	for _, item := range list.Items {
+		if item.Name == OperatorName {
+			return item.Namespace, nil
+		}
+	}
+	return "", fmt.Errorf("search CR %q not found in any namespace", OperatorName)
+}

--- a/controllers/integration_collectorconfig_seeder_test.go
+++ b/controllers/integration_collectorconfig_seeder_test.go
@@ -1,0 +1,171 @@
+// Copyright Contributors to the Open Cluster Management project
+package controllers
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestIntegrationCollectorConfigSeeder_AppliesConfigsAndReturns(t *testing.T) {
+	r := setupReconciler()
+	seeder := &IntegrationCollectorConfigSeeder{Client: r.Client, Namespace: testNamespace}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Start should succeed on the first attempt and return promptly — it must not block for the
+	// full retry interval when there's nothing to retry.
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return promptly after a successful first attempt")
+	}
+
+	cc := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, cc))
+	assert.NotEmpty(t, cc.Spec.CollectionRules)
+}
+
+func TestIntegrationCollectorConfigSeeder_StopsRetryingWhenContextCanceled(t *testing.T) {
+	// An empty namespace makes every Create fail (CollectorConfig is namespaced), so Start must
+	// keep retrying until the context is canceled, then return nil rather than blocking forever
+	// or returning an error (which controller-runtime would treat as fatal to the manager).
+	r := setupReconciler()
+	seeder := &IntegrationCollectorConfigSeeder{Client: r.Client, Namespace: ""}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Start should return nil, not an error, on context cancellation")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not stop after context cancellation")
+	}
+}
+
+func TestIntegrationCollectorConfigSeeder_NeedsLeaderElection(t *testing.T) {
+	seeder := &IntegrationCollectorConfigSeeder{}
+	assert.True(t, seeder.NeedLeaderElection())
+}
+
+// Regression test for a real bug caught during live cluster testing: WATCH_NAMESPACE/POD_NAMESPACE
+// are empty in a real ACM 5.0 deployment (the manager watches cluster-wide instead), so the
+// seeder must discover its namespace from the live Search CR rather than trusting those env vars.
+func TestIntegrationCollectorConfigSeeder_DiscoversNamespaceFromSearchCR(t *testing.T) {
+	instance := newSearchInstance() // named OperatorName, namespace testNamespace.
+	r := setupReconciler(instance)
+	// Namespace intentionally left empty, exactly as main.go now constructs it.
+	seeder := &IntegrationCollectorConfigSeeder{Client: r.Client, RetryInterval: 20 * time.Millisecond}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not discover the namespace and finish")
+	}
+
+	cc := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, cc), "config should be created in the Search CR's namespace, discovered dynamically")
+}
+
+// If the Search CR doesn't exist yet (very early in a fresh install), Start must keep retrying
+// rather than erroring out or creating configs in the wrong (empty) namespace.
+func TestIntegrationCollectorConfigSeeder_RetriesUntilSearchCRExists(t *testing.T) {
+	r := setupReconciler() // no Search CR yet.
+	seeder := &IntegrationCollectorConfigSeeder{Client: r.Client, RetryInterval: 20 * time.Millisecond}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	// Confirm it's still retrying (not stuck/errored) while the CR is absent.
+	select {
+	case err := <-done:
+		t.Fatalf("Start should still be retrying with no Search CR present, got: %v", err)
+	case <-time.After(150 * time.Millisecond):
+		// Expected — still polling.
+	}
+
+	// Now create the CR; the next poll should discover it and succeed.
+	instance := newSearchInstance()
+	require.NoError(t, r.Create(context.TODO(), instance))
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not recover after the Search CR was created")
+	}
+
+	// Assert on the actual side effect, not just "Start returned nil" — cancellation and
+	// success both return nil, so this is what actually proves it succeeded rather than timing out.
+	cc := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, cc))
+}
+
+// Simulates the exact race this design is meant to survive: the first attempt fails (e.g. the
+// CollectorConfig webhook's CA bundle isn't injected yet), and a later attempt succeeds. Start
+// must retry rather than giving up after the first failure (the sync.Once flaw it was built to
+// avoid), and must return promptly once it does succeed rather than blocking for the full
+// interval afterward.
+func TestIntegrationCollectorConfigSeeder_RetriesUntilSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	base := setupReconciler().Client.(client.WithWatch)
+	flakyClient := interceptor.NewClient(base, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if attempts.Add(1) == 1 {
+				return errors.New("simulated transient failure on first attempt")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+	seeder := &IntegrationCollectorConfigSeeder{
+		Client:        flakyClient,
+		Namespace:     testNamespace,
+		RetryInterval: 20 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start never recovered from the first transient failure")
+	}
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2), "must have retried after the first failure")
+}

--- a/controllers/integration_collectorconfig_seeder_test.go
+++ b/controllers/integration_collectorconfig_seeder_test.go
@@ -169,3 +169,71 @@ func TestIntegrationCollectorConfigSeeder_RetriesUntilSuccess(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, attempts.Load(), int32(2), "must have retried after the first failure")
 }
+
+// search-pause: true on the Search CR must halt seeding the same way it halts the rest of the
+// reconciler — Start must defer (no writes) while paused, then proceed once unpaused, without
+// needing a restart.
+func TestIntegrationCollectorConfigSeeder_HonorsSearchPause(t *testing.T) {
+	instance := newSearchInstance()
+	instance.Annotations = map[string]string{AnnotationSearchPause: "true"}
+	r := setupReconciler(instance)
+	seeder := &IntegrationCollectorConfigSeeder{Client: r.Client, RetryInterval: 20 * time.Millisecond}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	// While paused, Start must not have created anything yet.
+	select {
+	case err := <-done:
+		t.Fatalf("Start should still be deferring while paused, got: %v", err)
+	case <-time.After(150 * time.Millisecond):
+		// Expected.
+	}
+	err := r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, &searchv1alpha1.CollectorConfig{})
+	assert.Error(t, err, "nothing should be created while search-pause is true")
+
+	// Unpause; the next poll should proceed and succeed.
+	current := &searchv1alpha1.Search{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: OperatorName, Namespace: testNamespace}, current))
+	current.Annotations[AnnotationSearchPause] = "false"
+	require.NoError(t, r.Update(context.TODO(), current))
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not proceed after search-pause was cleared")
+	}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+	}, &searchv1alpha1.CollectorConfig{}))
+}
+
+// If more than one Search CR named OperatorName somehow exists (a bug elsewhere), Start must not
+// silently guess which namespace to seed into — it should keep retrying with an error instead.
+func TestIntegrationCollectorConfigSeeder_RejectsAmbiguousSearchCR(t *testing.T) {
+	dup1 := newSearchInstance()
+	dup1.Namespace = "namespace-a"
+	dup2 := newSearchInstance()
+	dup2.Namespace = "namespace-b"
+	r := setupReconciler(dup1, dup2)
+	seeder := &IntegrationCollectorConfigSeeder{Client: r.Client, RetryInterval: 20 * time.Millisecond}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- seeder.Start(ctx) }()
+
+	<-done // Start always returns nil once ctx is done, whether paused, retrying, or ambiguous.
+
+	for _, ns := range []string{"namespace-a", "namespace-b"} {
+		err := r.Get(context.TODO(), types.NamespacedName{
+			Name: "cnv-integration-collector-config", Namespace: ns,
+		}, &searchv1alpha1.CollectorConfig{})
+		assert.Error(t, err, "must not have guessed either namespace")
+	}
+}

--- a/controllers/integration_collectorconfig_seeder_test.go
+++ b/controllers/integration_collectorconfig_seeder_test.go
@@ -37,7 +37,7 @@ func TestIntegrationCollectorConfigSeeder_AppliesConfigsAndReturns(t *testing.T)
 
 	cc := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, cc))
 	assert.NotEmpty(t, cc.Spec.CollectionRules)
 }
@@ -91,7 +91,7 @@ func TestIntegrationCollectorConfigSeeder_DiscoversNamespaceFromSearchCR(t *test
 
 	cc := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, cc), "config should be created in the Search CR's namespace, discovered dynamically")
 }
 
@@ -129,7 +129,7 @@ func TestIntegrationCollectorConfigSeeder_RetriesUntilSearchCRExists(t *testing.
 	// success both return nil, so this is what actually proves it succeeded rather than timing out.
 	cc := &searchv1alpha1.CollectorConfig{}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, cc))
 }
 
@@ -192,7 +192,7 @@ func TestIntegrationCollectorConfigSeeder_HonorsSearchPause(t *testing.T) {
 		// Expected.
 	}
 	err := r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, &searchv1alpha1.CollectorConfig{})
 	assert.Error(t, err, "nothing should be created while search-pause is true")
 
@@ -209,7 +209,7 @@ func TestIntegrationCollectorConfigSeeder_HonorsSearchPause(t *testing.T) {
 		t.Fatal("Start did not proceed after search-pause was cleared")
 	}
 	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
-		Name: "cnv-integration-collector-config", Namespace: testNamespace,
+		Name: "cnv-integration", Namespace: testNamespace,
 	}, &searchv1alpha1.CollectorConfig{}))
 }
 
@@ -232,7 +232,7 @@ func TestIntegrationCollectorConfigSeeder_RejectsAmbiguousSearchCR(t *testing.T)
 
 	for _, ns := range []string{"namespace-a", "namespace-b"} {
 		err := r.Get(context.TODO(), types.NamespacedName{
-			Name: "cnv-integration-collector-config", Namespace: ns,
+			Name: "cnv-integration", Namespace: ns,
 		}, &searchv1alpha1.CollectorConfig{})
 		assert.Error(t, err, "must not have guessed either namespace")
 	}

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -178,6 +178,9 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "Failed to ensure webhook CA injection annotation")
 		// Non-fatal — continue reconciliation, the webhook may already have the annotation.
 	}
+	// Built-in integration CollectorConfigs are seeded once at operator startup by
+	// IntegrationCollectorConfigSeeder (see main.go), not on every reconcile — see
+	// docs/ARCHITECTURE.md for why.
 	result, err = r.createOrUpdateMergedCollectorConfig(ctx, instance)
 	if result != nil {
 		log.Error(err, "Merged CollectorConfig setup failed")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,9 +92,19 @@ are not reliably set in real deployments — verified empty on a live ACM 5.0.0-
 testing, causing the seeder to fail with `"an empty namespace may not be set during creation"` on
 the first version of this code. The rest of the reconciler never has this problem because it
 gets its namespace from the reconciled `Search` object itself (the manager watches cluster-wide
-when `WATCH_NAMESPACE` is empty). `IntegrationCollectorConfigSeeder.resolveNamespace` fixes this
-the same way: it looks up the live `Search` CR (named `OperatorName` — there's always exactly one)
-and uses its namespace, retrying via the same poll loop if the CR doesn't exist yet.
+when `WATCH_NAMESPACE` is empty). `IntegrationCollectorConfigSeeder.resolveSearch` fixes this the
+same way: it looks up the live `Search` CR (named `OperatorName`) and uses its namespace, retrying
+via the same poll loop if the CR doesn't exist yet. It requires exactly one match rather than
+returning the first one found — `Search` is namespaced with no uniqueness webhook, so nothing at
+the API level actually prevents a duplicate — and it also carries back the CR's `search-pause`
+state, since the seeder writes cluster state just like `Reconcile` and must honor the same pause
+guarantee (checked the same way, via `IsPaused`, before any write).
+
+The same startup race also means a canonical config can already exist without
+`IntegrationTeamLabel` (e.g. state left over from before this label existed). `applyOneIntegrationCollectorConfig`
+treats a missing label the same as a spec mismatch — it's not just cosmetic: both the webhook's
+exclude-overlap check and the merge step discover integration configs by this label, so an
+unlabeled canonical config would silently stop being protected and stop being merged.
 
 As each apiGroup gets covered by a real integration config, it's removed from the temporary
 `protectedAPIGroups` safety net in the webhook (see below) — the dynamic

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,9 +52,60 @@ Allows integration teams and users to customize search-collector behaviour (reso
 
 The webhook (`api/v1alpha1/collectorconfig_webhook.go`) sets defaults and validates on admission.
 
+### Built-in integration CollectorConfigs (ACM-37052)
+
+Integration teams (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle) contribute a
+plain `CollectorConfig` YAML file to `config/integration_collector_configs/` instead of writing
+Go code. `config/integrationconfigs.go` embeds that directory (`//go:embed`) at build time.
+
+**This is seeded once per operator process, at manager startup — not on every reconcile.**
+`IntegrationCollectorConfigSeeder` (`controllers/integration_collectorconfig_seeder.go`) is a
+`manager.Runnable` added via `mgr.Add(...)` in `main.go`. Its `Start` calls
+`applyIntegrationCollectorConfigs` (`controllers/create_integration_collectorconfigs.go`), which
+walks the embedded files and for each **unconditionally creates or overwrites** the CR with that
+fixed name — no diffing against customizations, no hash, no attempt to detect "is this a new
+release." If the API/webhook isn't ready yet (a known startup race — the CollectorConfig
+webhook's CA bundle injection can take a couple of reconciles), `Start` retries on a fixed
+interval until it succeeds once, then returns; it does not use `sync.Once`, since that would
+permanently give up after a single failed attempt.
+
+Because this only runs at startup, a team can freely edit their canonical config
+(`cnv-integration-collector-config`, etc.) and it persists for the life of that pod — the reset
+only happens on the *next* restart/upgrade, at which point it's unconditionally reverted to
+whatever's currently embedded. **A team that wants a change to survive across restarts before
+it's officially shipped creates a differently-named CollectorConfig instead of editing the
+canonical one** (e.g. `cnv-integration-collector-config-2`) — the seeder only knows about its
+fixed set of embedded names, so any other name is left alone entirely, and the merge step already
+discovers integration configs by label rather than name, so it picks up any number of them
+automatically. To ship a change permanently, the team opens a PR updating their YAML in
+`config/integration_collector_configs/` — the next operator upgrade applies it to every cluster
+that hasn't switched to a differently-named override for that team.
+
+**Known accepted limitation (tech preview):** this is deliberately not a smart merge. A
+customization to the canonical name is only safe for as long as the pod doesn't restart; there's
+no attempt to distinguish "this changed because of a new release" from "this changed because
+someone edited it" — restarting always wins. There's also no cleanup path if a team removes their
+YAML file entirely: the previously-created CR becomes orphaned and is left as-is.
+
+**Namespace is discovered dynamically, not read from an env var.** `WATCH_NAMESPACE`/`POD_NAMESPACE`
+are not reliably set in real deployments — verified empty on a live ACM 5.0.0-153 install during
+testing, causing the seeder to fail with `"an empty namespace may not be set during creation"` on
+the first version of this code. The rest of the reconciler never has this problem because it
+gets its namespace from the reconciled `Search` object itself (the manager watches cluster-wide
+when `WATCH_NAMESPACE` is empty). `IntegrationCollectorConfigSeeder.resolveNamespace` fixes this
+the same way: it looks up the live `Search` CR (named `OperatorName` — there's always exactly one)
+and uses its namespace, retrying via the same poll loop if the CR doesn't exist yet.
+
+As each apiGroup gets covered by a real integration config, it's removed from the temporary
+`protectedAPIGroups` safety net in the webhook (see below) — the dynamic
+`validateExcludeAgainstIntegrationConfigs` check already protects anything with a real `include`
+rule in an integration-labeled CollectorConfig, regardless of how that CR was created.
+
 ## Reconcile flow
 
-Each reconcile call processes the `Search` CR in a fixed sequence:
+Each reconcile call processes the `Search` CR in a fixed sequence. Note: seeding the built-in
+integration CollectorConfigs (above) happens once at manager startup via
+`IntegrationCollectorConfigSeeder`, outside of this per-CR reconcile sequence entirely.
 
 1. **Addon setup** (`once.Do`) — registers the OCM addon framework once per process.
 2. **Status update** (pod events only) — updates `Search.Status` with pod readiness; skips full reconcile.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,11 +81,16 @@ automatically. To ship a change permanently, the team opens a PR updating their 
 `config/integration_collector_configs/` — the next operator upgrade applies it to every cluster
 that hasn't switched to a differently-named override for that team.
 
-**Known accepted limitation (tech preview):** this is deliberately not a smart merge. A
-customization to the canonical name is only safe for as long as the pod doesn't restart; there's
+**Preventing overwrite with `manual-override`:** to protect a customization from being reset on
+restart, annotate the config with `search.open-cluster-management.io/manual-override`. The seeder
+skips any config carrying this annotation, regardless of whether its spec differs from the shipped
+default. Remove the annotation to resume receiving updates from future operator releases.
+
+**Known accepted limitation (tech preview):** without the manual-override annotation, a
+customization to the canonical name is only safe for as long as the pod doesn't restart — there's
 no attempt to distinguish "this changed because of a new release" from "this changed because
-someone edited it" — restarting always wins. There's also no cleanup path if a team removes their
-YAML file entirely: the previously-created CR becomes orphaned and is left as-is.
+someone edited it." There's also no cleanup path if a team removes their YAML file entirely: the
+previously-created CR becomes orphaned and is left as-is.
 
 **Namespace is discovered dynamically from the Search CR, not from env vars.**
 `WATCH_NAMESPACE`/`POD_NAMESPACE` are not reliably set in all deployment paths.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ Allows integration teams and users to customize search-collector behaviour (reso
 
 The webhook (`api/v1alpha1/collectorconfig_webhook.go`) sets defaults and validates on admission.
 
-### Built-in integration CollectorConfigs (ACM-37052)
+### Built-in integration CollectorConfigs
 
 Integration teams (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle) contribute a
 plain `CollectorConfig` YAML file to `config/integration_collector_configs/` instead of writing
@@ -70,11 +70,11 @@ interval until it succeeds once, then returns; it does not use `sync.Once`, sinc
 permanently give up after a single failed attempt.
 
 Because this only runs at startup, a team can freely edit their canonical config
-(`cnv-integration-collector-config`, etc.) and it persists for the life of that pod — the reset
+(`cnv-integration`, etc.) and it persists for the life of that pod — the reset
 only happens on the *next* restart/upgrade, at which point it's unconditionally reverted to
 whatever's currently embedded. **A team that wants a change to survive across restarts before
 it's officially shipped creates a differently-named CollectorConfig instead of editing the
-canonical one** (e.g. `cnv-integration-collector-config-2`) — the seeder only knows about its
+canonical one** (e.g. `cnv-integration-2`) — the seeder only knows about its
 fixed set of embedded names, so any other name is left alone entirely, and the merge step already
 discovers integration configs by label rather than name, so it picks up any number of them
 automatically. To ship a change permanently, the team opens a PR updating their YAML in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,24 +87,10 @@ no attempt to distinguish "this changed because of a new release" from "this cha
 someone edited it" — restarting always wins. There's also no cleanup path if a team removes their
 YAML file entirely: the previously-created CR becomes orphaned and is left as-is.
 
-**Namespace is discovered dynamically, not read from an env var.** `WATCH_NAMESPACE`/`POD_NAMESPACE`
-are not reliably set in real deployments — verified empty on a live ACM 5.0.0-153 install during
-testing, causing the seeder to fail with `"an empty namespace may not be set during creation"` on
-the first version of this code. The rest of the reconciler never has this problem because it
-gets its namespace from the reconciled `Search` object itself (the manager watches cluster-wide
-when `WATCH_NAMESPACE` is empty). `IntegrationCollectorConfigSeeder.resolveSearch` fixes this the
-same way: it looks up the live `Search` CR (named `OperatorName`) and uses its namespace, retrying
-via the same poll loop if the CR doesn't exist yet. It requires exactly one match rather than
-returning the first one found — `Search` is namespaced with no uniqueness webhook, so nothing at
-the API level actually prevents a duplicate — and it also carries back the CR's `search-pause`
-state, since the seeder writes cluster state just like `Reconcile` and must honor the same pause
-guarantee (checked the same way, via `IsPaused`, before any write).
-
-The same startup race also means a canonical config can already exist without
-`IntegrationTeamLabel` (e.g. state left over from before this label existed). `applyOneIntegrationCollectorConfig`
-treats a missing label the same as a spec mismatch — it's not just cosmetic: both the webhook's
-exclude-overlap check and the merge step discover integration configs by this label, so an
-unlabeled canonical config would silently stop being protected and stop being merged.
+**Namespace is discovered dynamically from the Search CR, not from env vars.**
+`WATCH_NAMESPACE`/`POD_NAMESPACE` are not reliably set in all deployment paths.
+`resolveSearch` lists the `Search` CRs cluster-wide, finds the one named `OperatorName`, and uses
+its namespace. It also checks `search-pause` before writing, consistent with the reconciler.
 
 As each apiGroup gets covered by a real integration config, it's removed from the temporary
 `protectedAPIGroups` safety net in the webhook (see below) — the dynamic

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
+	sigs.k8s.io/yaml v1.6.0
 )
 
 replace dario.cat/mergo v1.0.1 => dario.cat/mergo v1.0.2

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func main() {
 	// in real deployments, so the seeder discovers its namespace from the live Search CR instead.
 	if err := mgr.Add(&controllers.IntegrationCollectorConfigSeeder{
 		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
 	}); err != nil {
 		setupLog.Error(err, "unable to add integration CollectorConfig seeder")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -120,6 +120,15 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
+	// Namespace is intentionally left unset — WATCH_NAMESPACE/POD_NAMESPACE are not reliably set
+	// in real deployments, so the seeder discovers its namespace from the live Search CR instead.
+	if err := mgr.Add(&controllers.IntegrationCollectorConfigSeeder{
+		Client: mgr.GetClient(),
+	}); err != nil {
+		setupLog.Error(err, "unable to add integration CollectorConfig seeder")
+		os.Exit(1)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)


### PR DESCRIPTION
## ACM-37052: Built-in integration CollectorConfigs, seeded at startup

Integration teams (CNV, OLM, GRC, Kyverno, Gatekeeper, Argo, ACM app lifecycle) can now ship a
default `CollectorConfig` by dropping a plain YAML file into
`config/integration_collector_configs/` — no Go code required. This is the follow-through on the
`protectedAPIGroups` safety net from the exclude-action work (ACM-35522), which was explicitly
temporary "until integration teams ship labeled CollectorConfig CRs." That static list shrinks
from 28 groups down to 6 now that most of it is covered by these real configs.

**Approach:** the operator embeds these YAML files at build time and, once per process at manager
startup (not on every reconcile), creates or unconditionally overwrites each one on the cluster.
Because this only happens at startup, a team can freely edit their canonical config and it
persists for the life of that pod — the next restart/upgrade resets it to whatever's currently
shipped. A team that wants a change to survive restarts before it ships officially just creates a
differently-named CollectorConfig instead (still picked up by the existing label-based merge
step) — the seeder only touches its fixed set of known names.

Full design writeup in `docs/ARCHITECTURE.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in integration `CollectorConfig` manifests for app lifecycle, Argo CD, CNV, OLM, Gatekeeper, GRC, and Kyverno.
  * Operator now seeds these configurations at startup with retry until webhook readiness; canonical configs are kept in sync while alternate overrides are preserved.
* **Bug Fixes**
  * Updated webhook validation so integration-owned exclusions are handled correctly, including for non-service-account users.
* **Documentation**
  * Expanded architecture docs for startup seeding, namespace discovery, and pause behavior.
* **Chores**
  * Build now packages the embedded integration configuration assets; lint timeout increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->