### PR TITLE
[release-2.13] ACM-34431: isolate postgres with dedicated search-postgres-sa ServiceAccount

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -66,6 +66,16 @@ func getAPIServiceAccountName() string {
 	return "search-api-sa"
 }
 
+// getPostgresServiceAccountName returns the dedicated ServiceAccount for the
+// search-postgres deployment. Postgres is a self-contained database process that
+// makes no Kubernetes API calls at runtime — it only reads its credentials and TLS
+// certificates from volumes that the kubelet mounts. Binding it to its own SA with
+// no ClusterRole grants it the minimum possible privileges (none) while keeping
+// it fully isolated from the write permissions held by the other search components.
+func getPostgresServiceAccountName() string {
+	return "search-postgres-sa"
+}
+
 func getDefaultDBConfig(varName string) string {
 	value, okay := dbDefaultMap[varName]
 	if okay {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -46,6 +46,18 @@ func TestSharedClusterRoleHasNoImpersonate(t *testing.T) {
 	}
 }
 
+// TestPostgresServiceAccountIsIsolated verifies that the postgres SA uses a dedicated
+// name distinct from the shared search SA. Postgres makes no Kubernetes API calls so
+// it intentionally carries no RBAC rules — this test asserts identity isolation only.
+func TestPostgresServiceAccountIsIsolated(t *testing.T) {
+	pgSA := getPostgresServiceAccountName()
+	if pgSA == getServiceAccountName() {
+		t.Fatalf("postgres must not share the generic search-serviceaccount (%q)", pgSA)
+	}
+	if pgSA == "" {
+		t.Fatal("postgres SA name must not be empty")
+	}
+}
 func TestGetDeploymentConfigForNil(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{

--- a/controllers/create_pgdeployment.go
+++ b/controllers/create_pgdeployment.go
@@ -152,7 +152,17 @@ func (r *SearchReconciler) PGDeployment(instance *searchv1alpha1.Search) *appsv1
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{postgresContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
-	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
+	deployment.Spec.Template.Spec.ServiceAccountName = getPostgresServiceAccountName()
+
+	// Use a recreate strategy to reduce the possibility of data corruption.
+	// With the recreate strategy the existing postgres pod will be terminated before the new one starts.
+	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
+	// Increase the termination grace period to allow connections to finish.
+	terminationGracePeriodSeconds := int64(300) // 5 minutes
+	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
+
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -60,6 +60,29 @@ func (r *SearchReconciler) SearchServiceAccount(instance *searchv1alpha1.Search)
 	return sa
 }
 
+// SearchPostgresServiceAccount builds the dedicated SA for the search-postgres
+// deployment. Postgres makes no Kubernetes API calls, so no ClusterRole is bound
+// to this SA — it exists solely to isolate the pod identity from the other
+// search components.
+// An error is returned when the owner reference cannot be set so that the
+// reconcile loop can abort before creating an ownerless ServiceAccount.
+func (r *SearchReconciler) SearchPostgresServiceAccount(instance *searchv1alpha1.Search) (*corev1.ServiceAccount, error) {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPostgresServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, sa, r.Scheme); err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
 // SearchAPIServiceAccount builds the dedicated SA for the search-api
 // deployment. It is the only subject bound to the search-api ClusterRole
 // carrying impersonate rights.

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -151,6 +151,16 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "SearchAPIServiceAccount setup failed")
 		return *result, err
 	}
+	postgresSA, err := r.SearchPostgresServiceAccount(instance)
+	if err != nil {
+		log.Error(err, "SearchPostgresServiceAccount build failed")
+		return ctrl.Result{}, err
+	}
+	result, err = r.createSearchServiceAccount(ctx, postgresSA)
+	if result != nil {
+		log.Error(err, "SearchPostgresServiceAccount setup failed")
+		return *result, err
+	}
 	result, err = r.createUpdateRoles(ctx, r.ClusterRole(instance))
 	if result != nil {
 		log.Error(err, "ClusterRole setup failed")


### PR DESCRIPTION
Cherry-pick of PR #789 (postgres SA isolation) to `release-2.13`, following the same pattern as PR #798 (cherry-pick of the API SA split).

### Related Issue
https://issues.redhat.com/browse/ACM-34431

### Commit cherry-picked
`ba492f3` from `cherry-pick-797-to-release-2.14` (PR #799)

### Conflict resolution
One conflict in `controllers/create_pgdeployment.go`: the incoming commit also adds a `RecreateDeploymentStrategy` and a 5-minute `TerminationGracePeriodSeconds` alongside the SA name change. Both additions were kept as-is.