### PR TITLE
ACM-39880 - ingress from console-mce networkpolicy

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -538,7 +538,7 @@ func (r *SearchReconciler) createOrUpdateNetworkPolicy(ctx context.Context,
 // reconcileNetworkPolicies creates or updates the NetworkPolicy for each Search component.
 func (r *SearchReconciler) reconcileNetworkPolicies(ctx context.Context,
 	instance *searchv1alpha1.Search) (*reconcile.Result, error) {
-	for _, np := range r.NetworkPolicies(instance, "") {
+	for _, np := range r.NetworkPolicies(ctx, instance) {
 		if result, err := r.createOrUpdateNetworkPolicy(ctx, np); result != nil {
 			return result, err
 		}

--- a/controllers/create_networkpolicies.go
+++ b/controllers/create_networkpolicies.go
@@ -186,8 +186,8 @@ func (r *SearchReconciler) IndexerNetworkPolicy(instance *searchv1alpha1.Search,
 // Rationale:
 //   - Ingress: search-v2-api serves the Search GraphQL API to other components running in the
 //     same namespace (e.g. console-api) via its ClusterIP Service, so ingress is allowed from
-//     pods in the same namespace. Prometheus (openshift-monitoring) scrapes the same port for
-//     metrics.
+//     pods in the same namespace. console-mce in the multicluster-engine namespace also
+//     consumes the API. Prometheus (openshift-monitoring) scrapes the same port for metrics.
 //   - Egress: The API queries search-postgres, and performs TokenReview/SubjectAccessReview
 //     RBAC checks and ManagedCluster lookups against the Kubernetes API, in addition to
 //     resolving Service DNS names.
@@ -198,6 +198,18 @@ func (r *SearchReconciler) APINetworkPolicy(instance *searchv1alpha1.Search, _ s
 		{
 			// Same-namespace consumers of the Search GraphQL API (e.g. console-api).
 			From:  []networkingv1.NetworkPolicyPeer{podSelectorPeer(map[string]string{})},
+			Ports: tcpPort(apiPort),
+		},
+		{
+			// console-mce in the multicluster-engine namespace.
+			From: []networkingv1.NetworkPolicyPeer{{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{nsLabelKey: multiclusterEngine},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "console-mce"},
+				},
+			}},
 			Ports: tcpPort(apiPort),
 		},
 		monitoringIngressRule(apiPort),

--- a/controllers/create_networkpolicies.go
+++ b/controllers/create_networkpolicies.go
@@ -2,6 +2,8 @@
 package controllers
 
 import (
+	"context"
+
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -152,17 +154,17 @@ func (r *SearchReconciler) PostgresNetworkPolicy(instance *searchv1alpha1.Search
 //   - Ingress (monitoring): Prometheus (openshift-monitoring) scrapes indexer metrics.
 //   - Egress: The indexer writes aggregated data to search-postgres and watches hub-cluster
 //     resources directly via the Kubernetes API, in addition to resolving Service DNS names.
-func (r *SearchReconciler) IndexerNetworkPolicy(instance *searchv1alpha1.Search, _ string) *networkingv1.NetworkPolicy {
+func (r *SearchReconciler) IndexerNetworkPolicy(instance *searchv1alpha1.Search, mceNamespace string) *networkingv1.NetworkPolicy {
 	podLabels := generateLabels("name", indexerDeploymentName)
 	np := newNetworkPolicy(instance, indexerDeploymentName, podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
 		{
-			// Managed-cluster collectors arrive via ocm-proxyserver in multicluster-engine.
+			// Managed-cluster collectors arrive via ocm-proxyserver in the MCE namespace.
 			// The kube-apiserver aggregates proxy.open-cluster-management.io requests to
 			// ocm-proxyserver, which then proxies to the indexer on port 3010.
 			From: []networkingv1.NetworkPolicyPeer{{
 				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{nsLabelKey: multiclusterEngine},
+					MatchLabels: map[string]string{nsLabelKey: mceNamespace},
 				},
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"control-plane": "ocm-proxyserver"},
@@ -191,7 +193,7 @@ func (r *SearchReconciler) IndexerNetworkPolicy(instance *searchv1alpha1.Search,
 //   - Egress: The API queries search-postgres, and performs TokenReview/SubjectAccessReview
 //     RBAC checks and ManagedCluster lookups against the Kubernetes API, in addition to
 //     resolving Service DNS names.
-func (r *SearchReconciler) APINetworkPolicy(instance *searchv1alpha1.Search, _ string) *networkingv1.NetworkPolicy {
+func (r *SearchReconciler) APINetworkPolicy(instance *searchv1alpha1.Search, mceNamespace string) *networkingv1.NetworkPolicy {
 	podLabels := generateLabels("name", apiDeploymentName)
 	np := newNetworkPolicy(instance, apiDeploymentName, podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
@@ -201,10 +203,10 @@ func (r *SearchReconciler) APINetworkPolicy(instance *searchv1alpha1.Search, _ s
 			Ports: tcpPort(apiPort),
 		},
 		{
-			// console-mce in the multicluster-engine namespace.
+			// console-mce in the MCE namespace.
 			From: []networkingv1.NetworkPolicyPeer{{
 				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{nsLabelKey: multiclusterEngine},
+					MatchLabels: map[string]string{nsLabelKey: mceNamespace},
 				},
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"app": "console-mce"},
@@ -227,7 +229,7 @@ func (r *SearchReconciler) APINetworkPolicy(instance *searchv1alpha1.Search, _ s
 //     metrics and hit the liveness/readiness endpoints.
 //   - Egress: The collector watches hub-cluster resources via the Kubernetes API and pushes
 //     discovered resources to search-indexer, in addition to resolving Service DNS names.
-func (r *SearchReconciler) CollectorNetworkPolicy(instance *searchv1alpha1.Search, _ string) *networkingv1.NetworkPolicy {
+func (r *SearchReconciler) CollectorNetworkPolicy(instance *searchv1alpha1.Search) *networkingv1.NetworkPolicy {
 	podLabels := generateLabels("name", collectorDeploymentName)
 	np := newNetworkPolicy(instance, collectorDeploymentName, podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
@@ -247,7 +249,7 @@ func (r *SearchReconciler) CollectorNetworkPolicy(instance *searchv1alpha1.Searc
 //   - Egress: The operator manages nearly every resource type used by Search (Deployments,
 //     Services, RBAC, addon framework CRs, etc.) on the hub API server, and resolves Service DNS
 //     names.
-func (r *SearchReconciler) OperatorNetworkPolicy(instance *searchv1alpha1.Search, _ string) *networkingv1.NetworkPolicy {
+func (r *SearchReconciler) OperatorNetworkPolicy(instance *searchv1alpha1.Search) *networkingv1.NetworkPolicy {
 	podLabels := map[string]string{"app": "search", "control-plane": "controller-manager"}
 	np := newNetworkPolicy(instance, "search-operator", podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
@@ -265,12 +267,20 @@ func (r *SearchReconciler) OperatorNetworkPolicy(instance *searchv1alpha1.Search
 // component pod. Each policy only selects its own component's pods (never the whole
 // namespace), so unrelated workloads sharing the namespace (e.g. other ACM components) are
 // unaffected.
-func (r *SearchReconciler) NetworkPolicies(instance *searchv1alpha1.Search, serviceCIDR string) []*networkingv1.NetworkPolicy {
+func (r *SearchReconciler) NetworkPolicies(ctx context.Context, instance *searchv1alpha1.Search) []*networkingv1.NetworkPolicy {
+	mceNamespace := multiclusterEngine
+	if r.DynamicClient != nil {
+		if ns, err := r.getMCETargetNamespace(ctx); err != nil {
+			log.V(2).Info("Could not resolve MCE target namespace, using default", "default", multiclusterEngine)
+		} else {
+			mceNamespace = ns
+		}
+	}
 	return []*networkingv1.NetworkPolicy{
 		r.PostgresNetworkPolicy(instance),
-		r.IndexerNetworkPolicy(instance, serviceCIDR),
-		r.APINetworkPolicy(instance, serviceCIDR),
-		r.CollectorNetworkPolicy(instance, serviceCIDR),
-		r.OperatorNetworkPolicy(instance, serviceCIDR),
+		r.IndexerNetworkPolicy(instance, mceNamespace),
+		r.APINetworkPolicy(instance, mceNamespace),
+		r.CollectorNetworkPolicy(instance),
+		r.OperatorNetworkPolicy(instance),
 	}
 }

--- a/controllers/create_networkpolicies_test.go
+++ b/controllers/create_networkpolicies_test.go
@@ -85,7 +85,7 @@ func TestNetworkPolicies_AllComponentsPresent(t *testing.T) {
 	search := testSearchInstance()
 	r := newTestReconcilerForNetworkPolicies(t, search)
 
-	policies := r.NetworkPolicies(search, "10.96.0.0/12")
+	policies := r.NetworkPolicies(t.Context(), search)
 	assert.Len(t, policies, 5, "expected one NetworkPolicy per Search component")
 
 	// postgresNetworkPolicyName has both Ingress and Egress policyTypes (deny-all egress).
@@ -143,7 +143,7 @@ func TestIndexerNetworkPolicy(t *testing.T) {
 	search := testSearchInstance()
 	r := newTestReconcilerForNetworkPolicies(t, search)
 
-	np := r.IndexerNetworkPolicy(search, "10.96.0.0/12")
+	np := r.IndexerNetworkPolicy(search, "multicluster-engine")
 
 	assert.Equal(t, indexerDeploymentName, np.Spec.PodSelector.MatchLabels["name"])
 
@@ -176,7 +176,7 @@ func TestAPINetworkPolicy(t *testing.T) {
 	search := testSearchInstance()
 	r := newTestReconcilerForNetworkPolicies(t, search)
 
-	np := r.APINetworkPolicy(search, "10.96.0.0/12")
+	np := r.APINetworkPolicy(search, "multicluster-engine")
 
 	assert.Equal(t, apiDeploymentName, np.Spec.PodSelector.MatchLabels["name"])
 
@@ -211,7 +211,7 @@ func TestCollectorNetworkPolicy(t *testing.T) {
 	search := testSearchInstance()
 	r := newTestReconcilerForNetworkPolicies(t, search)
 
-	np := r.CollectorNetworkPolicy(search, "10.96.0.0/12")
+	np := r.CollectorNetworkPolicy(search)
 
 	assert.Equal(t, collectorDeploymentName, np.Spec.PodSelector.MatchLabels["name"])
 	assert.Len(t, np.Spec.Ingress, 1)
@@ -229,7 +229,7 @@ func TestOperatorNetworkPolicy(t *testing.T) {
 	search := testSearchInstance()
 	r := newTestReconcilerForNetworkPolicies(t, search)
 
-	np := r.OperatorNetworkPolicy(search, "10.96.0.0/12")
+	np := r.OperatorNetworkPolicy(search)
 
 	assert.Equal(t, "controller-manager", np.Spec.PodSelector.MatchLabels["control-plane"])
 

--- a/controllers/create_networkpolicies_test.go
+++ b/controllers/create_networkpolicies_test.go
@@ -180,7 +180,7 @@ func TestAPINetworkPolicy(t *testing.T) {
 
 	assert.Equal(t, apiDeploymentName, np.Spec.PodSelector.MatchLabels["name"])
 
-	var sawSameNamespace, sawMonitoring bool
+	var sawSameNamespace, sawConsoleMCE, sawMonitoring bool
 	for _, rule := range np.Spec.Ingress {
 		if containsTCPPort(rule.Ports, apiPort) {
 			for _, from := range rule.From {
@@ -188,12 +188,16 @@ func TestAPINetworkPolicy(t *testing.T) {
 					sawSameNamespace = true
 				}
 			}
+			if containsNamespaceAndPodSelector(rule.From, multiclusterEngine, "app", "console-mce") {
+				sawConsoleMCE = true
+			}
 			if containsNamespaceSelector(rule.From, openshiftMonitoring) {
 				sawMonitoring = true
 			}
 		}
 	}
 	assert.True(t, sawSameNamespace, "expected ingress from same-namespace consumers (e.g. console-api)")
+	assert.True(t, sawConsoleMCE, "expected ingress from console-mce in multicluster-engine namespace")
 	assert.True(t, sawMonitoring, "expected ingress from openshift-monitoring namespace")
 
 	// Egress policyType is NOT set for api: OVN-Kubernetes cannot match

--- a/docs/NETWORK_POLICIES.md
+++ b/docs/NETWORK_POLICIES.md
@@ -54,6 +54,7 @@ owned by the `Search` custom resource, so they're automatically removed if Searc
 | Direction | Peer | Port | Rationale |
 |---|---|---|---|
 | Ingress | Any pod in the same namespace | 4010/TCP | The API is consumed via its ClusterIP Service (`search-search-api`) directly by same-namespace clients such as `console-api` (see `console/backend/src/lib/search.ts`, which calls `https://search-search-api.<ns>.svc.cluster.local:4010`). It is not registered as an aggregated `APIService`, so traffic arrives directly from client pods rather than being proxied through the Kubernetes API server. |
+| Ingress | `console-mce` pods in `multicluster-engine` namespace | 4010/TCP | The MCE console (`console-mce`) queries the Search GraphQL API cross-namespace to power search features in the MCE UI. |
 | Ingress | `openshift-monitoring` namespace | 4010/TCP | Prometheus scrapes API metrics over the same HTTPS port used to serve GraphQL requests. |
 | Egress | *(not restricted — Ingress-only policy)* | — | OVN-Kubernetes handles `kubernetes.default.svc` ClusterIP traffic via the OVN service load balancer before NetworkPolicy evaluation, so no egress rule can match kube-API traffic. Applying an Egress policyType would silently block the API from reaching the Kubernetes API (TokenReview/SubjectAccessReview calls). |
 


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-39880

### Description of changes
- Added ingress networkpolicy from console-mce pod in namespace multicluster-engine
```
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: multicluster-engine
      podSelector:
        matchLabels:
          app: console-mce
    ports:
    - port: 4010
      protocol: TCP
```

Before:
```
{"level":50,"time":1786019851952,"msg":"ping searchAPI timeout"}
```
After:
```
{"level":30,"time":1786020042380,"msg":"search API found"}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled the multicluster console to access the Search GraphQL API on port 4010.
  * Network access now automatically uses the detected multicluster engine namespace, with a fallback for compatibility.
* **Documentation**
  * Documented the new network access flow for the multicluster console.
* **Tests**
  * Added coverage verifying console access and namespace-aware network policies alongside existing API consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->