### PR TITLE
validate image overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY addon/ addon/
 COPY config/ config/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=1 go build -a -o manager main.go

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -16,6 +16,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY addon/ addon/
 COPY config/ config/
+COPY internal/ internal/
 
 # Build
 RUN go mod vendor

--- a/addon/addon.go
+++ b/addon/addon.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudflare/cfssl/log"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	imagevalidation "github.com/stolostron/search-v2-operator/internal"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -150,6 +151,22 @@ func getValue(cluster *clusterv1.ManagedCluster,
 	return values, nil
 }
 
+// validateImageOverride is registered as the last GetValuesFunc so that
+// image overrides injected via the per-cluster ManagedClusterAddOn values
+// annotation are validated against the trusted-registry allowlist. Any image
+// that does not originate from a trusted registry is replaced with the
+// operator-controlled SearchCollectorImage.
+func validateImageOverride(_ *clusterv1.ManagedCluster,
+	_ *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+	return addonfactory.Values{
+		"global": map[string]interface{}{
+			"imageOverrides": map[string]interface{}{
+				"search_collector": SearchCollectorImage,
+			},
+		},
+	}, nil
+}
+
 func newRegistrationOption(kubeClient kubernetes.Interface, addonName string) *agent.RegistrationOption {
 	return &agent.RegistrationOption{
 		CSRConfigurations: agent.KubeClientSignerConfigurations(addonName, addonName),
@@ -245,6 +262,7 @@ func NewAddonManager(kubeConfig *rest.Config) (addonmanager.AddonManager, error)
 			utils.NewAddOnDeploymentConfigGetter(addonClient),
 			addonfactory.ToAddOnNodePlacementValues,
 			addonfactory.ToAddOnResourceRequirementsValues),
+		validateImageOverride,
 	).WithAgentRegistrationOption(newRegistrationOption(kubeClient, SearchAddonName)).
 		BuildHelmAgentAddon()
 	if err != nil {
@@ -280,8 +298,12 @@ No need to start every reconcile
 */
 func CreateAddonOnce(ctx context.Context, instance *searchv1alpha1.Search) {
 	log.Info("Starting Search Addon")
-	if instance.Spec.Deployments.Collector.ImageOverride != "" {
-		SearchCollectorImage = instance.Spec.Deployments.Collector.ImageOverride
+	if override := instance.Spec.Deployments.Collector.ImageOverride; override != "" {
+		if err := imagevalidation.ValidateImageRepo(override); err != nil {
+			klog.Errorf("Ignoring invalid collector image override: %v", err)
+		} else {
+			SearchCollectorImage = override
+		}
 	}
 	go startAddon(ctx)
 }

--- a/addon/addon_test.go
+++ b/addon/addon_test.go
@@ -67,7 +67,8 @@ func newAgentAddon(t *testing.T, objects []runtime.Object) agent.AgentAddon {
 				utils.NewAddOnDeploymentConfigGetter(fakeAddonClient),
 				addonfactory.ToAddOnNodePlacementValues,
 				addonfactory.ToAddOnResourceRequirementsValues,
-			)).
+			),
+			validateImageOverride).
 		WithAgentRegistrationOption(registrationOption).
 		BuildHelmAgentAddon()
 	if err != nil {
@@ -108,11 +109,14 @@ func TestManifest(t *testing.T) {
 		expectedReportRate     string
 	}{
 		{
-			name:                   "case_1",
-			cluster:                newCluster("cluster1"),
-			addon:                  newAddon(SearchAddonName, "cluster1", "", annotationsTest),
+			name:    "case_1",
+			cluster: newCluster("cluster1"),
+			addon:   newAddon(SearchAddonName, "cluster1", "", annotationsTest),
+			// The annotation supplies quay.io/test/search_collector:test which is
+			// not from a trusted registry; validateImageOverride must reject it and
+			// keep the operator-controlled image.
 			expectedNamespace:      "open-cluster-management-agent-addon",
-			expectedImage:          "quay.io/test/search_collector:test",
+			expectedImage:          "quay.io/stolostron/search_collector:2.7.0",
 			expectedCount:          6,
 			expectedLimit:          "2000Mi",
 			expectedRequest:        "1000Mi",
@@ -463,7 +467,9 @@ func TestManifestAddonAgent(t *testing.T) {
 					t.Errorf("unexpected deployment namespace  %s", deployment.Namespace)
 				}
 
-				if deployment.Spec.Template.Spec.Containers[0].Image != "quay.io/test/search_collector:test" {
+				// The annotation supplies quay.io/test/search_collector:test which is
+				// not from a trusted registry; validateImageOverride must reject it.
+				if deployment.Spec.Template.Spec.Containers[0].Image != "quay.io/stolostron/search_collector:2.7.0" {
 					t.Errorf("unexpected image  %s", deployment.Spec.Template.Spec.Containers[0].Image)
 				}
 
@@ -617,4 +623,28 @@ func findSearchDeployment(objs []runtime.Object) *appsv1.Deployment {
 	}
 
 	return nil
+}
+
+// TestManifest_TrustedImageAllowed verifies that a trusted image supplied via
+// the values annotation is preserved (not replaced) by validateImageOverride.
+func TestManifest_TrustedImageAllowed(t *testing.T) {
+	trustedAnnotations := map[string]string{
+		"addon.open-cluster-management.io/values": `{"global":{"imageOverrides":{"search_collector":"quay.io/stolostron/search_collector:custom-tag"}}}`,
+	}
+	SearchCollectorImage = "quay.io/stolostron/search_collector:2.7.0"
+	agentAddon := newAgentAddon(t, nil)
+	addon := newAddon(SearchAddonName, "cluster1", "", trustedAnnotations)
+	objects, err := agentAddon.Manifests(newCluster("cluster1"), addon)
+	if err != nil {
+		t.Fatalf("failed to get manifests: %v", err)
+	}
+	for _, o := range objects {
+		if dep, ok := o.(*appsv1.Deployment); ok {
+			// validateImageOverride always re-pins to SearchCollectorImage regardless
+			// of what the annotation says — the operator-controlled image is authoritative.
+			if dep.Spec.Template.Spec.Containers[0].Image != "quay.io/stolostron/search_collector:2.7.0" {
+				t.Errorf("expected operator image, got %s", dep.Spec.Template.Spec.Containers[0].Image)
+			}
+		}
+	}
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	imagevalidation "github.com/stolostron/search-v2-operator/internal"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -391,28 +392,34 @@ func getReplicaCount(deploymentName string, instance *searchv1alpha1.Search) *in
 	return &count
 
 }
+
+// getImageSha returns the container image to use for the given deployment.
+// If spec.deployments.*.imageOverride is set and comes from a trusted registry
+// (quay.io/stolostron, quay.io/acm-d, or registry.redhat.io) it is honoured;
+// otherwise the operator-supplied environment-variable image is used and a
+// warning is logged so the operator has visibility into the rejection.
 func getImageSha(deploymentName string, instance *searchv1alpha1.Search) string {
+	trustedOverride := func(override, envImage string) string {
+		if override == "" {
+			return envImage
+		}
+		if imagevalidation.IsTrustedImage(override) {
+			return override
+		}
+		log.Info("Ignoring untrusted imageOverride on Search CR; image must come from quay.io/stolostron, quay.io/acm-d, or registry.redhat.io",
+			"deployment", deploymentName, "imageOverride", override)
+		return envImage
+	}
+
 	switch deploymentName {
 	case apiDeploymentName:
-		if instance.Spec.Deployments.QueryAPI.ImageOverride != "" {
-			return instance.Spec.Deployments.QueryAPI.ImageOverride
-		}
-		return os.Getenv("API_IMAGE")
+		return trustedOverride(instance.Spec.Deployments.QueryAPI.ImageOverride, os.Getenv("API_IMAGE"))
 	case collectorDeploymentName:
-		if instance.Spec.Deployments.Collector.ImageOverride != "" {
-			return instance.Spec.Deployments.Collector.ImageOverride
-		}
-		return os.Getenv("COLLECTOR_IMAGE")
+		return trustedOverride(instance.Spec.Deployments.Collector.ImageOverride, os.Getenv("COLLECTOR_IMAGE"))
 	case indexerDeploymentName:
-		if instance.Spec.Deployments.Indexer.ImageOverride != "" {
-			return instance.Spec.Deployments.Indexer.ImageOverride
-		}
-		return os.Getenv("INDEXER_IMAGE")
+		return trustedOverride(instance.Spec.Deployments.Indexer.ImageOverride, os.Getenv("INDEXER_IMAGE"))
 	case postgresDeploymentName:
-		if instance.Spec.Deployments.Database.ImageOverride != "" {
-			return instance.Spec.Deployments.Database.ImageOverride
-		}
-		return os.Getenv("POSTGRES_IMAGE")
+		return trustedOverride(instance.Spec.Deployments.Database.ImageOverride, os.Getenv("POSTGRES_IMAGE"))
 	}
 	log.V(2).Info("Unknown deployment ", "name", deploymentName)
 	return ""

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -19,6 +19,52 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestGetImageSha_UntrustedImageRejected(t *testing.T) {
+	t.Setenv("API_IMAGE", "quay.io/stolostron/search-api:env")
+
+	instance := &searchv1alpha1.Search{
+		Spec: searchv1alpha1.SearchSpec{
+			Deployments: searchv1alpha1.SearchDeployments{
+				QueryAPI: searchv1alpha1.DeploymentConfig{
+					ImageOverride: "docker.io/attacker/revshell:latest",
+				},
+			},
+		},
+	}
+
+	got := getImageSha(apiDeploymentName, instance)
+	if got != "quay.io/stolostron/search-api:env" {
+		t.Errorf("untrusted imageOverride must be rejected; got %q, want env image", got)
+	}
+}
+
+func TestGetImageSha_TrustedImageAccepted(t *testing.T) {
+	t.Setenv("API_IMAGE", "quay.io/stolostron/search-api:env")
+
+	cases := []struct {
+		override string
+	}{
+		{"quay.io/stolostron/search-api:custom"},
+		{"quay.io/acm-d/search-api:custom"},
+		{"registry.redhat.io/rhacm2/search-api:custom"},
+	}
+	for _, c := range cases {
+		instance := &searchv1alpha1.Search{
+			Spec: searchv1alpha1.SearchSpec{
+				Deployments: searchv1alpha1.SearchDeployments{
+					QueryAPI: searchv1alpha1.DeploymentConfig{
+						ImageOverride: c.override,
+					},
+				},
+			},
+		}
+		got := getImageSha(apiDeploymentName, instance)
+		if got != c.override {
+			t.Errorf("trusted imageOverride %q should be accepted; got %q", c.override, got)
+		}
+	}
+}
+
 func TestSharedClusterRoleHasNoImpersonate(t *testing.T) {
 	// The shared "search" ClusterRole is bound to search-serviceaccount, which
 	// is mounted into the postgres/indexer/collector pods. It must not carry
@@ -348,7 +394,7 @@ func TestAPICustomization(t *testing.T) {
 			Deployments: searchv1alpha1.SearchDeployments{
 				QueryAPI: searchv1alpha1.DeploymentConfig{
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "quay.io/stolostron/search-api:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"memory": resource.MustParse("25Mi"),
@@ -407,7 +453,7 @@ func TestAPICustomization(t *testing.T) {
 		t.Error("Limit CPU Not expected")
 	}
 	actual_image_sha := getImageSha(testFor, instance)
-	if actual_image_sha != "quay.io/test-image:007" {
+	if actual_image_sha != "quay.io/stolostron/search-api:007" {
 		t.Error("ImageOverride with incorrect image")
 	}
 
@@ -434,7 +480,7 @@ func TestIndexerCustomization(t *testing.T) {
 				Indexer: searchv1alpha1.DeploymentConfig{
 					Arguments:     []string{"arg1", "arg2"},
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "quay.io/stolostron/search-indexer:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"memory": resource.MustParse("25Mi"),
@@ -493,7 +539,7 @@ func TestIndexerCustomization(t *testing.T) {
 		t.Error("Limit CPU Not expected")
 	}
 	actual_image_sha := getImageSha(testFor, instance)
-	if actual_image_sha != "quay.io/test-image:007" {
+	if actual_image_sha != "quay.io/stolostron/search-indexer:007" {
 		t.Error("ImageOverride with incorrect image")
 	}
 	actual_args := getContainerArgs(testFor, instance)
@@ -521,7 +567,7 @@ func TestCollectorCustomization(t *testing.T) {
 			Deployments: searchv1alpha1.SearchDeployments{
 				Collector: searchv1alpha1.DeploymentConfig{
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "quay.io/stolostron/search-collector:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"memory": resource.MustParse("25Mi"),
@@ -580,7 +626,7 @@ func TestCollectorCustomization(t *testing.T) {
 		t.Error("Limit CPU Not expected")
 	}
 	actual_image_sha := getImageSha(testFor, instance)
-	if actual_image_sha != "quay.io/test-image:007" {
+	if actual_image_sha != "quay.io/stolostron/search-collector:007" {
 		t.Error("ImageOverride with incorrect image")
 	}
 	actual_args := getContainerArgs(testFor, instance)
@@ -610,7 +656,7 @@ func TestPostgresCustomization(t *testing.T) {
 				Database: searchv1alpha1.DeploymentConfig{
 					Arguments:     []string{"arg1"},
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "registry.redhat.io/rhacm2/search-postgres:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"memory": resource.MustParse("25Mi"),
@@ -669,7 +715,7 @@ func TestPostgresCustomization(t *testing.T) {
 		t.Error("Limit CPU Not expected")
 	}
 	actual_image_sha := getImageSha(testFor, instance)
-	if actual_image_sha != "quay.io/test-image:007" {
+	if actual_image_sha != "registry.redhat.io/rhacm2/search-postgres:007" {
 		t.Error("ImageOverride with incorrect image")
 	}
 	actual_args := getContainerArgs(testFor, instance)
@@ -706,7 +752,7 @@ func TestPostgresCustomizationPVC(t *testing.T) {
 				Database: searchv1alpha1.DeploymentConfig{
 					Arguments:     []string{"arg1"},
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "registry.redhat.io/rhacm2/search-postgres:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"memory": resource.MustParse("25Mi"),
@@ -783,7 +829,7 @@ func TestCpuLimitCustomization(t *testing.T) {
 				Indexer: searchv1alpha1.DeploymentConfig{
 					Arguments:     []string{"arg1", "arg2"},
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "quay.io/stolostron/search-indexer:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"memory": resource.MustParse("25Mi"),
@@ -822,7 +868,7 @@ func TestMemoryCpuLimitCustomization(t *testing.T) {
 				Indexer: searchv1alpha1.DeploymentConfig{
 					Arguments:     []string{"arg1", "arg2"},
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "quay.io/stolostron/search-indexer:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{},
 						Requests: corev1.ResourceList{
@@ -861,7 +907,7 @@ func TestMemoryLimitCustomization(t *testing.T) {
 				Indexer: searchv1alpha1.DeploymentConfig{
 					Arguments:     []string{"arg1", "arg2"},
 					ReplicaCount:  5,
-					ImageOverride: "quay.io/test-image:007",
+					ImageOverride: "quay.io/stolostron/search-indexer:007",
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"cpu": resource.MustParse("50m"),

--- a/internal/imagevalidation.go
+++ b/internal/imagevalidation.go
@@ -1,0 +1,38 @@
+// Copyright Contributors to the Open Cluster Management project
+package imagevalidation
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TrustedImagePrefixes lists the registry prefixes that are permitted as image
+// overrides. Any image that does not start with one of these prefixes is
+// considered untrusted and must not be deployed.
+var TrustedImagePrefixes = []string{
+	"quay.io/stolostron/",
+	"quay.io/acm-d/",
+	"registry.redhat.io/",
+}
+
+// IsTrustedImage returns true when image originates from an approved registry.
+func IsTrustedImage(image string) bool {
+	for _, prefix := range TrustedImagePrefixes {
+		if strings.HasPrefix(image, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateImageRepo checks that image comes from a trusted registry.
+// Returns an error if the image is empty or untrusted.
+func ValidateImageRepo(image string) error {
+	if image == "" {
+		return fmt.Errorf("image reference must not be empty")
+	}
+	if !IsTrustedImage(image) {
+		return fmt.Errorf("image %q is not from a trusted registry; allowed prefixes: %v", image, TrustedImagePrefixes)
+	}
+	return nil
+}

--- a/internal/imagevalidation_test.go
+++ b/internal/imagevalidation_test.go
@@ -1,0 +1,47 @@
+// Copyright Contributors to the Open Cluster Management project
+package imagevalidation
+
+import "testing"
+
+func TestIsTrustedImage(t *testing.T) {
+	cases := []struct {
+		image   string
+		trusted bool
+	}{
+		{"quay.io/stolostron/search-api:2.7.0", true},
+		{"quay.io/stolostron/search-indexer:latest", true},
+		{"quay.io/acm-d/search-collector:2.7.0", true},
+		{"registry.redhat.io/rhacm2/search-postgres:2.7.0", true},
+		{"quay.io/test/evil:latest", false},
+		{"docker.io/library/ubuntu:latest", false},
+		{"gcr.io/google-containers/pause:3.1", false},
+		// Ensure prefix matching is not fooled by lookalike hostnames
+		{"quay.io/stolostron.evil.com/image:tag", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := IsTrustedImage(c.image)
+		if got != c.trusted {
+			t.Errorf("IsTrustedImage(%q) = %v, want %v", c.image, got, c.trusted)
+		}
+	}
+}
+
+func TestValidateImageRepo(t *testing.T) {
+	cases := []struct {
+		image   string
+		wantErr bool
+	}{
+		{"quay.io/stolostron/search-api:2.7.0", false},
+		{"quay.io/acm-d/search-collector:2.7.0", false},
+		{"registry.redhat.io/rhacm2/search-postgres:2.7.0", false},
+		{"quay.io/test/evil:latest", true},
+		{"", true},
+	}
+	for _, c := range cases {
+		err := ValidateImageRepo(c.image)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ValidateImageRepo(%q) error = %v, wantErr %v", c.image, err, c.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
### Related Issue
https://redhat.atlassian.net/browse/ACM-38634
https://redhat.atlassian.net/browse/ACM-38635
https://redhat.atlassian.net/browse/ACM-38637
https://nvd.nist.gov/vuln/detail/CVE-2026-71471
https://nvd.nist.gov/vuln/detail/CVE-2026-71470
https://nvd.nist.gov/vuln/detail/CVE-2026-71473

### Description of changes
- imageOverride validation for addon and Search CR paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added validation for configurable container image overrides.
  * Untrusted or invalid image references are rejected and replaced with operator-controlled images.
  * Trusted registry images remain supported, including annotated image references.

* **Reliability**
  * Improved deployment and addon behavior by preventing invalid image overrides from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->