### PR TITLE
fix(security): SCC V2 compliance for postgres pod (ACM-10027)

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -122,6 +122,9 @@ func getPodSecurityContext() *corev1.PodSecurityContext {
 	trueVal := true
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot: &trueVal,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 }
 

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -113,6 +113,9 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 		corev1.VolumeMount{Name: "postgres-run", MountPath: "/var/run/postgresql"},
 		corev1.VolumeMount{Name: "postgres-tmp", MountPath: "/tmp"},
 		corev1.VolumeMount{Name: "postgres-log", MountPath: "/var/log"},
+		// /var/lib/pgsql is the home dir; startup scripts write passwd and other files here.
+		// The PVC only covers /var/lib/pgsql/data, so the parent dir needs its own writable mount.
+		corev1.VolumeMount{Name: "postgres-home", MountPath: "/var/lib/pgsql"},
 	)
 	volumes := []corev1.Volume{
 		{
@@ -158,15 +161,19 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	postgresVolume := getPostgresVolume(instance)
 	volumes = append(volumes, postgresVolume,
 		corev1.Volume{
-			Name: "postgres-run",
+			Name:         "postgres-run",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 		},
 		corev1.Volume{
-			Name: "postgres-tmp",
+			Name:         "postgres-tmp",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 		},
 		corev1.Volume{
-			Name: "postgres-log",
+			Name:         "postgres-log",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+		},
+		corev1.Volume{
+			Name:         "postgres-home",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 		},
 	)

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -108,6 +108,12 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	}
 	postgresContainer.Env = append(postgresContainer.Env, env...)
 	postgresContainer.Resources = getResourceRequirements(deploymentName, instance)
+	// emptyDir volumes required for readOnlyRootFilesystem: postgres writes to these paths at runtime
+	postgresContainer.VolumeMounts = append(postgresContainer.VolumeMounts,
+		corev1.VolumeMount{Name: "postgres-run", MountPath: "/var/run/postgresql"},
+		corev1.VolumeMount{Name: "postgres-tmp", MountPath: "/tmp"},
+		corev1.VolumeMount{Name: "postgres-log", MountPath: "/var/log"},
+	)
 	volumes := []corev1.Volume{
 		{
 			Name: "postgresql-cfg",
@@ -150,16 +156,22 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 		},
 	}
 	postgresVolume := getPostgresVolume(instance)
-	volumes = append(volumes, postgresVolume)
+	volumes = append(volumes, postgresVolume,
+		corev1.Volume{
+			Name: "postgres-run",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+		},
+		corev1.Volume{
+			Name: "postgres-tmp",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+		},
+		corev1.Volume{
+			Name: "postgres-log",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+		},
+	)
 	postgresContainer.ImagePullPolicy = getImagePullPolicy(deploymentName, instance)
-	falseVal := false
-	trueVal := true
-	postgresContainer.SecurityContext = &corev1.SecurityContext{
-		Privileged:               &falseVal,
-		AllowPrivilegeEscalation: &falseVal,
-		RunAsNonRoot:             &trueVal,
-		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-	}
+	postgresContainer.SecurityContext = getContainerSecurityContext()
 	deployment.Spec.Replicas = getReplicaCount(deploymentName, instance)
 
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()


### PR DESCRIPTION
## Summary

Addresses [ACM-10027](https://redhat.atlassian.net/browse/ACM-10027) — SCC V2 compliance for the search-postgres pod.

The 2024 comment on ACM-10027 deferred `readOnlyRootFilesystem: true` because it caused a crashloop with no tmpfs mounts. This PR adds the required mounts and completes the work.

## Changes

**`controllers/common.go` — `getPodSecurityContext()`**
- Added `seccompProfile: RuntimeDefault` — applies to all search pods (postgres, api, indexer, collector)

**`controllers/create_pgdeployment.go`**
- Switched from an inline security context (which was missing `ReadOnlyRootFilesystem`) to `getContainerSecurityContext()` for consistency with api, indexer, and collector containers
- Added 3 memory-backed `emptyDir` volumes for paths postgres writes to at runtime:
  - `/var/run/postgresql` — socket directory
  - `/tmp` — temporary files  
  - `/var/log` — log output

## SCC V2 compliance checklist (postgres pod)

| Requirement | Before | After |
|---|---|---|
| `runAsNonRoot: true` | ✅ | ✅ |
| `allowPrivilegeEscalation: false` | ✅ | ✅ |
| `capabilities.drop: [ALL]` | ✅ | ✅ |
| `readOnlyRootFilesystem: true` | ❌ | ✅ |
| `seccompProfile: RuntimeDefault` | ❌ | ✅ |

## Testing

`ok  github.com/stolostron/search-v2-operator/controllers`

## Jira

[ACM-10027](https://redhat.atlassian.net/browse/ACM-10027)

[ACM-10027]: https://redhat.atlassian.net/browse/ACM-10027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-10027]: https://redhat.atlassian.net/browse/ACM-10027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Enabled the default pod seccomp profile (`RuntimeDefault`) for PostgreSQL workloads.
  * Improved compatibility with read-only root filesystems by adding writable in-memory directories for PostgreSQL runtime needs (e.g., `/var/run/postgresql`, `/tmp`, `/var/log`, and `/var/lib/pgsql` parent).
  * Standardized PostgreSQL container security context to consistently run without elevated privileges and prevent privilege escalation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->