### PR TITLE
ACM-30184 - postgres tls profile consistency

### DIFF
--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -661,7 +661,7 @@ func TestPGDeployment(t *testing.T) {
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	r := &SearchReconciler{Client: cl, Scheme: s}
-	actualDep := r.PGDeployment(search)
+	actualDep := r.PGDeployment(search, "testhash")
 
 	// Validate Env variables
 	for _, env := range actualDep.Spec.Template.Spec.Containers[0].Env {

--- a/controllers/create_pgconfigmap.go
+++ b/controllers/create_pgconfigmap.go
@@ -3,6 +3,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"strings"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
@@ -12,7 +14,7 @@ import (
 )
 
 // PostgresConfigmap returns a configmap object for the search postgres controller for the operator.
-func (r *SearchReconciler) PostgresConfigmap(instance *searchv1alpha1.Search) *corev1.ConfigMap {
+func (r *SearchReconciler) PostgresConfigmap(instance *searchv1alpha1.Search, pgTLS PostgresTLSConfig) *corev1.ConfigMap {
 	startScript := "postgresql-start.sh"
 	ns := instance.GetNamespace()
 	cm := &corev1.ConfigMap{
@@ -29,13 +31,14 @@ func (r *SearchReconciler) PostgresConfigmap(instance *searchv1alpha1.Search) *c
 	data["custom-postgresql.conf"] = `# Customizations appended to postgresql.conf.
 `
 
-	data["postgresql.conf"] = `ssl = 'on'
+	data["postgresql.conf"] = fmt.Sprintf(`ssl = 'on'
 ssl_cert_file = '/sslcert/tls.crt'
 ssl_key_file = '/sslcert/tls.key'
-ssl_ciphers = 'HIGH:!aNULL'
+ssl_min_protocol_version = '%s'
+ssl_ciphers = '%s'
 max_parallel_workers_per_gather = '8'
 statement_timeout = '60000'
-logging_collector = 'false'`
+logging_collector = 'false'`, pgTLS.SSLMinProtocolVersion, pgTLS.SSLCiphers)
 
 	data["postgresql-pre-start.sh"] = `#!/bin/bash
 set -euo pipefail
@@ -273,4 +276,12 @@ func UpdatePostgresConfigmap(existing, new *corev1.ConfigMap) {
 			new.Data["custom-postgresql.conf"] = customPostgresConfig
 		}
 	}
+}
+
+// postgresConfigHash returns a short hex hash of postgresql.conf for use as a pod annotation.
+// custom-postgresql.conf is already merged into postgresql.conf by UpdatePostgresConfigmap,
+// and startup scripts don't require a pod restart, so only this key is hashed.
+func postgresConfigHash(data map[string]string) string {
+	sum := sha256.Sum256([]byte(data["postgresql.conf"]))
+	return fmt.Sprintf("%x", sum[:8])
 }

--- a/controllers/create_pgconfigmap_test.go
+++ b/controllers/create_pgconfigmap_test.go
@@ -2,6 +2,8 @@
 package controllers
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"testing"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
@@ -28,7 +30,10 @@ func TestPostgresConfigmapWithStatementTimeout(t *testing.T) {
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	r := &SearchReconciler{Client: cl, Scheme: s}
 
-	configMap := r.PostgresConfigmap(search)
+	configMap := r.PostgresConfigmap(search, PostgresTLSConfig{
+		SSLMinProtocolVersion: "TLSv1.2",
+		SSLCiphers:            "HIGH:!aNULL",
+	})
 
 	// Verify that statement_timeout is included in postgresql.conf
 	postgresConf := configMap.Data["postgresql.conf"]
@@ -149,4 +154,18 @@ func TestUpdatePostgresConfigmapCustomConfigAlreadyMerged(t *testing.T) {
 	// Should merge custom config with new postgresql.conf
 	expectedConf := "ssl = 'on'\nssl_cert_file = '/sslcert/tls.crt'\nstatement_timeout = '60000'\n" + customConfig
 	assert.Equal(t, expectedConf, new.Data["postgresql.conf"])
+}
+
+func TestPostgresConfigmapHash(t *testing.T) {
+	data := map[string]string{
+		"pregresql.conf":      "adsf =ghjk",
+		"postgresql.conf":     "thing = on",
+		"postpostgresql.conf": "qwer=tyui",
+	}
+	hash := sha256.Sum256([]byte(data["postgresql.conf"]))
+	expectedHash := fmt.Sprintf("%x", hash[:8])
+
+	returnedHash := postgresConfigHash(data)
+
+	assert.Equal(t, expectedHash, returnedHash)
 }

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1.Deployment {
+func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search, configHash string) *appsv1.Deployment {
 	deploymentName := postgresDeploymentName
 	image_sha := getImageSha(deploymentName, instance)
 	log.V(2).Info("Using postgres image ", "name", image_sha)
@@ -180,6 +180,12 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	postgresContainer.ImagePullPolicy = getImagePullPolicy(deploymentName, instance)
 	postgresContainer.SecurityContext = getContainerSecurityContext()
 	deployment.Spec.Replicas = getReplicaCount(deploymentName, instance)
+
+	// Annotate the pod template with a config hash so ConfigMap changes trigger a rollout.
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	deployment.Spec.Template.Annotations["search.open-cluster-management.io/postgres-config-hash"] = configHash
 
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{postgresContainer}

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -203,7 +203,20 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "Postgres Service setup failed")
 		return *result, err
 	}
-	result, err = r.createOrUpdateDeployment(ctx, r.PGDeployment(instance))
+	// Create/update the postgres ConfigMap before the Deployment so that
+	// UpdatePostgresConfigmap can merge custom-postgresql.conf into postgresql.conf
+	// and rollout the pod in the event of a changed config hash.
+	pgTLS := r.getPostgresTLSConfig(ctx)
+	pgConfigMap := r.PostgresConfigmap(instance, pgTLS)
+	result, err = r.createOrUpdateConfigMap(ctx, pgConfigMap)
+	if result != nil {
+		log.Error(err, "Postgres configmap setup failed")
+		return *result, err
+	}
+	// pgConfigMap.Data["postgresql.conf"] now contains the merged result
+	pgConfigHash := postgresConfigHash(pgConfigMap.Data)
+
+	result, err = r.createOrUpdateDeployment(ctx, r.PGDeployment(instance, pgConfigHash))
 	if result != nil {
 		log.Error(err, "Postgres Deployment setup failed")
 		return *result, err
@@ -258,11 +271,6 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createConfigMap(ctx, r.IndexerConfigmap(instance))
 	if result != nil {
 		log.Error(err, "Indexer configmap  setup failed")
-		return *result, err
-	}
-	result, err = r.createOrUpdateConfigMap(ctx, r.PostgresConfigmap(instance))
-	if result != nil {
-		log.Error(err, "Postgres configmap setup failed")
 		return *result, err
 	}
 	result, err = r.createConfigMap(ctx, r.SearchCACert(instance))

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -911,7 +911,8 @@ func TestSearch_controller_DBConfigAndEnvOverlap(t *testing.T) {
 		t.Fatalf("Failed to get configmap %s: %v", "search-postgres", err)
 	}
 	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl = 'on'")
-	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl_ciphers = 'HIGH:!aNULL'")
+	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl_ciphers = '")
+	verifyConfigmapDataContent(t, configmap, "postgresql.conf", "ssl_min_protocol_version = '")
 	verifyConfigmapDataContent(t, configmap, "postgresql-start.sh", "ALTER ROLE searchuser set work_mem='33MB'")
 
 	//check for created search-postgres deployment

--- a/controllers/tlsconfig.go
+++ b/controllers/tlsconfig.go
@@ -102,6 +102,57 @@ func defaultProfileSpec() *configv1.TLSProfileSpec {
 	return &spec
 }
 
+// PostgresTLSConfig holds PostgreSQL SSL settings derived from the cluster TLS profile.
+type PostgresTLSConfig struct {
+	SSLMinProtocolVersion string // e.g. "TLSv1.2"
+	SSLCiphers            string // colon-separated OpenSSL cipher names
+}
+
+// getPostgresTLSConfig reads the cluster TLS profile and maps it to PostgreSQL ssl_ settings.
+func (r *SearchReconciler) getPostgresTLSConfig(ctx context.Context) PostgresTLSConfig {
+	profileSpec, err := r.fetchTLSProfileSpec(ctx)
+	if err != nil {
+		log.Info("Could not read APIServer TLS profile for postgres, using Intermediate defaults")
+		profileSpec = defaultProfileSpec()
+	}
+
+	return PostgresTLSConfig{
+		SSLMinProtocolVersion: tlsVersionToPostgres(profileSpec.MinTLSVersion),
+		SSLCiphers:            opensslCiphersFromProfile(profileSpec.Ciphers),
+	}
+}
+
+// tlsVersionToPostgres maps OpenShift TLS version constants to PostgreSQL's ssl_min_protocol_version values.
+func tlsVersionToPostgres(v configv1.TLSProtocolVersion) string {
+	switch v {
+	case configv1.VersionTLS10:
+		return "TLSv1"
+	case configv1.VersionTLS11:
+		return "TLSv1.1"
+	case configv1.VersionTLS12:
+		return "TLSv1.2"
+	case configv1.VersionTLS13:
+		return "TLSv1.3"
+	default:
+		return "TLSv1.2"
+	}
+}
+
+// opensslCiphersFromProfile converts the profile's cipher list to a PostgreSQL ssl_ciphers string.
+// TLS 1.3 ciphers (TLS_ prefix) are excluded because PostgreSQL/OpenSSL manages them separately.
+func opensslCiphersFromProfile(ciphers []string) string {
+	var filtered []string
+	for _, c := range ciphers {
+		if !strings.HasPrefix(c, "TLS_") {
+			filtered = append(filtered, c)
+		}
+	}
+	if len(filtered) == 0 {
+		return "HIGH:!aNULL"
+	}
+	return strings.Join(filtered, ":")
+}
+
 // cipherIDsToIANA converts crypto/tls cipher suite IDs to IANA names using Go's stdlib.
 // No hardcoded map — automatically picks up new ciphers when Go adds them.
 func cipherIDsToIANA(ids []uint16) []string {

--- a/controllers/tlsconfig_test.go
+++ b/controllers/tlsconfig_test.go
@@ -8,14 +8,17 @@ import (
 	"strings"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -208,6 +211,181 @@ func TestDeploymentsWorkWithNilTLSEnvVars(t *testing.T) {
 
 	assert.NotContains(t, indexerNames, "TLS_MIN_VERSION")
 	assert.NotContains(t, apiNames, "TLS_MIN_VERSION")
+}
+
+func TestTlsVersionToPostgres(t *testing.T) {
+	tests := []struct {
+		input configv1.TLSProtocolVersion
+		want  string
+	}{
+		{configv1.VersionTLS10, "TLSv1"},
+		{configv1.VersionTLS11, "TLSv1.1"},
+		{configv1.VersionTLS12, "TLSv1.2"},
+		{configv1.VersionTLS13, "TLSv1.3"},
+		{"UnknownVersion", "TLSv1.2"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			assert.Equal(t, tt.want, tlsVersionToPostgres(tt.input))
+		})
+	}
+}
+
+func TestOpensslCiphersFromProfile(t *testing.T) {
+	t.Run("filters TLS 1.3 ciphers", func(t *testing.T) {
+		ciphers := []string{
+			"TLS_AES_128_GCM_SHA256",
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-RSA-AES256-GCM-SHA384",
+		}
+		result := opensslCiphersFromProfile(ciphers)
+		assert.Equal(t, "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384", result)
+	})
+
+	t.Run("all TLS 1.3 returns fallback", func(t *testing.T) {
+		assert.Equal(t, "HIGH:!aNULL", opensslCiphersFromProfile(
+			[]string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"}))
+	})
+
+	t.Run("nil returns fallback", func(t *testing.T) {
+		assert.Equal(t, "HIGH:!aNULL", opensslCiphersFromProfile(nil))
+	})
+
+	t.Run("empty returns fallback", func(t *testing.T) {
+		assert.Equal(t, "HIGH:!aNULL", opensslCiphersFromProfile([]string{}))
+	})
+
+	t.Run("no TLS 1.3 passes all through", func(t *testing.T) {
+		ciphers := []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"}
+		assert.Equal(t, "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			opensslCiphersFromProfile(ciphers))
+	})
+}
+
+func TestGetPostgresTLSConfig_Intermediate(t *testing.T) {
+	apiServer := newFakeAPIServer(map[string]interface{}{"type": "Intermediate"})
+	r := &SearchReconciler{
+		Client:        fake.NewClientBuilder().Build(),
+		Scheme:        scheme.Scheme,
+		DynamicClient: newFakeDynamicClient(apiServer),
+	}
+
+	cfg := r.getPostgresTLSConfig(context.TODO())
+
+	assert.Equal(t, "TLSv1.2", cfg.SSLMinProtocolVersion)
+	assert.NotEmpty(t, cfg.SSLCiphers)
+	assert.NotContains(t, cfg.SSLCiphers, "TLS_")
+}
+
+func TestGetPostgresTLSConfig_Old(t *testing.T) {
+	apiServer := newFakeAPIServer(map[string]interface{}{"type": "Old"})
+	r := &SearchReconciler{
+		Client:        fake.NewClientBuilder().Build(),
+		Scheme:        scheme.Scheme,
+		DynamicClient: newFakeDynamicClient(apiServer),
+	}
+
+	cfg := r.getPostgresTLSConfig(context.TODO())
+
+	assert.Equal(t, "TLSv1", cfg.SSLMinProtocolVersion)
+	assert.Contains(t, cfg.SSLCiphers, "DES-CBC3-SHA")
+}
+
+func TestGetPostgresTLSConfig_Modern(t *testing.T) {
+	apiServer := newFakeAPIServer(map[string]interface{}{"type": "Modern"})
+	r := &SearchReconciler{
+		Client:        fake.NewClientBuilder().Build(),
+		Scheme:        scheme.Scheme,
+		DynamicClient: newFakeDynamicClient(apiServer),
+	}
+
+	cfg := r.getPostgresTLSConfig(context.TODO())
+
+	assert.Equal(t, "TLSv1.3", cfg.SSLMinProtocolVersion)
+	assert.Equal(t, "HIGH:!aNULL", cfg.SSLCiphers)
+}
+
+func TestGetPostgresTLSConfig_NoAPIServer(t *testing.T) {
+	r := &SearchReconciler{
+		Client:        fake.NewClientBuilder().Build(),
+		Scheme:        scheme.Scheme,
+		DynamicClient: newFakeDynamicClient(),
+	}
+
+	cfg := r.getPostgresTLSConfig(context.TODO())
+
+	assert.Equal(t, "TLSv1.2", cfg.SSLMinProtocolVersion)
+	assert.NotEmpty(t, cfg.SSLCiphers)
+}
+
+func TestGetPostgresTLSConfig_NoProfile(t *testing.T) {
+	apiServer := newFakeAPIServer(nil)
+	r := &SearchReconciler{
+		Client:        fake.NewClientBuilder().Build(),
+		Scheme:        scheme.Scheme,
+		DynamicClient: newFakeDynamicClient(apiServer),
+	}
+
+	cfg := r.getPostgresTLSConfig(context.TODO())
+
+	assert.Equal(t, "TLSv1.2", cfg.SSLMinProtocolVersion)
+	assert.NotEmpty(t, cfg.SSLCiphers)
+}
+
+func TestPostgresConfigmapTLSSettings(t *testing.T) {
+	r := &SearchReconciler{
+		Client: fake.NewClientBuilder().Build(),
+		Scheme: scheme.Scheme,
+	}
+	cm := r.PostgresConfigmap(newTLSTestSearchInstance(), PostgresTLSConfig{
+		SSLMinProtocolVersion: "TLSv1.3",
+		SSLCiphers:            "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+	})
+
+	conf := cm.Data["postgresql.conf"]
+	assert.Contains(t, conf, "ssl_min_protocol_version = 'TLSv1.3'")
+	assert.Contains(t, conf, "ssl_ciphers = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384'")
+}
+
+func TestPostgresConfigHash_ChangesWithConfig(t *testing.T) {
+	hash1 := postgresConfigHash(map[string]string{
+		"postgresql.conf": "ssl_min_protocol_version = 'TLSv1.2'",
+	})
+	hash2 := postgresConfigHash(map[string]string{
+		"postgresql.conf": "ssl_min_protocol_version = 'TLSv1.3'",
+	})
+
+	assert.NotEqual(t, hash1, hash2)
+}
+
+func TestPostgresConfigHash_Stable(t *testing.T) {
+	data := map[string]string{"postgresql.conf": "ssl = 'on'"}
+	assert.Equal(t, postgresConfigHash(data), postgresConfigHash(data))
+}
+
+func TestPostgresConfigHash_IgnoresScripts(t *testing.T) {
+	base := map[string]string{
+		"postgresql.conf":     "ssl = 'on'",
+		"postgresql-start.sh": "echo v1",
+	}
+	modified := map[string]string{
+		"postgresql.conf":     "ssl = 'on'",
+		"postgresql-start.sh": "echo v2",
+	}
+	assert.Equal(t, postgresConfigHash(base), postgresConfigHash(modified))
+}
+
+func TestPGDeployment_ConfigHashAnnotation(t *testing.T) {
+	r := &SearchReconciler{
+		Client: fake.NewClientBuilder().Build(),
+		Scheme: scheme.Scheme,
+	}
+
+	dep := r.PGDeployment(newTLSTestSearchInstance(), "abc123")
+
+	require.NotNil(t, dep.Spec.Template.Annotations)
+	assert.Equal(t, "abc123",
+		dep.Spec.Template.Annotations["search.open-cluster-management.io/postgres-config-hash"])
 }
 
 // helpers


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-30184

### Description of changes
- Put discovered tls profile config into postgres configmap
- Rollout on postgresql.conf change through computed hash annotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL now derives TLS settings from the cluster’s API server TLS profile.
  * PostgreSQL configuration changes are detected automatically, triggering deployment updates when needed.
  * Custom PostgreSQL configuration is merged before deployment updates.

* **Bug Fixes**
  * Improved fallback behavior when TLS profile information is unavailable.
  * Added safeguards to ensure configuration change metadata is applied consistently.

* **Tests**
  * Expanded coverage for TLS settings, configuration hashing, fallback behavior, and deployment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->