### PR TITLE
ACM-39123 - addon search networkpolicy

### DIFF
--- a/addon/addon_test.go
+++ b/addon/addon_test.go
@@ -113,7 +113,7 @@ func TestManifest(t *testing.T) {
 			addon:                  newAddon(SearchAddonName, "cluster1", "", annotationsTest),
 			expectedNamespace:      "open-cluster-management-agent-addon",
 			expectedImage:          "quay.io/test/search_collector:test",
-			expectedCount:          5,
+			expectedCount:          6,
 			expectedLimit:          "2000Mi",
 			expectedRequest:        "1000Mi",
 			expectedArgs:           "--v=2",
@@ -127,7 +127,7 @@ func TestManifest(t *testing.T) {
 			addon:                  newAddon(SearchAddonName, "cluster1", "test", annotations250),
 			expectedNamespace:      "test",
 			expectedImage:          "quay.io/stolostron/search_collector:2.7.0",
-			expectedCount:          5,
+			expectedCount:          6,
 			expectedLimit:          "2000Mi",
 			expectedRequest:        "1000Mi",
 			expectedArgs:           "--v=2",
@@ -599,8 +599,8 @@ func TestManifestAddonAgent(t *testing.T) {
 			t.Fatalf("failed to get manifests %v", err)
 		}
 
-		if len(objects) != 5 {
-			t.Fatalf("expected 5 manifests, but %v", objects)
+		if len(objects) != 6 {
+			t.Fatalf("expected 6 manifests, but %v", objects)
 		}
 
 		c.verifyDeployment(t, objects)

--- a/addon/manifests/chart/templates/networkpolicy.yaml
+++ b/addon/manifests/chart/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "controller.fullname" . }}-network-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "controller.fullname" . }}
+    chart: {{ template "controller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: search
+spec:
+  podSelector:
+    matchLabels:
+      component: "search"
+  policyTypes:
+  - Ingress
+{{- if .Values.prometheus.enabled }}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 5010
+{{- end }}

--- a/docs/NETWORK_POLICIES.md
+++ b/docs/NETWORK_POLICIES.md
@@ -81,7 +81,7 @@ deny-all ingress — the collector has no legitimate inbound traffic in that cas
 |---|---|---|---|
 | Ingress | `openshift-monitoring` namespace *(only when `prometheus.enabled`)* | 5010/TCP | Prometheus scrapes collector metrics on the managed cluster. |
 | Ingress | *(deny-all when `prometheus.enabled` is false)* | — | The collector serves no inbound traffic other than metrics; liveness/readiness probes from the kubelet bypass NetworkPolicy. |
-| Egress | *(not restricted — Ingress-only policy)* | — | The collector needs to reach the hub's kube-apiserver (via its addon bootstrap kubeconfig) to push discovered resources to the indexer. No egress restriction is applied for the same OVN-Kubernetes reason as the hub components. |
+| Egress | *(not restricted — Ingress-only policy)* | — | The collector uses `HUB_CONFIG` to send `clusterstatuses` requests to the hub API server's `proxy.open-cluster-management.io` aggregated API, which proxies traffic to the indexer. It also watches local cluster resources via the managed cluster's Kubernetes API. Egress is not restricted because destination addresses (hub API server, local API server) vary per deployment. |
 
 ### search-v2-operator (controller-manager)
 

--- a/docs/NETWORK_POLICIES.md
+++ b/docs/NETWORK_POLICIES.md
@@ -69,6 +69,20 @@ cluster/namespace, and are out of scope for this operator's `NetworkPolicy` reco
 | Ingress | `openshift-monitoring` namespace | 5010/TCP | Prometheus scrapes collector metrics and probes the liveness/readiness endpoints. |
 | Egress | *(not restricted — Ingress-only policy)* | — | OVN-Kubernetes handles `kubernetes.default.svc` ClusterIP traffic via the OVN service load balancer before NetworkPolicy evaluation, so no egress rule can match kube-API traffic. Applying an Egress policyType would silently block the collector from reaching the Kubernetes API (resource watch). |
 
+### search-collector (managed cluster addon)
+
+Managed-cluster collectors are deployed via the addon framework (Helm chart in
+`addon/manifests/chart/templates/`). The chart is embedded in the search-v2-operator binary and
+deployed at runtime to each managed cluster's `open-cluster-management-agent-addon` namespace.
+When `prometheus.enabled` is true, Prometheus scraping is allowed; when false, the policy is
+deny-all ingress — the collector has no legitimate inbound traffic in that case.
+
+| Direction | Peer | Port | Rationale |
+|---|---|---|---|
+| Ingress | `openshift-monitoring` namespace *(only when `prometheus.enabled`)* | 5010/TCP | Prometheus scrapes collector metrics on the managed cluster. |
+| Ingress | *(deny-all when `prometheus.enabled` is false)* | — | The collector serves no inbound traffic other than metrics; liveness/readiness probes from the kubelet bypass NetworkPolicy. |
+| Egress | *(not restricted — Ingress-only policy)* | — | The collector needs to reach the hub's kube-apiserver (via its addon bootstrap kubeconfig) to push discovered resources to the indexer. No egress restriction is applied for the same OVN-Kubernetes reason as the hub components. |
+
 ### search-v2-operator (controller-manager)
 
 | Direction | Peer | Port | Rationale |


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-39123

### Description of changes
- managed cluster search collector networkpolicy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network policies to restrict inbound traffic to search components.
  * Enabled Prometheus monitoring access on TCP port 5010 when monitoring is configured.
  * Denied inbound traffic when monitoring is disabled while preserving required outbound hub API access.
  * Applied these protections automatically through the managed-cluster search collector deployment.

* **Documentation**
  * Added documentation describing the search collector’s network policy behavior and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->