### PR TITLE
[release-2.17] ACM-34431: split impersonate into dedicated search-api ServiceAccount

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -75,7 +75,7 @@ func getServiceAccountName() string {
 // which share the generic search-serviceaccount — cannot escalate to
 // system:masters via their mounted token.
 func getAPIServiceAccountName() string {
-	return "search-api-serviceaccount"
+	return "search-api-sa"
 }
 
 func getDefaultDBConfig(varName string) string {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -69,6 +69,15 @@ func getServiceAccountName() string {
 	return "search-serviceaccount"
 }
 
+// getAPIServiceAccountName returns the dedicated ServiceAccount used only by
+// the search-api deployment. Impersonation rights (users/groups/serviceaccounts)
+// are bound to this SA alone so that the postgres, indexer and collector pods —
+// which share the generic search-serviceaccount — cannot escalate to
+// system:masters via their mounted token.
+func getAPIServiceAccountName() string {
+	return "search-api-serviceaccount"
+}
+
 func getDefaultDBConfig(varName string) string {
 	value, okay := dbDefaultMap[varName]
 	if okay {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -18,6 +18,34 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestSharedClusterRoleHasNoImpersonate(t *testing.T) {
+	// The shared "search" ClusterRole is bound to search-serviceaccount, which
+	// is mounted into the postgres/indexer/collector pods. It must not carry
+	// impersonate; that verb is isolated on the search-api ClusterRole which is
+	// bound only to search-api-serviceaccount.
+	for _, rule := range getRules() {
+		for _, v := range rule.Verbs {
+			if v == "impersonate" {
+				t.Fatalf("shared search ClusterRole must not grant impersonate; found on %v", rule.Resources)
+			}
+		}
+	}
+	hasImpersonate := false
+	for _, rule := range getAPIRules() {
+		for _, v := range rule.Verbs {
+			if v == "impersonate" {
+				hasImpersonate = true
+			}
+		}
+	}
+	if !hasImpersonate {
+		t.Fatal("search-api ClusterRole expected to carry impersonate")
+	}
+	if getAPIServiceAccountName() == getServiceAccountName() {
+		t.Fatal("search-api must use a dedicated ServiceAccount")
+	}
+}
+
 func TestGetDeploymentConfigForNil(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -22,7 +22,7 @@ func TestSharedClusterRoleHasNoImpersonate(t *testing.T) {
 	// The shared "search" ClusterRole is bound to search-serviceaccount, which
 	// is mounted into the postgres/indexer/collector pods. It must not carry
 	// impersonate; that verb is isolated on the search-api ClusterRole which is
-	// bound only to search-api-serviceaccount.
+	// bound only to search-api-sa.
 	for _, rule := range getRules() {
 		for _, v := range rule.Verbs {
 			if v == "impersonate" {

--- a/controllers/create_apideployment.go
+++ b/controllers/create_apideployment.go
@@ -81,7 +81,7 @@ func (r *SearchReconciler) APIDeployment(instance *searchv1alpha1.Search) *appsv
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{apiContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
-	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
+	deployment.Spec.Template.Spec.ServiceAccountName = getAPIServiceAccountName()
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -23,6 +23,10 @@ func (r *SearchReconciler) createUpdateRoles(ctx context.Context,
 		Name:      crole.Name,
 		Namespace: crole.Namespace,
 	}, existingClusterRole)
+	if err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "Could not get clusterrole", "clusterrole", crole.Name)
+		return &reconcile.Result{}, err
+	}
 	if err != nil && errors.IsNotFound(err) {
 		err = r.Create(ctx, crole)
 		if err != nil {

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -124,7 +124,11 @@ func (r *SearchReconciler) ClusterRoleBinding(instance *searchv1alpha1.Search) *
 // postgres, indexer and collector pods (which share search-serviceaccount)
 // cannot escalate to system:masters via their mounted token.
 func (r *SearchReconciler) APIClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
-	cr := &rbacv1.ClusterRole{
+	// Note: SetControllerReference is intentionally omitted. ClusterRole is cluster-scoped;
+	// Search is namespaced. Kubernetes forbids a namespaced owner on a cluster-scoped
+	// dependent, so the reference would always fail. Cleanup is handled explicitly in
+	// finalizeSearch via deleteClusterRole.
+	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRole",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -134,14 +138,12 @@ func (r *SearchReconciler) APIClusterRole(instance *searchv1alpha1.Search) *rbac
 		},
 		Rules: getAPIRules(),
 	}
-	if err := controllerutil.SetControllerReference(instance, cr, r.Scheme); err != nil {
-		log.Info("Could not set control for ClusterRole " + cr.Name)
-	}
-	return cr
 }
 
 func (r *SearchReconciler) APIClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
-	crb := &rbacv1.ClusterRoleBinding{
+	// Note: SetControllerReference is intentionally omitted for the same reason as
+	// APIClusterRole. Cleanup is handled explicitly in finalizeSearch.
+	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -160,10 +162,6 @@ func (r *SearchReconciler) APIClusterRoleBinding(instance *searchv1alpha1.Search
 			Namespace: instance.GetNamespace(),
 		}},
 	}
-	if err := controllerutil.SetControllerReference(instance, crb, r.Scheme); err != nil {
-		log.Info("Could not set control for ClusterRoleBinding " + crb.Name)
-	}
-	return crb
 }
 
 func (r *SearchReconciler) AddonClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -32,13 +32,14 @@ func (r *SearchReconciler) createUpdateRoles(ctx context.Context,
 		log.Info("Created clusterrole " + crole.Name)
 		log.V(9).Info("Created clusterrole ", "clusterrole", crole)
 	} else if !equality.Semantic.DeepEqual(existingClusterRole.Rules, crole.Rules) {
-		err = r.Update(ctx, crole)
+		existingClusterRole.Rules = crole.Rules
+		err = r.Update(ctx, existingClusterRole)
 		if err != nil {
 			log.Error(err, "Could not update clusterrole "+crole.Name)
 			return &reconcile.Result{}, err
 		}
 		log.Info("Updated clusterrole " + crole.Name)
-		log.V(9).Info("Updated clusterrole ", "clusterrole", crole)
+		log.V(9).Info("Updated clusterrole ", "clusterrole", existingClusterRole)
 	}
 	return nil, nil
 }

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -60,6 +60,13 @@ func (r *SearchReconciler) createRoleBinding(ctx context.Context,
 		}
 		log.Info("Created clusterrolebinding " + rolebinding.Name)
 		log.V(2).Info("Created clusterrolebinding ", "clusterrolebinding", rolebinding)
+	} else if err == nil && !equality.Semantic.DeepEqual(found.Subjects, rolebinding.Subjects) {
+		found.Subjects = rolebinding.Subjects
+		if err = r.Update(ctx, found); err != nil {
+			log.Error(err, "Could not update clusterrolebinding "+rolebinding.Name)
+			return &reconcile.Result{}, err
+		}
+		log.Info("Updated clusterrolebinding " + rolebinding.Name)
 	}
 	return nil, nil
 }
@@ -107,6 +114,53 @@ func (r *SearchReconciler) ClusterRoleBinding(instance *searchv1alpha1.Search) *
 	return crb
 }
 
+// APIClusterRole holds the impersonation rights that only search-api needs.
+// It is bound exclusively to the search-api ServiceAccount so that the
+// postgres, indexer and collector pods (which share search-serviceaccount)
+// cannot escalate to system:masters via their mounted token.
+func (r *SearchReconciler) APIClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
+	cr := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getRoleName() + "-api",
+		},
+		Rules: getAPIRules(),
+	}
+	if err := controllerutil.SetControllerReference(instance, cr, r.Scheme); err != nil {
+		log.Info("Could not set control for ClusterRole " + cr.Name)
+	}
+	return cr
+}
+
+func (r *SearchReconciler) APIClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
+	crb := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getRoleBindingName() + "-api",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     getRoleName() + "-api",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      getAPIServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		}},
+	}
+	if err := controllerutil.SetControllerReference(instance, crb, r.Scheme); err != nil {
+		log.Info("Could not set control for ClusterRoleBinding " + crb.Name)
+	}
+	return crb
+}
+
 func (r *SearchReconciler) AddonClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
@@ -136,11 +190,17 @@ func (r *SearchReconciler) GlobalSearchUserClusterRole(instance *searchv1alpha1.
 }
 
 func getSubjects(namespace string) []rbacv1.Subject {
-	return []rbacv1.Subject{{
-		Kind:      "ServiceAccount",
-		Name:      getServiceAccountName(),
-		Namespace: namespace,
-	},
+	return []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      getServiceAccountName(),
+			Namespace: namespace,
+		},
+		{
+			Kind:      "ServiceAccount",
+			Name:      getAPIServiceAccountName(),
+			Namespace: namespace,
+		},
 	}
 }
 
@@ -176,6 +236,20 @@ func getRules() []rbacv1.PolicyRule {
 			Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews"},
 			Verbs:     []string{"create"},
 		},
+		{
+			APIGroups: []string{"search.open-cluster-management.io"},
+			Resources: []string{"collectorconfigs/status"},
+			Verbs:     []string{"patch", "update"},
+		},
+	}
+}
+
+// getAPIRules returns the rules bound only to the search-api ServiceAccount.
+// These are layered on top of getRules() (search-api is also bound to the
+// shared "search" ClusterRole) and isolate the impersonation rights that
+// search-api uses for user-scoped query authorization.
+func getAPIRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"authentication.k8s.io", "authorization.k8s.io"},
 			Resources: []string{"uids",

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -59,3 +59,23 @@ func (r *SearchReconciler) SearchServiceAccount(instance *searchv1alpha1.Search)
 	}
 	return sa
 }
+
+// SearchAPIServiceAccount builds the dedicated SA for the search-api
+// deployment. It is the only subject bound to the search-api ClusterRole
+// carrying impersonate rights.
+func (r *SearchReconciler) SearchAPIServiceAccount(instance *searchv1alpha1.Search) *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getAPIServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, sa, r.Scheme); err != nil {
+		log.V(2).Info("Could not set control for ", "serviceaccount", getAPIServiceAccountName())
+	}
+	return sa
+}

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -487,6 +487,16 @@ func (r *SearchReconciler) finalizeSearch(instance *searchv1alpha1.Search) error
 	if err != nil {
 		return err
 	}
+	// The API ClusterRole and ClusterRoleBinding are cluster-scoped and cannot carry
+	// an owner reference (Search is namespaced), so they must be deleted explicitly here.
+	err = r.deleteClusterRole(instance, getRoleName()+"-api")
+	if err != nil {
+		return err
+	}
+	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-api")
+	if err != nil {
+		return err
+	}
 	log.Info("Successfully finalized search")
 	return nil
 }

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -149,9 +149,19 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "SearchServiceAccount setup failed")
 		return *result, err
 	}
+	result, err = r.createSearchServiceAccount(ctx, r.SearchAPIServiceAccount(instance))
+	if result != nil {
+		log.Error(err, "SearchAPIServiceAccount setup failed")
+		return *result, err
+	}
 	result, err = r.createUpdateRoles(ctx, r.ClusterRole(instance))
 	if result != nil {
 		log.Error(err, "ClusterRole setup failed")
+		return *result, err
+	}
+	result, err = r.createUpdateRoles(ctx, r.APIClusterRole(instance))
+	if result != nil {
+		log.Error(err, "APIClusterRole setup failed")
 		return *result, err
 	}
 	result, err = r.createUpdateRoles(ctx, r.AddonClusterRole(instance))
@@ -167,6 +177,11 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createRoleBinding(ctx, r.ClusterRoleBinding(instance))
 	if result != nil {
 		log.Error(err, "ClusterRoleBinding setup failed")
+		return *result, err
+	}
+	result, err = r.createRoleBinding(ctx, r.APIClusterRoleBinding(instance))
+	if result != nil {
+		log.Error(err, "APIClusterRoleBinding setup failed")
 		return *result, err
 	}
 	result, err = r.createSecret(ctx, r.PGSecret(instance))

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -964,3 +964,69 @@ func TestSearch_controller_DBConfigAndEnvOverlap(t *testing.T) {
 	verifyDeploymentEnv(t, dep4, "indEnv", "indEnvValue")
 	verifyDeploymentArgs(t, dep4, "-v=4")
 }
+
+// TestCreateUpdateRoles_UpdatesExistingClusterRole verifies that when a pre-existing
+// ClusterRole has stale rules (e.g. still carries impersonate on the shared role),
+// createUpdateRoles copies the desired rules onto the fetched object and updates it.
+// This exercises the resourceVersion-preserving path: the fetched existingClusterRole
+// is updated rather than the freshly constructed crole, which has no resourceVersion
+// and would be rejected by the API server.
+func TestCreateUpdateRoles_UpdatesExistingClusterRole(t *testing.T) {
+	namespace := "test-ns"
+	search := &searchv1alpha1.Search{
+		TypeMeta:   metav1.TypeMeta{Kind: "Search"},
+		ObjectMeta: metav1.ObjectMeta{Name: OperatorName, Namespace: namespace},
+	}
+
+	// Pre-existing ClusterRole with stale rules (impersonate still present).
+	staleRule := rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"users", "serviceaccounts", "groups"},
+		Verbs:     []string{"impersonate"},
+	}
+	existing := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            getRoleName(),
+			Namespace:       namespace, // match the namespace set by ClusterRole() builder
+			ResourceVersion: "999",    // simulates a server-assigned value
+		},
+		Rules: []rbacv1.PolicyRule{staleRule},
+	}
+
+	s := scheme.Scheme
+	if err := searchv1alpha1.SchemeBuilder.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(s); err != nil {
+		t.Fatalf("scheme rbac: %v", err)
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(existing).Build()
+	r := &SearchReconciler{Client: cl, Scheme: s}
+
+	// Build the desired ClusterRole (no impersonate in getRules()).
+	desired := r.ClusterRole(search)
+
+	result, err := r.createUpdateRoles(context.TODO(), desired)
+	if result != nil || err != nil {
+		t.Fatalf("createUpdateRoles returned unexpected result=%v err=%v", result, err)
+	}
+
+	updated := &rbacv1.ClusterRole{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: getRoleName(), Namespace: namespace}, updated); err != nil {
+		t.Fatalf("get updated ClusterRole: %v", err)
+	}
+
+	// Confirm the stale impersonate rule is gone.
+	for _, rule := range updated.Rules {
+		for _, v := range rule.Verbs {
+			if v == "impersonate" {
+				t.Errorf("shared ClusterRole still contains impersonate after update: %+v", rule)
+			}
+		}
+	}
+
+	// Confirm the updated object matches the desired rules.
+	if len(updated.Rules) != len(desired.Rules) {
+		t.Errorf("expected %d rules after update, got %d", len(desired.Rules), len(updated.Rules))
+	}
+}

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1016,17 +1017,9 @@ func TestCreateUpdateRoles_UpdatesExistingClusterRole(t *testing.T) {
 		t.Fatalf("get updated ClusterRole: %v", err)
 	}
 
-	// Confirm the stale impersonate rule is gone.
-	for _, rule := range updated.Rules {
-		for _, v := range rule.Verbs {
-			if v == "impersonate" {
-				t.Errorf("shared ClusterRole still contains impersonate after update: %+v", rule)
-			}
-		}
-	}
-
-	// Confirm the updated object matches the desired rules.
-	if len(updated.Rules) != len(desired.Rules) {
-		t.Errorf("expected %d rules after update, got %d", len(desired.Rules), len(updated.Rules))
+	// Confirm the updated object matches the desired rules exactly (full semantic equality,
+	// not just length — catches cases where count matches but content differs).
+	if !equality.Semantic.DeepEqual(updated.Rules, desired.Rules) {
+		t.Errorf("ClusterRole rules after update do not match desired:\ngot:  %+v\nwant: %+v", updated.Rules, desired.Rules)
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #783 to `release-2.17`.

### Related Issue
https://issues.redhat.com/browse/ACM-34431

### Commits cherry-picked from #783
- `39d1113` ACM-34431: split impersonate into dedicated search-api ServiceAccount
- `0fa184d` fix: preserve resourceVersion when updating shared ClusterRole
- `f43dc4b` fix: address review comments — error handling and test assertion
- `f11bf45` fix: rename search-api-serviceaccount to search-api-sa
- `d0ea7f1` fix: remove ineffective owner refs from API ClusterRole/Binding; add finalization

### Conflict resolution
One conflict in `controllers/search_controller.go`: the original commit's context included calls to `ensureWebhookCAInjection` and `createOrUpdateMergedCollectorConfig`, which were added to `main` after the `release-2.17` branch diverged. Those calls were dropped; only the `APIClusterRoleBinding` reconcile step was applied.