### PR TITLE
Indexer's NetworkPolicy ingress from proxy server, not kube api server

### DIFF
--- a/controllers/create_networkpolicies.go
+++ b/controllers/create_networkpolicies.go
@@ -18,6 +18,7 @@ const (
 	openshiftKubeAPIServer = "openshift-kube-apiserver"
 	openshiftMonitoring    = "openshift-monitoring"
 	openshiftDNS           = "openshift-dns"
+	multiclusterEngine     = "multicluster-engine"
 )
 
 // Container ports exposed by each Search component. These match the Service definitions in
@@ -140,12 +141,14 @@ func (r *SearchReconciler) PostgresNetworkPolicy(instance *searchv1alpha1.Search
 // IndexerNetworkPolicy restricts access to the search-indexer pod.
 //
 // Rationale:
-//   - Ingress (kube-apiserver): Managed-cluster search-collector agents push discovered
-//     resources to the indexer through the hub API server's service proxy using their addon
-//     bootstrap kubeconfig, so that proxied traffic is sourced from kube-apiserver pods.
+//   - Ingress (ocm-proxyserver): Managed-cluster search-collector agents push discovered
+//     resources to the indexer through the hub API server's aggregated API for
+//     proxy.open-cluster-management.io. The kube-apiserver forwards these requests to the
+//     ocm-proxyserver (multicluster-engine namespace), which then connects to the indexer.
+//     Traffic is therefore sourced from ocm-proxyserver pods.
 //   - Ingress (hub-local collector): The hub-local search-collector deployed by this operator
 //     connects to the indexer directly (same namespace, no proxy), so its pod-selector ingress
-//     is required in addition to the kube-apiserver namespace selector above.
+//     is required in addition to the ocm-proxyserver rule above.
 //   - Ingress (monitoring): Prometheus (openshift-monitoring) scrapes indexer metrics.
 //   - Egress: The indexer writes aggregated data to search-postgres and watches hub-cluster
 //     resources directly via the Kubernetes API, in addition to resolving Service DNS names.
@@ -154,9 +157,17 @@ func (r *SearchReconciler) IndexerNetworkPolicy(instance *searchv1alpha1.Search,
 	np := newNetworkPolicy(instance, indexerDeploymentName, podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
 		{
-			// Managed-cluster collectors arrive via the kube-apiserver service proxy.
-			// The hub-local collector connects directly (same namespace), so it gets its own rule below.
-			From:  []networkingv1.NetworkPolicyPeer{namespaceSelectorPeer(openshiftKubeAPIServer)},
+			// Managed-cluster collectors arrive via ocm-proxyserver in multicluster-engine.
+			// The kube-apiserver aggregates proxy.open-cluster-management.io requests to
+			// ocm-proxyserver, which then proxies to the indexer on port 3010.
+			From: []networkingv1.NetworkPolicyPeer{{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{nsLabelKey: multiclusterEngine},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"control-plane": "ocm-proxyserver"},
+				},
+			}},
 			Ports: tcpPort(indexerPort),
 		},
 		{

--- a/controllers/create_networkpolicies_test.go
+++ b/controllers/create_networkpolicies_test.go
@@ -58,6 +58,18 @@ func containsNamespaceSelector(peers []networkingv1.NetworkPolicyPeer, namespace
 	return false
 }
 
+// containsNamespaceAndPodSelector returns true if any peer combines a namespace selector for the
+// given namespace name with a pod selector matching the given label key/value pair.
+func containsNamespaceAndPodSelector(peers []networkingv1.NetworkPolicyPeer, namespaceName, podLabelKey, podLabelValue string) bool {
+	for _, p := range peers {
+		if p.NamespaceSelector != nil && p.NamespaceSelector.MatchLabels[nsLabelKey] == namespaceName &&
+			p.PodSelector != nil && p.PodSelector.MatchLabels[podLabelKey] == podLabelValue {
+			return true
+		}
+	}
+	return false
+}
+
 // containsPodSelectorLabel returns true if any of the peers selects pods with the given label
 // key/value pair.
 func containsPodSelectorLabel(peers []networkingv1.NetworkPolicyPeer, key, value string) bool {
@@ -135,12 +147,12 @@ func TestIndexerNetworkPolicy(t *testing.T) {
 
 	assert.Equal(t, indexerDeploymentName, np.Spec.PodSelector.MatchLabels["name"])
 
-	// Ingress: from kube-apiserver (proxied managed-cluster collector traffic), the hub-local
+	// Ingress: from ocm-proxyserver (proxied managed-cluster collector traffic), the hub-local
 	// collector (direct, same-namespace connection), and monitoring (metrics).
-	var sawAPIServer, sawHubCollector, sawMonitoring bool
+	var sawProxyServer, sawHubCollector, sawMonitoring bool
 	for _, rule := range np.Spec.Ingress {
-		if containsNamespaceSelector(rule.From, openshiftKubeAPIServer) && containsTCPPort(rule.Ports, indexerPort) {
-			sawAPIServer = true
+		if containsNamespaceAndPodSelector(rule.From, multiclusterEngine, "control-plane", "ocm-proxyserver") && containsTCPPort(rule.Ports, indexerPort) {
+			sawProxyServer = true
 		}
 		if containsPodSelectorLabel(rule.From, "name", collectorDeploymentName) && containsTCPPort(rule.Ports, indexerPort) {
 			sawHubCollector = true
@@ -149,7 +161,7 @@ func TestIndexerNetworkPolicy(t *testing.T) {
 			sawMonitoring = true
 		}
 	}
-	assert.True(t, sawAPIServer, "expected ingress from kube-apiserver namespace (proxied managed-cluster collectors)")
+	assert.True(t, sawProxyServer, "expected ingress from ocm-proxyserver in multicluster-engine namespace (proxied managed-cluster collectors)")
 	assert.True(t, sawHubCollector, "expected ingress from hub-local collector pod (direct, same-namespace connection)")
 	assert.True(t, sawMonitoring, "expected ingress from openshift-monitoring namespace")
 

--- a/docs/NETWORK_POLICIES.md
+++ b/docs/NETWORK_POLICIES.md
@@ -44,7 +44,7 @@ owned by the `Search` custom resource, so they're automatically removed if Searc
 
 | Direction | Peer | Port | Rationale |
 |---|---|---|---|
-| Ingress | `openshift-kube-apiserver` namespace | 3010/TCP | Managed-cluster `search-collector` agents push discovered resources to the indexer through the hub API server's service-proxy (addon bootstrap kubeconfig), so that traffic is sourced from kube-apiserver pods. |
+| Ingress | `ocm-proxyserver` pods in `multicluster-engine` namespace | 3010/TCP | Managed-cluster `search-collector` agents push discovered resources to the indexer through the hub API server's aggregated API (`proxy.open-cluster-management.io`). The kube-apiserver forwards these requests to `ocm-proxyserver` in the `multicluster-engine` namespace, which then proxies to the indexer. Traffic is therefore sourced from `ocm-proxyserver` pods (labeled `control-plane: ocm-proxyserver`), not from kube-apiserver pods. |
 | Ingress | Pods labeled `name: search-collector` | 3010/TCP | The hub-local collector deployed by this operator runs in the same namespace and connects to the indexer directly (no proxy). |
 | Ingress | `openshift-monitoring` namespace | 3010/TCP | Prometheus (`prometheus-k8s`) scrapes indexer metrics over the same HTTPS port used for data ingestion (see the indexer `ServiceMonitor`). |
 | Egress | *(not restricted — Ingress-only policy)* | — | OVN-Kubernetes handles `kubernetes.default.svc` ClusterIP traffic via the OVN service load balancer before NetworkPolicy evaluation, so no egress rule can match kube-API traffic. Applying an Egress policyType would silently block the indexer from reaching the Kubernetes API. |


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-37751

### Description of changes
- Was getting 503's from klusterlet addon search pod. The MCE ocm-proxyserver NetworkPolicy also needs an egress to :3010 to the Indexer https://github.com/stolostron/backplane-operator/pull/3763


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow managed-cluster collector traffic through the multicluster engine proxy.

* **Documentation**
  * Updated network policy documentation to reflect the revised traffic source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->