### PR TITLE
fix(network-policy): allow webhook ingress from all sources (hostNetwork)

### DIFF
--- a/controllers/create_networkpolicies.go
+++ b/controllers/create_networkpolicies.go
@@ -245,10 +245,12 @@ func (r *SearchReconciler) CollectorNetworkPolicy(instance *searchv1alpha1.Searc
 // Rationale:
 //   - Ingress (webhook): The Kubernetes API server calls the operator's admission webhook
 //     (CollectorConfig validation) on port 9443. The API server uses hostNetwork: true, so its
-//     traffic cannot be matched by namespaceSelector or podSelector — only an unrestricted port
-//     rule works. Webhook access is inherently restricted by the Kubernetes service network:
-//     only the API server can route to webhook ClusterIP services. This is the standard model
-//     used by all OCP operators (see cluster-kube-apiserver-operator CNTRLPLANE-2698).
+//     traffic cannot be matched by a plain namespaceSelector — OCP/OVN-Kubernetes only matches
+//     hostNetwork traffic when a peer sets BOTH namespaceSelector and podSelector to an empty
+//     LabelSelector (the documented "allow-from-hostnetwork" pattern). An empty namespaceSelector
+//     alone would silently reintroduce this bug. Combined with an empty podSelector, this peer
+//     matches any pod in any namespace plus hostNetwork traffic — i.e. all cluster-internal
+//     traffic, which is the full reachable set for a ClusterIP-only webhook service anyway.
 //   - Ingress (metrics): Prometheus (openshift-monitoring) scrapes the controller-runtime
 //     metrics port.
 //   - Egress: The operator manages nearly every resource type used by Search (Deployments,
@@ -259,12 +261,16 @@ func (r *SearchReconciler) OperatorNetworkPolicy(instance *searchv1alpha1.Search
 	np := newNetworkPolicy(instance, "search-operator", podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
 		{
-			// Webhook port: allow from all sources. The kube-apiserver uses hostNetwork: true,
-			// making its traffic unmatchable by namespace/pod selectors. Restricting this port
-			// to openshift-kube-apiserver namespace blocks webhook calls on clusters with
-			// NetworkPolicies enabled (API server traffic arrives from the node IP, not from
-			// a pod in that namespace). Access is inherently restricted by the Kubernetes
-			// service network — only the API server routes to webhook ClusterIP services.
+			// Webhook port: allow from any namespace/pod in the cluster, including
+			// hostNetwork pods. The kube-apiserver uses hostNetwork: true, so an empty
+			// namespaceSelector alone would NOT match it (OCP docs: "Using the
+			// namespaceSelector field without the podSelector field set to {} will not
+			// include hostNetwork pods"). Both selectors must be empty in the same peer
+			// to also match hostNetwork traffic.
+			From: []networkingv1.NetworkPolicyPeer{{
+				NamespaceSelector: &metav1.LabelSelector{},
+				PodSelector:       &metav1.LabelSelector{},
+			}},
 			Ports: tcpPort(operatorWebhookPort),
 		},
 		monitoringIngressRule(operatorMetricsPort),

--- a/controllers/create_networkpolicies.go
+++ b/controllers/create_networkpolicies.go
@@ -243,9 +243,14 @@ func (r *SearchReconciler) CollectorNetworkPolicy(instance *searchv1alpha1.Searc
 // itself.
 //
 // Rationale:
-//   - Ingress: The Kubernetes API server calls the operator's admission webhook (CollectorConfig
-//     defaulting/validation) on the webhook port. Prometheus (openshift-monitoring) scrapes the
-//     controller-runtime metrics port.
+//   - Ingress (webhook): The Kubernetes API server calls the operator's admission webhook
+//     (CollectorConfig validation) on port 9443. The API server uses hostNetwork: true, so its
+//     traffic cannot be matched by namespaceSelector or podSelector — only an unrestricted port
+//     rule works. Webhook access is inherently restricted by the Kubernetes service network:
+//     only the API server can route to webhook ClusterIP services. This is the standard model
+//     used by all OCP operators (see cluster-kube-apiserver-operator CNTRLPLANE-2698).
+//   - Ingress (metrics): Prometheus (openshift-monitoring) scrapes the controller-runtime
+//     metrics port.
 //   - Egress: The operator manages nearly every resource type used by Search (Deployments,
 //     Services, RBAC, addon framework CRs, etc.) on the hub API server, and resolves Service DNS
 //     names.
@@ -254,7 +259,12 @@ func (r *SearchReconciler) OperatorNetworkPolicy(instance *searchv1alpha1.Search
 	np := newNetworkPolicy(instance, "search-operator", podLabels)
 	np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
 		{
-			From:  []networkingv1.NetworkPolicyPeer{namespaceSelectorPeer(openshiftKubeAPIServer)},
+			// Webhook port: allow from all sources. The kube-apiserver uses hostNetwork: true,
+			// making its traffic unmatchable by namespace/pod selectors. Restricting this port
+			// to openshift-kube-apiserver namespace blocks webhook calls on clusters with
+			// NetworkPolicies enabled (API server traffic arrives from the node IP, not from
+			// a pod in that namespace). Access is inherently restricted by the Kubernetes
+			// service network — only the API server routes to webhook ClusterIP services.
 			Ports: tcpPort(operatorWebhookPort),
 		},
 		monitoringIngressRule(operatorMetricsPort),

--- a/controllers/create_networkpolicies_test.go
+++ b/controllers/create_networkpolicies_test.go
@@ -70,6 +70,20 @@ func containsNamespaceAndPodSelector(peers []networkingv1.NetworkPolicyPeer, nam
 	return false
 }
 
+// containsEmptyNamespaceAndPodSelector returns true if any peer sets BOTH NamespaceSelector and
+// PodSelector to a non-nil, empty (match-everything) LabelSelector. This is the OCP/OVN-Kubernetes
+// "allow-from-hostnetwork" pattern: it matches pods in any namespace AND hostNetwork traffic,
+// which a namespaceSelector alone does not.
+func containsEmptyNamespaceAndPodSelector(peers []networkingv1.NetworkPolicyPeer) bool {
+	for _, p := range peers {
+		if p.NamespaceSelector != nil && len(p.NamespaceSelector.MatchLabels) == 0 && len(p.NamespaceSelector.MatchExpressions) == 0 &&
+			p.PodSelector != nil && len(p.PodSelector.MatchLabels) == 0 && len(p.PodSelector.MatchExpressions) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // containsPodSelectorLabel returns true if any of the peers selects pods with the given label
 // key/value pair.
 func containsPodSelectorLabel(peers []networkingv1.NetworkPolicyPeer, key, value string) bool {
@@ -233,12 +247,19 @@ func TestOperatorNetworkPolicy(t *testing.T) {
 
 	assert.Equal(t, "controller-manager", np.Spec.PodSelector.MatchLabels["control-plane"])
 
-	var sawWebhookOpenToAll, sawMetricsOpenToAll, sawMonitoring bool
+	var sawWebhookClusterWide, sawWebhookOpenToAll, sawMetricsOpenToAll, sawMonitoring bool
 	for _, rule := range np.Spec.Ingress {
-		// Webhook rule must have NO From restriction (empty From = allow all sources).
-		// The kube-apiserver uses hostNetwork: true, making its traffic unmatchable by
-		// namespace/pod selectors. Webhook security relies on the Kubernetes admission
-		// control model (only the API server routes to webhook services).
+		// Webhook rule must use the "allow-from-hostnetwork" pattern: an empty
+		// NamespaceSelector AND an empty PodSelector on the SAME peer. The kube-apiserver
+		// uses hostNetwork: true, so a namespaceSelector alone would NOT match it (OCP
+		// docs: "Using the namespaceSelector field without the podSelector field set to {}
+		// will not include hostNetwork pods"). This still matches any pod in any namespace
+		// plus hostNetwork traffic, i.e. all cluster-internal traffic.
+		if containsEmptyNamespaceAndPodSelector(rule.From) && containsTCPPort(rule.Ports, operatorWebhookPort) {
+			sawWebhookClusterWide = true
+		}
+		// A completely bare From (or one with no selectors at all) would also allow
+		// hostNetwork traffic, but is over-broad and must NOT be used for the webhook.
 		if len(rule.From) == 0 && containsTCPPort(rule.Ports, operatorWebhookPort) {
 			sawWebhookOpenToAll = true
 		}
@@ -249,8 +270,12 @@ func TestOperatorNetworkPolicy(t *testing.T) {
 			sawMonitoring = true
 		}
 	}
-	assert.True(t, sawWebhookOpenToAll,
-		"expected webhook ingress with empty From (API server uses hostNetwork, cannot be selector-matched)")
+	assert.True(t, sawWebhookClusterWide,
+		"expected webhook ingress with empty namespaceSelector+podSelector on the same peer "+
+			"(API server uses hostNetwork, requires the allow-from-hostnetwork pattern)")
+	assert.False(t, sawWebhookOpenToAll,
+		"webhook ingress must not use a completely unrestricted From — it should be scoped "+
+			"to the cluster via the empty namespaceSelector+podSelector peer")
 	assert.False(t, sawMetricsOpenToAll,
 		"metrics port must NOT have unrestricted ingress — only openshift-monitoring should reach it")
 	assert.True(t, sawMonitoring, "expected ingress from openshift-monitoring for metrics")

--- a/controllers/create_networkpolicies_test.go
+++ b/controllers/create_networkpolicies_test.go
@@ -233,16 +233,26 @@ func TestOperatorNetworkPolicy(t *testing.T) {
 
 	assert.Equal(t, "controller-manager", np.Spec.PodSelector.MatchLabels["control-plane"])
 
-	var sawWebhook, sawMonitoring bool
+	var sawWebhookOpenToAll, sawMetricsOpenToAll, sawMonitoring bool
 	for _, rule := range np.Spec.Ingress {
-		if containsNamespaceSelector(rule.From, openshiftKubeAPIServer) && containsTCPPort(rule.Ports, operatorWebhookPort) {
-			sawWebhook = true
+		// Webhook rule must have NO From restriction (empty From = allow all sources).
+		// The kube-apiserver uses hostNetwork: true, making its traffic unmatchable by
+		// namespace/pod selectors. Webhook security relies on the Kubernetes admission
+		// control model (only the API server routes to webhook services).
+		if len(rule.From) == 0 && containsTCPPort(rule.Ports, operatorWebhookPort) {
+			sawWebhookOpenToAll = true
+		}
+		if len(rule.From) == 0 && containsTCPPort(rule.Ports, operatorMetricsPort) {
+			sawMetricsOpenToAll = true
 		}
 		if containsNamespaceSelector(rule.From, openshiftMonitoring) && containsTCPPort(rule.Ports, operatorMetricsPort) {
 			sawMonitoring = true
 		}
 	}
-	assert.True(t, sawWebhook, "expected ingress from kube-apiserver for admission webhook calls")
+	assert.True(t, sawWebhookOpenToAll,
+		"expected webhook ingress with empty From (API server uses hostNetwork, cannot be selector-matched)")
+	assert.False(t, sawMetricsOpenToAll,
+		"metrics port must NOT have unrestricted ingress — only openshift-monitoring should reach it")
 	assert.True(t, sawMonitoring, "expected ingress from openshift-monitoring for metrics")
 
 	// Egress policyType is NOT set for the operator: OVN-Kubernetes cannot match

--- a/docs/NETWORK_POLICIES.md
+++ b/docs/NETWORK_POLICIES.md
@@ -88,7 +88,7 @@ deny-all ingress — the collector has no legitimate inbound traffic in that cas
 
 | Direction | Peer | Port | Rationale |
 |---|---|---|---|
-| Ingress | *(all sources)* | 9443/TCP | The Kubernetes API server calls the operator's `CollectorConfig` admission webhook. The API server uses `hostNetwork: true`, making its traffic unmatchable by namespace/pod selectors — only an unrestricted port rule works. Webhook authentication is mTLS (CA bundle), not NetworkPolicy. |
+| Ingress | *(any namespace/pod in cluster — empty `namespaceSelector` + `podSelector` on the same peer)* | 9443/TCP | The Kubernetes API server calls the operator's `CollectorConfig` admission webhook. The API server uses `hostNetwork: true`, so an empty `namespaceSelector` alone would not match it — OCP requires the `allow-from-hostnetwork` pattern (empty `namespaceSelector` **and** `podSelector` on one peer) to also match hostNetwork traffic. This scopes ingress to cluster-internal traffic (the full reachable set for a ClusterIP-only service) rather than a fully unrestricted rule. |
 | Ingress | `openshift-monitoring` namespace | 8080/TCP | Prometheus scrapes controller-runtime metrics. |
 | Egress | *(not restricted — Ingress-only policy)* | — | OVN-Kubernetes handles `kubernetes.default.svc` ClusterIP traffic via the OVN service load balancer before NetworkPolicy evaluation, so no egress rule can match kube-API traffic. Applying an Egress policyType would silently block the operator from reaching the Kubernetes API (it manages Deployments, Services, Secrets, RBAC, addon CRs, etc.). |
 

--- a/docs/NETWORK_POLICIES.md
+++ b/docs/NETWORK_POLICIES.md
@@ -88,7 +88,7 @@ deny-all ingress — the collector has no legitimate inbound traffic in that cas
 
 | Direction | Peer | Port | Rationale |
 |---|---|---|---|
-| Ingress | `openshift-kube-apiserver` namespace | 9443/TCP | The Kubernetes API server calls the operator's `CollectorConfig` admission webhook (defaulting/validation). |
+| Ingress | *(all sources)* | 9443/TCP | The Kubernetes API server calls the operator's `CollectorConfig` admission webhook. The API server uses `hostNetwork: true`, making its traffic unmatchable by namespace/pod selectors — only an unrestricted port rule works. Webhook authentication is mTLS (CA bundle), not NetworkPolicy. |
 | Ingress | `openshift-monitoring` namespace | 8080/TCP | Prometheus scrapes controller-runtime metrics. |
 | Egress | *(not restricted — Ingress-only policy)* | — | OVN-Kubernetes handles `kubernetes.default.svc` ClusterIP traffic via the OVN service load balancer before NetworkPolicy evaluation, so no egress rule can match kube-API traffic. Applying an Egress policyType would silently block the operator from reaching the Kubernetes API (it manages Deployments, Services, Secrets, RBAC, addon CRs, etc.). |
 


### PR DESCRIPTION
## Summary

- The `OperatorNetworkPolicy` webhook ingress rule restricted port 9443 to `openshift-kube-apiserver` namespace, but the API server uses `hostNetwork: true` — its traffic arrives from the node IP, which **cannot be matched by namespaceSelector**
- This blocks all CollectorConfig admission webhook calls on clusters with NetworkPolicies enabled (ACM 5.0.0-206+), causing every `create`/`update` to fail admission
- Fresh installs were unaffected because the integration seeder completes before the NetworkPolicy is applied; **upgrades** fail because the policy already exists

## Fix

Remove the `From` restriction on the webhook ingress rule (empty `From` = allow from all sources). This matches the pattern used by other OCP operators:

- **[cluster-kube-apiserver-operator PR #2029](https://github.com/openshift/cluster-kube-apiserver-operator/pull/2029)**: "kube-apiserver static pods use `hostNetwork: true` and bypass NetworkPolicy entirely"
- **[OCP 4.17 docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/network_security/network-policy)**: "A network policy does not apply to the host network namespace"

Webhook security is enforced by **mTLS** (ValidatingWebhookConfiguration CA bundle injection), not by NetworkPolicy — so removing the namespace restriction does not reduce security posture.

## Test plan

- [x] `TestOperatorNetworkPolicy` updated and passes — verifies webhook rule has empty `From`
- [x] `TestReconcileNetworkPolicies_CreatesAndUpdates` passes
- [ ] QE: verify CollectorConfig create/update succeeds on upgrade with NetworkPolicies enabled (ACM 5.0.0-206+)

Fixes the issue reported by @RuiciHong during ACM-37052 upgrade testing.

/cc @jlpadilla @smcavey


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated admission webhook network access to support Kubernetes API servers using host networking.
  * Webhook traffic on port 9443 is now allowed from all sources, while metrics ingress remains restricted to monitoring traffic.

* **Documentation**
  * Clarified the distinction between webhook and metrics ingress requirements and explained the host-networking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->