### PR TITLE
ACM-34431: isolate postgres with dedicated search-postgres-sa ServiceAccount

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -84,6 +84,16 @@ func getAPIServiceAccountName() string {
 	return "search-api-sa"
 }
 
+// getPostgresServiceAccountName returns the dedicated ServiceAccount for the
+// search-postgres deployment. Postgres is a self-contained database process that
+// makes no Kubernetes API calls at runtime — it only reads its credentials and TLS
+// certificates from volumes that the kubelet mounts. Binding it to its own SA with
+// no ClusterRole grants it the minimum possible privileges (none) while keeping
+// it fully isolated from the write permissions held by the other search components.
+func getPostgresServiceAccountName() string {
+	return "search-postgres-sa"
+}
+
 func getDefaultDBConfig(varName string) string {
 	value, okay := dbDefaultMap[varName]
 	if okay {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -46,6 +46,18 @@ func TestSharedClusterRoleHasNoImpersonate(t *testing.T) {
 	}
 }
 
+// TestPostgresServiceAccountIsIsolated verifies that the postgres SA uses a dedicated
+// name distinct from the shared search SA. Postgres makes no Kubernetes API calls so
+// it intentionally carries no RBAC rules — this test asserts identity isolation only.
+func TestPostgresServiceAccountIsIsolated(t *testing.T) {
+	pgSA := getPostgresServiceAccountName()
+	if pgSA == getServiceAccountName() {
+		t.Fatalf("postgres must not share the generic search-serviceaccount (%q)", pgSA)
+	}
+	if pgSA == "" {
+		t.Fatal("postgres SA name must not be empty")
+	}
+}
 func TestGetDeploymentConfigForNil(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -190,7 +190,7 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search, configH
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{postgresContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
-	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
+	deployment.Spec.Template.Spec.ServiceAccountName = getPostgresServiceAccountName()
 
 	// Use a recreate strategy to reduce the possibility of data corruption.
 	// With the recreate strategy the existing postgres pod will be terminated before the new one starts.

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -60,6 +60,29 @@ func (r *SearchReconciler) SearchServiceAccount(instance *searchv1alpha1.Search)
 	return sa
 }
 
+// SearchPostgresServiceAccount builds the dedicated SA for the search-postgres
+// deployment. Postgres makes no Kubernetes API calls, so no ClusterRole is bound
+// to this SA — it exists solely to isolate the pod identity from the other
+// search components.
+// An error is returned when the owner reference cannot be set so that the
+// reconcile loop can abort before creating an ownerless ServiceAccount.
+func (r *SearchReconciler) SearchPostgresServiceAccount(instance *searchv1alpha1.Search) (*corev1.ServiceAccount, error) {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPostgresServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, sa, r.Scheme); err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
 // SearchAPIServiceAccount builds the dedicated SA for the search-api
 // deployment. It is the only subject bound to the search-api ClusterRole
 // carrying impersonate rights.

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -161,6 +161,16 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "SearchAPIServiceAccount setup failed")
 		return *result, err
 	}
+	postgresSA, err := r.SearchPostgresServiceAccount(instance)
+	if err != nil {
+		log.Error(err, "SearchPostgresServiceAccount build failed")
+		return ctrl.Result{}, err
+	}
+	result, err = r.createSearchServiceAccount(ctx, postgresSA)
+	if result != nil {
+		log.Error(err, "SearchPostgresServiceAccount setup failed")
+		return *result, err
+	}
 	result, err = r.createUpdateRoles(ctx, r.ClusterRole(instance))
 	if result != nil {
 		log.Error(err, "ClusterRole setup failed")


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-34431

### Description of changes

**Why postgres is special:** Unlike the other search components, `search-postgres` is a self-contained database process with no Kubernetes API client. It reads its credentials and TLS certificates exclusively from volumes mounted by the kubelet — it makes zero Kubernetes API calls at runtime.

**Change:** Introduce a dedicated `search-postgres-sa` ServiceAccount bound to **no ClusterRole** and switch the `search-postgres` Deployment to use it. This removes postgres from the shared `search-serviceaccount`, ensuring that a compromise of the database pod cannot exercise any of the write permissions held by the operator, indexer, or collector.

| File | Change |
|---|---|
| `controllers/common.go` | Added `getPostgresServiceAccountName()` → `"search-postgres-sa"` |
| `controllers/create_serviceaccount.go` | Added `SearchPostgresServiceAccount()` builder — SA only, no rules bound |
| `controllers/create_pgdeployment.go` | Switched `ServiceAccountName` to `getPostgresServiceAccountName()` |
| `controllers/search_controller.go` | Wired `SearchPostgresServiceAccount` into the reconcile loop |
| `controllers/common_test.go` | Added `TestPostgresServiceAccountIsIsolated` — asserts SA name is non-empty and distinct from the shared and API SAs |

Builds on PR #783 (`acm-34431-split-service-accounts`).
Part of ACM-34431 (FIND-001, CWE-269, CVSS 9.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * PostgreSQL workloads now run under a dedicated service account, separate from the shared search service account.
  * The dedicated account is automatically created and maintained for each deployment.
  * PostgreSQL service-account access is isolated without unnecessary role bindings.

* **Bug Fixes**
  * Improved service-account isolation for PostgreSQL components.
  * Deployments now report service-account setup failures instead of continuing with incomplete configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->