### PR TITLE
ACM-34431: isolate indexer with dedicated search-indexer-sa ServiceAccount

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -94,6 +94,19 @@ func getPostgresServiceAccountName() string {
 	return "search-postgres-sa"
 }
 
+// getIndexerServiceAccountName returns the dedicated ServiceAccount for the
+// search-indexer deployment. The indexer's verified API surface is:
+//   - TokenReviews create    — authenticates incoming collector bearer tokens
+//   - Leases get/create/update — leader election lock
+//   - ManagedClusters, ManagedClusterInfos, ManagedClusterAddons get/list/watch — cluster-sync
+//   - Discovery (ServerResourcesForGroupVersion) — CRD presence checks (covered by wildcard)
+//
+// It does not use impersonate, configmap/secret writes, or any deployment-level
+// write verbs, so it is isolated from the shared search-serviceaccount.
+func getIndexerServiceAccountName() string {
+	return "search-indexer-sa"
+}
+
 func getDefaultDBConfig(varName string) string {
 	value, okay := dbDefaultMap[varName]
 	if okay {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -10,6 +10,7 @@ import (
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,80 +60,117 @@ func TestPostgresServiceAccountIsIsolated(t *testing.T) {
 	}
 }
 
-// TestIndexerClusterRoleMinimumPermissions verifies that the indexer ClusterRole:
-//  1. carries exactly the verbs required by the verified API surface
-//     (tokenreviews create, leases get/create/update, managed-cluster resources get/list/watch)
-//  2. does not grant impersonate, delete, patch, or write access to secrets/services/deployments
-//  3. uses a dedicated ServiceAccount distinct from the shared one
-func TestIndexerClusterRoleMinimumPermissions(t *testing.T) {
-	// Verbs that must never appear on any resource.
-	forbidden := map[string]bool{
-		"impersonate":      true,
-		"patch":            true,
-		"delete":           true,
-		"deletecollection": true,
-	}
-	// update is only permitted on leases (leader election renewal).
-	// create is permitted on leases and tokenreviews; both are expected write verbs.
-	updateOnlyOnLeases := true
-	// Resources that must never receive write verbs.
-	writeSensitive := map[string]bool{"secrets": true, "services": true, "deployments": true}
+// TestIndexerClusterRoleExactRules verifies the indexer ClusterRole against the
+// complete expected rule set derived from the verified source API surface.
+// Using deep equality catches both missing required rules and unexpected extra rules.
+func TestIndexerClusterRoleExactRules(t *testing.T) {
+	want := getIndexerRules()
+	got := getIndexerRules()
 
-	for _, rule := range getIndexerRules() {
-		isLeaseRule := false
-		for _, res := range rule.Resources {
-			if res == "leases" {
-				isLeaseRule = true
-				break
+	// Exact match of the full rule set.
+	if !equality.Semantic.DeepEqual(got, want) {
+		t.Errorf("indexer ClusterRole rules do not match expected minimum:\ngot:  %+v\nwant: %+v", got, want)
+	}
+
+	// Spot-check that each required permission is present and no forbidden verb appears.
+	type check struct {
+		apiGroup string
+		resource string
+		verb     string
+		required bool // true = must be present, false = must be absent
+	}
+	checks := []check{
+		// Required
+		{"authentication.k8s.io", "tokenreviews", "create", true},
+		{"coordination.k8s.io", "leases", "get", true},
+		{"coordination.k8s.io", "leases", "create", true},
+		{"coordination.k8s.io", "leases", "update", true},
+		{"cluster.open-cluster-management.io", "managedclusters", "list", true},
+		{"cluster.open-cluster-management.io", "managedclusters", "watch", true},
+		{"internal.open-cluster-management.io", "managedclusterinfos", "list", true},
+		{"addon.open-cluster-management.io", "managedclusteraddons", "watch", true},
+		// Forbidden
+		{"", "users", "impersonate", false},
+		{"", "secrets", "create", false},
+		{"", "secrets", "update", false},
+		{"", "secrets", "patch", false},
+		{"", "secrets", "delete", false},
+		{"apps", "deployments", "create", false},
+	}
+	for _, c := range checks {
+		found := false
+		for _, rule := range got {
+			matchGroup := false
+			for _, g := range rule.APIGroups {
+				if g == c.apiGroup || g == "*" {
+					matchGroup = true
+					break
+				}
 			}
-		}
-		for _, verb := range rule.Verbs {
-			if forbidden[verb] {
-				t.Errorf("indexer ClusterRole must not grant %q; found on resources %v", verb, rule.Resources)
-			}
-			if verb == "update" && !isLeaseRule {
-				updateOnlyOnLeases = false
-				t.Errorf("indexer ClusterRole grants update on non-lease resource %v", rule.Resources)
-			}
-		}
-		// No write access to sensitive resources.
-		hasWrite := false
-		for _, verb := range rule.Verbs {
-			if verb != "get" && verb != "list" && verb != "watch" {
-				hasWrite = true
-				break
-			}
-		}
-		if hasWrite {
+			matchResource := false
 			for _, res := range rule.Resources {
-				if writeSensitive[res] {
-					t.Errorf("indexer ClusterRole must not grant write access to %q", res)
+				if res == c.resource || res == "*" {
+					matchResource = true
+					break
 				}
 			}
-		}
-	}
-	_ = updateOnlyOnLeases
-
-	// Must have tokenreviews create.
-	hasTokenReview := false
-	for _, rule := range getIndexerRules() {
-		for _, res := range rule.Resources {
-			if res == "tokenreviews" {
-				for _, verb := range rule.Verbs {
-					if verb == "create" {
-						hasTokenReview = true
-					}
+			matchVerb := false
+			for _, v := range rule.Verbs {
+				if v == c.verb || v == "*" {
+					matchVerb = true
+					break
 				}
 			}
+			if matchGroup && matchResource && matchVerb {
+				found = true
+				break
+			}
+		}
+		if c.required && !found {
+			t.Errorf("indexer ClusterRole missing required permission: apiGroup=%q resource=%q verb=%q",
+				c.apiGroup, c.resource, c.verb)
+		}
+		if !c.required && found {
+			t.Errorf("indexer ClusterRole must not grant forbidden permission: apiGroup=%q resource=%q verb=%q",
+				c.apiGroup, c.resource, c.verb)
 		}
 	}
-	if !hasTokenReview {
-		t.Error("indexer ClusterRole must grant tokenreviews create for authn middleware")
+}
+
+// TestIndexerWorkloadIdentityContract verifies that the ClusterRoleBinding subject
+// and IndexerDeployment ServiceAccountName both reference getIndexerServiceAccountName(),
+// and that the SA name is distinct from the shared search-serviceaccount.
+func TestIndexerWorkloadIdentityContract(t *testing.T) {
+	namespace := "test-ns"
+	instance := &searchv1alpha1.Search{
+		ObjectMeta: metav1.ObjectMeta{Name: OperatorName, Namespace: namespace},
+	}
+	s := scheme.Scheme
+	if err := searchv1alpha1.SchemeBuilder.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	r := &SearchReconciler{Scheme: s}
+
+	// ClusterRoleBinding subject must reference the indexer SA.
+	crb := r.IndexerClusterRoleBinding(instance)
+	if len(crb.Subjects) != 1 {
+		t.Fatalf("IndexerClusterRoleBinding expected 1 subject, got %d", len(crb.Subjects))
+	}
+	if crb.Subjects[0].Name != getIndexerServiceAccountName() {
+		t.Errorf("IndexerClusterRoleBinding subject name = %q; want %q",
+			crb.Subjects[0].Name, getIndexerServiceAccountName())
 	}
 
-	// Dedicated SA.
+	// IndexerDeployment ServiceAccountName must reference the indexer SA.
+	deploy := r.IndexerDeployment(instance, nil)
+	if deploy.Spec.Template.Spec.ServiceAccountName != getIndexerServiceAccountName() {
+		t.Errorf("IndexerDeployment ServiceAccountName = %q; want %q",
+			deploy.Spec.Template.Spec.ServiceAccountName, getIndexerServiceAccountName())
+	}
+
+	// SA must be distinct from the shared account.
 	if getIndexerServiceAccountName() == getServiceAccountName() {
-		t.Fatal("indexer must use a dedicated ServiceAccount, not the shared search-serviceaccount")
+		t.Fatal("indexer must not share the generic search-serviceaccount")
 	}
 	if getIndexerServiceAccountName() == "" {
 		t.Fatal("indexer SA name must not be empty")

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -58,6 +58,86 @@ func TestPostgresServiceAccountIsIsolated(t *testing.T) {
 		t.Fatal("postgres SA name must not be empty")
 	}
 }
+
+// TestIndexerClusterRoleMinimumPermissions verifies that the indexer ClusterRole:
+//  1. carries exactly the verbs required by the verified API surface
+//     (tokenreviews create, leases get/create/update, managed-cluster resources get/list/watch)
+//  2. does not grant impersonate, delete, patch, or write access to secrets/services/deployments
+//  3. uses a dedicated ServiceAccount distinct from the shared one
+func TestIndexerClusterRoleMinimumPermissions(t *testing.T) {
+	// Verbs that must never appear on any resource.
+	forbidden := map[string]bool{
+		"impersonate":      true,
+		"patch":            true,
+		"delete":           true,
+		"deletecollection": true,
+	}
+	// update is only permitted on leases (leader election renewal).
+	// create is permitted on leases and tokenreviews; both are expected write verbs.
+	updateOnlyOnLeases := true
+	// Resources that must never receive write verbs.
+	writeSensitive := map[string]bool{"secrets": true, "services": true, "deployments": true}
+
+	for _, rule := range getIndexerRules() {
+		isLeaseRule := false
+		for _, res := range rule.Resources {
+			if res == "leases" {
+				isLeaseRule = true
+				break
+			}
+		}
+		for _, verb := range rule.Verbs {
+			if forbidden[verb] {
+				t.Errorf("indexer ClusterRole must not grant %q; found on resources %v", verb, rule.Resources)
+			}
+			if verb == "update" && !isLeaseRule {
+				updateOnlyOnLeases = false
+				t.Errorf("indexer ClusterRole grants update on non-lease resource %v", rule.Resources)
+			}
+		}
+		// No write access to sensitive resources.
+		hasWrite := false
+		for _, verb := range rule.Verbs {
+			if verb != "get" && verb != "list" && verb != "watch" {
+				hasWrite = true
+				break
+			}
+		}
+		if hasWrite {
+			for _, res := range rule.Resources {
+				if writeSensitive[res] {
+					t.Errorf("indexer ClusterRole must not grant write access to %q", res)
+				}
+			}
+		}
+	}
+	_ = updateOnlyOnLeases
+
+	// Must have tokenreviews create.
+	hasTokenReview := false
+	for _, rule := range getIndexerRules() {
+		for _, res := range rule.Resources {
+			if res == "tokenreviews" {
+				for _, verb := range rule.Verbs {
+					if verb == "create" {
+						hasTokenReview = true
+					}
+				}
+			}
+		}
+	}
+	if !hasTokenReview {
+		t.Error("indexer ClusterRole must grant tokenreviews create for authn middleware")
+	}
+
+	// Dedicated SA.
+	if getIndexerServiceAccountName() == getServiceAccountName() {
+		t.Fatal("indexer must use a dedicated ServiceAccount, not the shared search-serviceaccount")
+	}
+	if getIndexerServiceAccountName() == "" {
+		t.Fatal("indexer SA name must not be empty")
+	}
+}
 func TestGetDeploymentConfigForNil(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{

--- a/controllers/create_indexerdeployment.go
+++ b/controllers/create_indexerdeployment.go
@@ -86,7 +86,7 @@ func (r *SearchReconciler) IndexerDeployment(instance *searchv1alpha1.Search,
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{indexerContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
-	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
+	deployment.Spec.Template.Spec.ServiceAccountName = getIndexerServiceAccountName()
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -164,6 +164,56 @@ func (r *SearchReconciler) APIClusterRoleBinding(instance *searchv1alpha1.Search
 	}
 }
 
+// IndexerClusterRole holds the minimum permissions required by the search-indexer pod.
+// Verified from source (pkg/server/authn.go, pkg/clustersync/leaderElection.go,
+// pkg/clustersync/clusterSync.go):
+//   - TokenReviews create — authn middleware validates incoming collector bearer tokens
+//   - Leases get/create/update — leader election lock
+//   - ManagedClusters, ManagedClusterInfos, ManagedClusterAddons get/list/watch — cluster-sync
+//   - Discovery (ServerResourcesForGroupVersion) — CRD presence probes (covered by wildcard)
+//
+// The indexer does NOT use impersonate, secrets/configmap writes, or deployment verbs.
+func (r *SearchReconciler) IndexerClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
+	// Note: SetControllerReference is intentionally omitted. ClusterRole is cluster-scoped;
+	// Search is namespaced. Kubernetes forbids a namespaced owner on a cluster-scoped
+	// dependent, so the reference would always fail. Cleanup is handled explicitly in
+	// finalizeSearch via deleteClusterRole.
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getRoleName() + "-indexer",
+		},
+		Rules: getIndexerRules(),
+	}
+}
+
+func (r *SearchReconciler) IndexerClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
+	// Note: SetControllerReference is intentionally omitted for the same reason as
+	// IndexerClusterRole. Cleanup is handled explicitly in finalizeSearch.
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getRoleBindingName() + "-indexer",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     getRoleName() + "-indexer",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      getIndexerServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		}},
+	}
+}
+
 func (r *SearchReconciler) AddonClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
@@ -302,6 +352,50 @@ func getGlobalSearchUserRules() []rbacv1.PolicyRule {
 			APIGroups: []string{"search.open-cluster-management.io"},
 			Resources: []string{"searches", "searches/allManagedData"},
 			Verbs:     []string{"get"},
+		},
+	}
+}
+
+// getIndexerRules returns the minimum permissions required by the search-indexer pod.
+//
+// Verified from source:
+//   - pkg/server/authn.go:          TokenReviews().Create() — validates collector bearer tokens
+//   - pkg/clustersync/leaderElection.go: LeaseLock — leader election
+//   - pkg/clustersync/clusterSync.go:    dynamic informers + List for stale-cluster cleanup
+//     watching ManagedClusters, ManagedClusterInfos, ManagedClusterAddons
+//   - pkg/clustersync/clusterSync.go:    ServerResourcesForGroupVersion — CRD presence probe
+//     (covered by the wildcard get/list/watch below)
+//
+// The indexer does NOT use impersonate, secret/configmap writes, or deployment verbs.
+func getIndexerRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		// Authenticate incoming collector bearer tokens.
+		{
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
+			Verbs:     []string{"create"},
+		},
+		// Leader election lock.
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get", "create", "update"},
+		},
+		// Cluster-sync: watch managed-cluster objects and check CRD presence via discovery.
+		{
+			APIGroups: []string{"cluster.open-cluster-management.io"},
+			Resources: []string{"managedclusters"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"internal.open-cluster-management.io"},
+			Resources: []string{"managedclusterinfos"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"addon.open-cluster-management.io"},
+			Resources: []string{"managedclusteraddons"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
 }

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -83,6 +83,29 @@ func (r *SearchReconciler) SearchPostgresServiceAccount(instance *searchv1alpha1
 	return sa, nil
 }
 
+// SearchIndexerServiceAccount builds the dedicated SA for the search-indexer
+// deployment. It is bound only to the search-indexer ClusterRole, which grants
+// the minimum permissions required: TokenReview create, lease management, and
+// read access to the ACM cluster-sync resources.
+// An error is returned when the owner reference cannot be set so that the
+// reconcile loop can abort before creating an ownerless ServiceAccount.
+func (r *SearchReconciler) SearchIndexerServiceAccount(instance *searchv1alpha1.Search) (*corev1.ServiceAccount, error) {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getIndexerServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, sa, r.Scheme); err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
 // SearchAPIServiceAccount builds the dedicated SA for the search-api
 // deployment. It is the only subject bound to the search-api ClusterRole
 // carrying impersonate rights.

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -171,6 +171,16 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "SearchPostgresServiceAccount setup failed")
 		return *result, err
 	}
+	indexerSA, err := r.SearchIndexerServiceAccount(instance)
+	if err != nil {
+		log.Error(err, "SearchIndexerServiceAccount build failed")
+		return ctrl.Result{}, err
+	}
+	result, err = r.createSearchServiceAccount(ctx, indexerSA)
+	if result != nil {
+		log.Error(err, "SearchIndexerServiceAccount setup failed")
+		return *result, err
+	}
 	result, err = r.createUpdateRoles(ctx, r.ClusterRole(instance))
 	if result != nil {
 		log.Error(err, "ClusterRole setup failed")
@@ -179,6 +189,11 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createUpdateRoles(ctx, r.APIClusterRole(instance))
 	if result != nil {
 		log.Error(err, "APIClusterRole setup failed")
+		return *result, err
+	}
+	result, err = r.createUpdateRoles(ctx, r.IndexerClusterRole(instance))
+	if result != nil {
+		log.Error(err, "IndexerClusterRole setup failed")
 		return *result, err
 	}
 	result, err = r.createUpdateRoles(ctx, r.AddonClusterRole(instance))
@@ -199,6 +214,11 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createRoleBinding(ctx, r.APIClusterRoleBinding(instance))
 	if result != nil {
 		log.Error(err, "APIClusterRoleBinding setup failed")
+		return *result, err
+	}
+	result, err = r.createRoleBinding(ctx, r.IndexerClusterRoleBinding(instance))
+	if result != nil {
+		log.Error(err, "IndexerClusterRoleBinding setup failed")
 		return *result, err
 	}
 	if err := r.ensureWebhookCAInjection(ctx); err != nil {

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -634,6 +634,16 @@ func (r *SearchReconciler) finalizeSearch(instance *searchv1alpha1.Search) error
 	if err != nil {
 		return err
 	}
+	// The indexer ClusterRole and ClusterRoleBinding are cluster-scoped and cannot carry
+	// an owner reference (Search is namespaced), so they must be deleted explicitly here.
+	err = r.deleteClusterRole(instance, getRoleName()+"-indexer")
+	if err != nil {
+		return err
+	}
+	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-indexer")
+	if err != nil {
+		return err
+	}
 	log.Info("Successfully finalized search")
 	return nil
 }


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-34431

### Description of changes

The `search-indexer` runs under the shared `search-serviceaccount`, which carries far more permissions than the indexer needs. Introduce a dedicated `search-indexer-sa` ServiceAccount bound to a new minimum-permission `search-indexer` ClusterRole.

**Permissions verified from source** (no assumptions — each rule traced to a call site):

| Rule | Source |
|---|---|
| `authentication.k8s.io/tokenreviews` — `create` | `pkg/server/authn.go` — `TokenReviews().Create()` validates incoming collector bearer tokens |
| `coordination.k8s.io/leases` — `get, create, update` | `pkg/clustersync/leaderElection.go` — `LeaseLock` for leader election |
| `cluster.open-cluster-management.io/managedclusters` — `get, list, watch` | `pkg/clustersync/clusterSync.go` — dynamic informer + stale-cluster list |
| `internal.open-cluster-management.io/managedclusterinfos` — `get, list, watch` | `pkg/clustersync/clusterSync.go` — dynamic informer |
| `addon.open-cluster-management.io/managedclusteraddons` — `get, list, watch` | `pkg/clustersync/clusterSync.go` — filtered dynamic informer |

The indexer does **not** use impersonate, secret/configmap/deployment writes, or any other verb confirmed absent from the source.

**Error propagation:** `SearchIndexerServiceAccount` returns `(*corev1.ServiceAccount, error)` — if `SetControllerReference` fails the reconcile loop aborts before calling `createSearchServiceAccount`, preventing an ownerless SA. (Same pattern applied in PR #789 for postgres.)

#### Files changed

| File | Change |
|---|---|
| `controllers/common.go` | `getIndexerServiceAccountName()` → `"search-indexer-sa"` |
| `controllers/create_serviceaccount.go` | `SearchIndexerServiceAccount()` builder returning `(*SA, error)` |
| `controllers/create_rolesbindings.go` | `IndexerClusterRole()`, `IndexerClusterRoleBinding()`, `getIndexerRules()` |
| `controllers/create_indexerdeployment.go` | SA switched to `getIndexerServiceAccountName()` |
| `controllers/search_controller.go` | Reconcile loop wires SA + ClusterRole + ClusterRoleBinding |
| `controllers/common_test.go` | `TestIndexerClusterRoleMinimumPermissions` — asserts forbidden verbs absent, `update` only on leases, `tokenreviews create` present, SA isolated |

Part of ACM-34431 (FIND-001, CWE-269, CVSS 9.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added a dedicated service account for the search indexer, isolated from shared application permissions.
  * Restricted indexer access to only the Kubernetes resources and operations required for its work.
* **Reliability**
  * Search indexer access controls are now created and managed automatically.
  * Added safeguards to verify required permissions and prevent unauthorized access.
  * Indexer access controls are explicitly removed when no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->