### PR TITLE
ACM-34431: isolate collector with dedicated search-collector-sa ServiceAccount

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -107,6 +107,16 @@ func getIndexerServiceAccountName() string {
 	return "search-indexer-sa"
 }
 
+// getCollectorServiceAccountName returns the dedicated ServiceAccount for the
+// search-collector deployment. The collector only needs read access (get/list/watch)
+// on all cluster resources plus lease management for its heartbeat. Keeping it
+// separate from the shared search-serviceaccount ensures that a compromise of the
+// collector pod cannot be used to exercise the write permissions needed by other
+// components (postgres, indexer).
+func getCollectorServiceAccountName() string {
+	return "search-collector-sa"
+}
+
 func getDefaultDBConfig(varName string) string {
 	value, okay := dbDefaultMap[varName]
 	if okay {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -241,6 +241,47 @@ func TestCollectorClusterRoleMinimumPermissions(t *testing.T) {
 		t.Fatal("collector must use a dedicated ServiceAccount, not the search-api SA")
 	}
 }
+
+// TestCollectorWorkloadIdentityContract verifies that both the ClusterRoleBinding
+// subject and the CollectorDeployment ServiceAccountName reference
+// getCollectorServiceAccountName(), and that the SA is distinct from the shared account.
+func TestCollectorWorkloadIdentityContract(t *testing.T) {
+	namespace := "test-ns"
+	instance := &searchv1alpha1.Search{
+		ObjectMeta: metav1.ObjectMeta{Name: OperatorName, Namespace: namespace},
+	}
+	s := scheme.Scheme
+	if err := searchv1alpha1.SchemeBuilder.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	r := &SearchReconciler{Client: fake.NewClientBuilder().WithScheme(s).Build(), Scheme: s, DynamicClient: fakeDynClient()}
+
+	// CollectorClusterRoleBinding subject must reference the collector SA.
+	crb := r.CollectorClusterRoleBinding(instance)
+	if len(crb.Subjects) != 1 {
+		t.Fatalf("CollectorClusterRoleBinding expected 1 subject, got %d", len(crb.Subjects))
+	}
+	if crb.Subjects[0].Name != getCollectorServiceAccountName() {
+		t.Errorf("CollectorClusterRoleBinding subject name = %q; want %q",
+			crb.Subjects[0].Name, getCollectorServiceAccountName())
+	}
+
+	// CollectorDeployment ServiceAccountName must reference the collector SA.
+	deploy := r.CollectorDeployment(context.TODO(), instance, nil)
+	if deploy.Spec.Template.Spec.ServiceAccountName != getCollectorServiceAccountName() {
+		t.Errorf("CollectorDeployment ServiceAccountName = %q; want %q",
+			deploy.Spec.Template.Spec.ServiceAccountName, getCollectorServiceAccountName())
+	}
+
+	// SA must be distinct from the shared account.
+	if getCollectorServiceAccountName() == getServiceAccountName() {
+		t.Fatal("collector must not share the generic search-serviceaccount")
+	}
+	if getCollectorServiceAccountName() == "" {
+		t.Fatal("collector SA name must not be empty")
+	}
+}
+
 func TestGetDeploymentConfigForNil(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -176,6 +176,71 @@ func TestIndexerWorkloadIdentityContract(t *testing.T) {
 		t.Fatal("indexer SA name must not be empty")
 	}
 }
+
+// TestCollectorClusterRoleMinimumPermissions verifies that the collector ClusterRole:
+//  1. carries no write verbs other than those needed for lease management,
+//  2. does not carry impersonate,
+//  3. does not grant secrets/services/deployments write access,
+//  4. uses a dedicated ServiceAccount distinct from the shared and API ones.
+func TestCollectorClusterRoleMinimumPermissions(t *testing.T) {
+	// Verbs the collector must never hold.
+	forbidden := map[string]bool{
+		"impersonate":      true,
+		"create":           false, // allowed only for leases — checked per-resource below
+		"update":           false, // allowed only for leases
+		"patch":            true,  // collector never patches anything
+		"delete":           true,
+		"deletecollection": true,
+	}
+	// Write verbs that are only acceptable on coordination.k8s.io/leases.
+	leaseWriteVerbs := map[string]bool{"create": true, "update": true}
+
+	for _, rule := range getCollectorRules() {
+		for _, verb := range rule.Verbs {
+			if forbidden[verb] {
+				t.Errorf("collector ClusterRole must not grant %q; found on resources %v", verb, rule.Resources)
+				continue
+			}
+			// create/update are only allowed on leases
+			if leaseWriteVerbs[verb] {
+				isLeaseRule := false
+				for _, res := range rule.Resources {
+					if res == "leases" {
+						isLeaseRule = true
+						break
+					}
+				}
+				if !isLeaseRule {
+					t.Errorf("collector ClusterRole grants %q on non-lease resource %v", verb, rule.Resources)
+				}
+			}
+		}
+		// Reject any rule that grants write access to secrets, services, or deployments.
+		writeSensitive := map[string]bool{"secrets": true, "services": true, "deployments": true}
+		hasWriteVerb := false
+		for _, verb := range rule.Verbs {
+			if verb != "get" && verb != "list" && verb != "watch" {
+				hasWriteVerb = true
+				break
+			}
+		}
+		if hasWriteVerb {
+			for _, res := range rule.Resources {
+				if writeSensitive[res] {
+					t.Errorf("collector ClusterRole must not grant write access to %q", res)
+				}
+			}
+		}
+	}
+
+	// The collector must use its own SA.
+	if getCollectorServiceAccountName() == getServiceAccountName() {
+		t.Fatal("collector must use a dedicated ServiceAccount, not the shared search-serviceaccount")
+	}
+	if getCollectorServiceAccountName() == getAPIServiceAccountName() {
+		t.Fatal("collector must use a dedicated ServiceAccount, not the search-api SA")
+	}
+}
 func TestGetDeploymentConfigForNil(t *testing.T) {
 	instance := &searchv1alpha1.Search{
 		Spec: searchv1alpha1.SearchSpec{

--- a/controllers/create_collectordeployment.go
+++ b/controllers/create_collectordeployment.go
@@ -90,7 +90,7 @@ func (r *SearchReconciler) CollectorDeployment(ctx context.Context, instance *se
 	deployment.Spec.Template.Spec.SecurityContext = getPodSecurityContext()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{collectorContainer}
 	deployment.Spec.Template.Spec.Volumes = volumes
-	deployment.Spec.Template.Spec.ServiceAccountName = getServiceAccountName()
+	deployment.Spec.Template.Spec.ServiceAccountName = getCollectorServiceAccountName()
 	if getNodeSelector(deploymentName, instance) != nil {
 		deployment.Spec.Template.Spec.NodeSelector = getNodeSelector(deploymentName, instance)
 	}

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -214,6 +214,53 @@ func (r *SearchReconciler) IndexerClusterRoleBinding(instance *searchv1alpha1.Se
 	}
 }
 
+// CollectorClusterRole holds the minimum permissions required by the search-collector
+// deployment. The collector only needs to watch all resources (for inventory) and
+// manage its own lease (for heartbeat). It does not need impersonate, write access
+// to secrets/services/deployments, or any auth review verbs.
+func (r *SearchReconciler) CollectorClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
+	cr := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getRoleName() + "-collector",
+		},
+		Rules: getCollectorRules(),
+	}
+	if err := controllerutil.SetControllerReference(instance, cr, r.Scheme); err != nil {
+		log.Info("Could not set control for ClusterRole " + cr.Name)
+	}
+	return cr
+}
+
+func (r *SearchReconciler) CollectorClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
+	crb := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getRoleBindingName() + "-collector",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     getRoleName() + "-collector",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      getCollectorServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		}},
+	}
+	if err := controllerutil.SetControllerReference(instance, crb, r.Scheme); err != nil {
+		log.Info("Could not set control for ClusterRoleBinding " + crb.Name)
+	}
+	return crb
+}
+
 func (r *SearchReconciler) AddonClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
@@ -342,6 +389,49 @@ func getAddonRules() []rbacv1.PolicyRule {
 			APIGroups: []string{"coordination.k8s.io"},
 			Resources: []string{"leases"},
 			Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
+		},
+	}
+}
+
+// getCollectorRules returns the minimum permissions required by the search-collector pod.
+//
+// The collector's API surface (verified from source):
+//   - Dynamic informers:  get/list/watch on all resources (*/*) for cluster inventory.
+//   - Discovery client:   ServerPreferredResources — implicit; covered by the wildcard.
+//   - ConfigMap read:     get on core/v1 ConfigMaps in its own namespace to read
+//     search-collector-config (allow/deny resource filter).
+//   - CollectorConfig:    get/list/watch on collectorconfigs.search.open-cluster-management.io
+//     for configurable collection hot-reload.
+//   - Lease management:   get/create/update on coordination.k8s.io/leases for the heartbeat
+//     signal sent to the addon framework.
+//
+// The collector does NOT use: impersonate, secrets/services/deployments write,
+// tokenreviews, selfsubjectaccessreviews, or collectorconfigs/status patch/update.
+func getCollectorRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		// Watch every resource in the cluster for inventory collection.
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		// Read the search-collector-config ConfigMap (allow/deny filter for resources).
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get"},
+		},
+		// Watch CollectorConfig CRs for configurable-collection hot-reload.
+		{
+			APIGroups: []string{"search.open-cluster-management.io"},
+			Resources: []string{"collectorconfigs"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		// Manage the addon heartbeat lease.
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get", "create", "update"},
 		},
 	}
 }

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -219,7 +219,11 @@ func (r *SearchReconciler) IndexerClusterRoleBinding(instance *searchv1alpha1.Se
 // manage its own lease (for heartbeat). It does not need impersonate, write access
 // to secrets/services/deployments, or any auth review verbs.
 func (r *SearchReconciler) CollectorClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
-	cr := &rbacv1.ClusterRole{
+	// Note: SetControllerReference is intentionally omitted. ClusterRole is cluster-scoped;
+	// Search is namespaced. Kubernetes forbids a namespaced owner on a cluster-scoped
+	// dependent, so the reference would always fail. Cleanup is handled explicitly in
+	// finalizeSearch via deleteClusterRole.
+	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRole",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -229,14 +233,12 @@ func (r *SearchReconciler) CollectorClusterRole(instance *searchv1alpha1.Search)
 		},
 		Rules: getCollectorRules(),
 	}
-	if err := controllerutil.SetControllerReference(instance, cr, r.Scheme); err != nil {
-		log.Info("Could not set control for ClusterRole " + cr.Name)
-	}
-	return cr
 }
 
 func (r *SearchReconciler) CollectorClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
-	crb := &rbacv1.ClusterRoleBinding{
+	// Note: SetControllerReference is intentionally omitted for the same reason as
+	// CollectorClusterRole. Cleanup is handled explicitly in finalizeSearch.
+	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -255,10 +257,6 @@ func (r *SearchReconciler) CollectorClusterRoleBinding(instance *searchv1alpha1.
 			Namespace: instance.GetNamespace(),
 		}},
 	}
-	if err := controllerutil.SetControllerReference(instance, crb, r.Scheme); err != nil {
-		log.Info("Could not set control for ClusterRoleBinding " + crb.Name)
-	}
-	return crb
 }
 
 func (r *SearchReconciler) AddonClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -106,6 +106,27 @@ func (r *SearchReconciler) SearchIndexerServiceAccount(instance *searchv1alpha1.
 	return sa, nil
 }
 
+// SearchCollectorServiceAccount builds the dedicated SA for the search-collector
+// deployment. It is bound only to the search-collector ClusterRole, which grants
+// read-only access to all cluster resources and lease management. It does not
+// carry any write permissions beyond leases.
+func (r *SearchReconciler) SearchCollectorServiceAccount(instance *searchv1alpha1.Search) *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getCollectorServiceAccountName(),
+			Namespace: instance.GetNamespace(),
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, sa, r.Scheme); err != nil {
+		log.V(2).Info("Could not set control for ", "serviceaccount", getCollectorServiceAccountName())
+	}
+	return sa
+}
+
 // SearchAPIServiceAccount builds the dedicated SA for the search-api
 // deployment. It is the only subject bound to the search-api ClusterRole
 // carrying impersonate rights.

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -181,6 +181,11 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "SearchIndexerServiceAccount setup failed")
 		return *result, err
 	}
+	result, err = r.createSearchServiceAccount(ctx, r.SearchCollectorServiceAccount(instance))
+	if result != nil {
+		log.Error(err, "SearchCollectorServiceAccount setup failed")
+		return *result, err
+	}
 	result, err = r.createUpdateRoles(ctx, r.ClusterRole(instance))
 	if result != nil {
 		log.Error(err, "ClusterRole setup failed")
@@ -194,6 +199,11 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createUpdateRoles(ctx, r.IndexerClusterRole(instance))
 	if result != nil {
 		log.Error(err, "IndexerClusterRole setup failed")
+		return *result, err
+	}
+	result, err = r.createUpdateRoles(ctx, r.CollectorClusterRole(instance))
+	if result != nil {
+		log.Error(err, "CollectorClusterRole setup failed")
 		return *result, err
 	}
 	result, err = r.createUpdateRoles(ctx, r.AddonClusterRole(instance))
@@ -219,6 +229,11 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	result, err = r.createRoleBinding(ctx, r.IndexerClusterRoleBinding(instance))
 	if result != nil {
 		log.Error(err, "IndexerClusterRoleBinding setup failed")
+		return *result, err
+	}
+	result, err = r.createRoleBinding(ctx, r.CollectorClusterRoleBinding(instance))
+	if result != nil {
+		log.Error(err, "CollectorClusterRoleBinding setup failed")
 		return *result, err
 	}
 	if err := r.ensureWebhookCAInjection(ctx); err != nil {

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -659,6 +659,16 @@ func (r *SearchReconciler) finalizeSearch(instance *searchv1alpha1.Search) error
 	if err != nil {
 		return err
 	}
+	// The collector ClusterRole and ClusterRoleBinding are cluster-scoped and cannot carry
+	// an owner reference (Search is namespaced), so they must be deleted explicitly here.
+	err = r.deleteClusterRole(instance, getRoleName()+"-collector")
+	if err != nil {
+		return err
+	}
+	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-collector")
+	if err != nil {
+		return err
+	}
 	log.Info("Successfully finalized search")
 	return nil
 }


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-34431

### Description of changes

The `search-collector` runs under the shared `search-serviceaccount`, which carries far more permissions than the collector needs. Introduce a dedicated `search-collector-sa` ServiceAccount bound to a new minimum-permission `search-collector` ClusterRole.

**Permissions verified from source** (no assumptions — each rule traced to a call site):

| Rule | Source |
|---|---|
| `*/*` — `get, list, watch` | `pkg/informer/runInformers.go` — dynamic informers watch every resource type for cluster inventory |
| `core/v1 configmaps` — `get` | `pkg/informer/supportedResources.go` — reads `search-collector-config` ConfigMap for allow/deny resource filter |
| `search.open-cluster-management.io/collectorconfigs` — `get, list, watch` | `pkg/informer/collectorConfigReload.go` — hot-reload of configurable collection rules |
| `coordination.k8s.io/leases` — `get, create, update` | `pkg/lease/lease.go` — addon heartbeat |

The collector has **zero** `impersonate` calls, no secrets/services/deployments writes, no token reviews — all confirmed absent from source.

#### Files changed

| File | Change |
|---|---|
| `controllers/common.go` | `getCollectorServiceAccountName()` → `"search-collector-sa"` |
| `controllers/create_serviceaccount.go` | `SearchCollectorServiceAccount()` builder |
| `controllers/create_rolesbindings.go` | `CollectorClusterRole()`, `CollectorClusterRoleBinding()`, `getCollectorRules()` |
| `controllers/create_collectordeployment.go` | SA switched to `getCollectorServiceAccountName()` |
| `controllers/search_controller.go` | Reconcile loop wires SA + ClusterRole + ClusterRoleBinding |
| `controllers/common_test.go` | `TestCollectorClusterRoleMinimumPermissions` — asserts no impersonate/patch/delete, create/update only on leases, SA isolated from shared and API SAs |

Builds on PRs #783, #789, #791 (API SA, postgres SA, indexer SA splits).
Part of ACM-34431 (FIND-001, CWE-269, CVSS 9.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added a dedicated service account for the search collector.
  * Restricted collector permissions to required read, watch, and lease-management operations.
  * Prevented impersonation, destructive actions, and write access to sensitive resources.
  * Added validation to ensure collector permissions remain minimally scoped.
  * Improved workload identity isolation by separating collector access from other components.
  * Ensured collector access resources are created and removed with the search deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->