### PR TITLE
validate envVar secretkeyrefs

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -221,6 +221,16 @@ func getContainerArgs(deploymentName string, instance *searchv1alpha1.Search) []
 	return result
 }
 
+// operatorManagedSecrets is the set of secrets created by the operator.
+// CR-supplied env vars with valueFrom.secretKeyRef are only allowed to
+// reference secrets in this set, preventing CR editors from mounting
+// arbitrary namespace secrets into search containers.
+var operatorManagedSecrets = map[string]struct{}{
+	"search-postgres":     {},
+	apiReadonlySecretName: {},
+	mcpReadonlySecretName: {},
+}
+
 func getContainerEnvVar(deploymentName string, instance *searchv1alpha1.Search) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	deploymentConfig := getDeploymentConfig(deploymentName, instance)
@@ -232,6 +242,14 @@ func getContainerEnvVar(deploymentName string, instance *searchv1alpha1.Search) 
 	for _, e := range deploymentConfig.Env {
 		if deploymentName == postgresDeploymentName && e.Name == "WORK_MEM" {
 			continue
+		}
+		// Drop env vars that reference secrets the operator didn't create.
+		if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			if _, ok := operatorManagedSecrets[e.ValueFrom.SecretKeyRef.Name]; !ok {
+				log.Info("Dropping env var referencing non-operator secret",
+					"name", e.Name, "secret", e.ValueFrom.SecretKeyRef.Name)
+				continue
+			}
 		}
 		result = append(result, e)
 	}

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -1296,6 +1296,72 @@ func TestCreateOrUpdateConfigMap_PostgresNoCustomConfig(t *testing.T) {
 	assert.Equal(t, expectedCustomConf, updated.Data["custom-postgresql.conf"])
 }
 
+func TestGetContainerEnvVarDropsNonOperatorSecrets(t *testing.T) {
+	instance := &searchv1alpha1.Search{
+		Spec: searchv1alpha1.SearchSpec{
+			Deployments: searchv1alpha1.SearchDeployments{
+				QueryAPI: searchv1alpha1.DeploymentConfig{
+					Env: []corev1.EnvVar{
+						{Name: "PLAIN", Value: "plainvalue"},
+						// Operator-managed secret — should be kept.
+						{Name: "DB_PASS", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "search-postgres"},
+								Key:                  "database-password",
+							},
+						}},
+						// Non-operator secret — should be dropped.
+						{Name: "EVIL", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "attacker-secret"},
+								Key:                  "token",
+							},
+						}},
+						// Another operator-managed secret.
+						{Name: "API_PASS", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: apiReadonlySecretName},
+								Key:                  "database-password",
+							},
+						}},
+						// MCP readonly secret.
+						{Name: "MCP_PASS", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: mcpReadonlySecretName},
+								Key:                  "database-password",
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	envVars := getContainerEnvVar("search-api", instance)
+
+	// Expect 4 env vars: PLAIN, DB_PASS, API_PASS, MCP_PASS. EVIL should be dropped.
+	assert.Equal(t, 4, len(envVars), "Expected 4 env vars, EVIL should be dropped")
+
+	names := make([]string, len(envVars))
+	for i, e := range envVars {
+		names[i] = e.Name
+	}
+	assert.Equal(t, []string{"PLAIN", "DB_PASS", "API_PASS", "MCP_PASS"}, names)
+}
+
+func TestGetContainerEnvVarNilEnv(t *testing.T) {
+	instance := &searchv1alpha1.Search{
+		Spec: searchv1alpha1.SearchSpec{
+			Deployments: searchv1alpha1.SearchDeployments{
+				QueryAPI: searchv1alpha1.DeploymentConfig{},
+			},
+		},
+	}
+
+	envVars := getContainerEnvVar("search-api", instance)
+	assert.Equal(t, 0, len(envVars), "Nil env should return empty slice")
+}
+
 func TestGetPrometheusAlertMaxAppsCount(t *testing.T) {
 	search := &searchv1alpha1.Search{
 		TypeMeta:   metav1.TypeMeta{Kind: "Search"},


### PR DESCRIPTION
### Related Issue
https://redhat.atlassian.net/browse/ACM-38634
https://nvd.nist.gov/vuln/detail/CVE-2026-71470

### Description of changes
- Added check that SecretKeyRefs modified in EnvVars only come from Operator created Secrets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variables sourced from unapproved secrets are now excluded from container deployments.
  * Approved operator-managed secrets continue to work as expected.
  * Existing PostgreSQL memory-setting filtering remains unchanged.

* **Tests**
  * Added coverage for approved, unapproved, plain-text, and missing environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->