### PR TITLE
[release-2.11] ACM-38636 - CVE-2026-71472

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -4,6 +4,7 @@ package controllers
 import (
 	"context"
 	"os"
+	"regexp"
 	"strings"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
@@ -162,8 +163,16 @@ func getContainerArgs(deploymentName string, instance *searchv1alpha1.Search) []
 func getContainerEnvVar(deploymentName string, instance *searchv1alpha1.Search) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	deploymentConfig := getDeploymentConfig(deploymentName, instance)
-	if deploymentConfig.Env != nil {
-		return deploymentConfig.Env
+	if deploymentConfig.Env == nil {
+		return result
+	}
+	// For postgres, skip WORK_MEM — it is read and sanitized by GetDBConfigFromSearchCR,
+	// which handles CR env, dbconfig ConfigMap, and default priority in one place.
+	for _, e := range deploymentConfig.Env {
+		if deploymentName == postgresDeploymentName && e.Name == "WORK_MEM" {
+			continue
+		}
+		result = append(result, e)
 	}
 	return result
 }
@@ -443,7 +452,7 @@ func (r *SearchReconciler) GetDBConfigFromSearchCR(ctx context.Context,
 	for _, env := range postgresDeployConfig.Env {
 		if env.Name == configName {
 			log.Info("Set config from search CR Environment variables for postgres", configName, env.Value)
-			return env.Value
+			return sanitizeDBConfig(configName, env.Value)
 		}
 	}
 	// get value from dbconfig configmap if present
@@ -452,13 +461,33 @@ func (r *SearchReconciler) GetDBConfigFromSearchCR(ctx context.Context,
 		value, present := customMap[configName]
 		if present {
 			log.Info("Set config from dbconfig configMap ", "configMap", instance.Spec.DBConfig, configName, value)
-			return value
+			return sanitizeDBConfig(configName, value)
 		}
 	}
 	// get default value
 	defaultValue := getDefaultDBConfig(configName)
 	log.V(2).Info("Set config with default value", configName, defaultValue)
 	return defaultValue
+}
+
+// workMemPattern matches valid PostgreSQL memory-unit values (e.g. "64MB", "4096kB", "1GB", "65536").
+// Any value not matching this pattern is rejected to prevent shell/SQL injection into the
+// generated postgresql-start.sh script.
+var workMemPattern = regexp.MustCompile(`^[0-9]+(kB|MB|GB|TB)?$`)
+
+// sanitizeDBConfig validates user-supplied DB config values. Returns the default
+// if the value doesn't pass validation, preventing injection into shell scripts
+// or SQL statements.
+func sanitizeDBConfig(configName, value string) string {
+	switch configName {
+	case "WORK_MEM":
+		if !workMemPattern.MatchString(value) {
+			log.Info("Ignoring invalid WORK_MEM value; using default",
+				"value", value, "default", default_WORK_MEM)
+			return default_WORK_MEM
+		}
+	}
+	return value
 }
 
 func getDeploymentConfig(name string, instance *searchv1alpha1.Search) searchv1alpha1.DeploymentConfig {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -715,4 +716,60 @@ func TestPGDeployment(t *testing.T) {
 	if !sharedMemoryVolume.VolumeSource.EmptyDir.SizeLimit.Equal(resource.MustParse("1Gi")) { // nolint:staticcheck // "could remove embedded field 'VolumeSource' from selector"
 		t.Errorf("Expected shared volume SizeLimit to be 1Gi, but got: %+v ", sharedMemoryVolume.VolumeSource.EmptyDir.SizeLimit) // nolint:staticcheck // "could remove embedded field 'VolumeSource' from selector"
 	}
+}
+
+func TestSanitizeDBConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"valid plain number", "65536", "65536"},
+		{"valid kB", "4096kB", "4096kB"},
+		{"valid MB", "64MB", "64MB"},
+		{"valid GB", "1GB", "1GB"},
+		{"valid TB", "1TB", "1TB"},
+		{"shell injection", `64MB'; touch /tmp/pwned #`, default_WORK_MEM},
+		{"SQL injection", `64MB'; DROP TABLE search.resources; --`, default_WORK_MEM},
+		{"empty string", "", default_WORK_MEM},
+		{"wrong unit", "64mb", default_WORK_MEM},
+		{"spaces", "64 MB", default_WORK_MEM},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeDBConfig("WORK_MEM", tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPGDeploymentRejectsInvalidWorkMem(t *testing.T) {
+	malicious := `64MB'; touch /tmp/pwned #`
+	search := &searchv1alpha1.Search{
+		TypeMeta:   metav1.TypeMeta{Kind: "Search"},
+		ObjectMeta: metav1.ObjectMeta{Name: "search-v2-operator"},
+		Spec: searchv1alpha1.SearchSpec{
+			Deployments: searchv1alpha1.SearchDeployments{
+				Database: searchv1alpha1.DeploymentConfig{
+					Env: []corev1.EnvVar{{Name: "WORK_MEM", Value: malicious}},
+				},
+			},
+		},
+	}
+	s := scheme.Scheme
+	err := searchv1alpha1.SchemeBuilder.AddToScheme(s)
+	assert.NoError(t, err)
+
+	cl := fake.NewClientBuilder().WithRuntimeObjects(search).Build()
+	r := &SearchReconciler{Client: cl, Scheme: s}
+	dep := r.PGDeployment(search)
+
+	for _, env := range dep.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "WORK_MEM" {
+			assert.Equal(t, default_WORK_MEM, env.Value,
+				"invalid WORK_MEM in deployment env should fall back to default")
+			return
+		}
+	}
+	t.Error("WORK_MEM env var not found in deployment")
 }

--- a/controllers/create_pgconfigmap_test.go
+++ b/controllers/create_pgconfigmap_test.go
@@ -1,0 +1,50 @@
+// Copyright Contributors to the Open Cluster Management project
+package controllers
+
+import (
+	"testing"
+
+	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPostgresConfigmapRejectsInvalidWorkMem(t *testing.T) {
+	// WORK_MEM containing shell/SQL metacharacters must not be embedded in postgresql-start.sh.
+	malicious := `64MB'"; touch /tmp/pwned #`
+	search := &searchv1alpha1.Search{
+		TypeMeta:   metav1.TypeMeta{Kind: "Search"},
+		ObjectMeta: metav1.ObjectMeta{Name: "search-v2-operator", Namespace: "test-namespace"},
+		Spec: searchv1alpha1.SearchSpec{
+			Deployments: searchv1alpha1.SearchDeployments{
+				Database: searchv1alpha1.DeploymentConfig{
+					Env: []corev1.EnvVar{{Name: "WORK_MEM", Value: malicious}},
+				},
+			},
+		},
+	}
+	s := scheme.Scheme
+	err := searchv1alpha1.SchemeBuilder.AddToScheme(s)
+	assert.NoError(t, err)
+
+	objs := []runtime.Object{search}
+	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	r := &SearchReconciler{Client: cl, Scheme: s}
+
+	configMap := r.PostgresConfigmap(search)
+	startScript := configMap.Data["postgresql-start.sh"]
+
+	assert.NotContains(t, startScript, "touch /tmp/pwned",
+		"untrusted WORK_MEM payload must not reach postgresql-start.sh")
+	assert.Contains(t, startScript, "ALTER ROLE searchuser set work_mem='"+default_WORK_MEM+"'",
+		"invalid WORK_MEM should fall back to the default")
+
+	// Valid values are still accepted.
+	for _, valid := range []string{"64MB", "4096kB", "1GB", "65536"} {
+		assert.True(t, workMemPattern.MatchString(valid), "expected %q to be accepted", valid)
+	}
+}


### PR DESCRIPTION
This is a cherry-pick of #782 (and the fix from #788) to release-2.11.

### Related Issue
https://issues.redhat.com/browse/ACM-38636
https://nvd.nist.gov/vuln/detail/CVE-2026-71472

### Description of changes
- Added regex parsing/validation of WORK_MEM to prevent shell/SQL injection into PostgreSQL startup scripts
- Conflicts resolved: kept release-2.11's shared memory volume validation in TestPGDeployment, and skipped tests for functions not present in release-2.11

/assign smcavey