### PR TITLE
Search SA DELETE CollectorConfigs RBAC

### DIFF
--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -268,6 +268,7 @@ spec:
           - collectorconfigs
           verbs:
           - create
+          - delete
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -230,6 +230,7 @@ rules:
   - collectorconfigs
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -90,7 +90,7 @@ var cleanOnce sync.Once
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/finalizers,verbs=update
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;update;patch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;get;list;watch;update;patch;delete
-//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=create;delete;get;list;patch
 //+kubebuilder:rbac:groups=multicluster.openshift.io,resources=multiclusterengines,verbs=get;list


### PR DESCRIPTION
### Description of changes
- Added DELETE collectorconfigs verb to Search serviceaccount to be able to delete as intended by the webhook: https://github.com/stolostron/search-v2-operator/blob/325f8b876c66fb9cdab6a23cd53d9b8a744a744f/api/v1alpha1/collectorconfig_webhook_test.go#L516-L521
- Found with @ruici-h in https://github.com/stolostron/search-e2e-test/pull/471
```
oc delete sccc app-lifecycle-integration --as="system:serviceaccount:open-cluster-management:search-v2-operator"
Error from server (Forbidden): collectorconfigs.search.open-cluster-management.io "app-lifecycle-integration" is forbidden: User "system:serviceaccount:open-cluster-management:search-v2-operator" cannot delete resource "collectorconfigs" in API group "search.open-cluster-management.io" in the namespace "open-cluster-management"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deleting collector configuration resources.
  - Updated permissions across the application to allow authorized deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->