### PR TITLE
ACM-34432 Pre-provision search-api and search-collector ClusterRoles to remove impersonate from operator SA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,13 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+install-operand-rbac: ## Apply the pre-provisioned search-api and search-collector ClusterRoles to the cluster.
+	# These ClusterRoles have fixed names that must not carry the kustomize namePrefix,
+	# so they are intentionally excluded from config/rbac/kustomization.yaml and applied
+	# here directly.  In OLM deployments they are applied from bundle/manifests/.
+	kubectl apply -f config/rbac/search_api_clusterrole.yaml
+	kubectl apply -f config/rbac/search_collector_clusterrole.yaml
+
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 

--- a/bundle/manifests/search-api-clusterrole.yaml
+++ b/bundle/manifests/search-api-clusterrole.yaml
@@ -1,0 +1,72 @@
+# search-api ClusterRole — bound exclusively to search-api-sa.
+# Contains all permissions specific to the search-api pod: impersonation rights
+# for per-user RBAC enforcement, Secret/Service access for mTLS cert management,
+# and authorization review verbs for RBAC-filtered query results.
+#
+# Pre-provisioned as a static manifest so the operator SA never needs to hold
+# 'impersonate' just to pass Kubernetes RBAC escalation prevention when creating
+# this role.  The operator creates only the ClusterRoleBinding that references
+# this role, which requires the narrower 'bind' verb.
+#
+# NOTE: This file is NOT managed by controller-gen.  Changes here must be kept in sync
+# with bundle/manifests/search-api-clusterrole.yaml (OLM path) and docs/RBAC.md.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: search-api
+rules:
+# User-extra impersonation — required to forward the full user identity
+# (credential ID, node name, pod name, etc.) through the Kubernetes API server
+# when executing SelfSubjectRulesReviews on behalf of the end user.
+- apiGroups:
+  - authentication.k8s.io
+  - authorization.k8s.io
+  resources:
+  - uids
+  - userextras/authentication.kubernetes.io/credential-id
+  - userextras/authentication.kubernetes.io/node-name
+  - userextras/authentication.kubernetes.io/node-uid
+  - userextras/authentication.kubernetes.io/pod-name
+  - userextras/authentication.kubernetes.io/pod-uid
+  verbs:
+  - impersonate
+# Principal impersonation — required to issue requests as the authenticated user.
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - serviceaccounts
+  - groups
+  verbs:
+  - impersonate
+# Secret and Service access — required by search-api to manage its mTLS certs.
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# TokenReview — required to authenticate the end user's bearer token before
+# impersonating them for RBAC-filtered query results.
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+# Authorization reviews — required to evaluate per-user RBAC rules for
+# filtering search results to resources the requesting user may access.
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  - selfsubjectrulesreviews
+  verbs:
+  - create

--- a/bundle/manifests/search-api-clusterrole.yaml
+++ b/bundle/manifests/search-api-clusterrole.yaml
@@ -1,6 +1,6 @@
 # search-api ClusterRole — bound exclusively to search-api-sa.
 # Contains all permissions specific to the search-api pod: impersonation rights
-# for per-user RBAC enforcement, Secret/Service access for mTLS cert management,
+# for per-user RBAC enforcement, and Secret get access for federated hub config.
 # and authorization review verbs for RBAC-filtered query results.
 #
 # Pre-provisioned as a static manifest so the operator SA never needs to hold
@@ -46,19 +46,16 @@ rules:
   - groups
   verbs:
   - impersonate
-# Secret and Service access — required by search-api to manage its mTLS certs.
+# Secret get — required by the federated query path to read the named search-global
+# Secret in each managed-hub namespace (search-v2-api/pkg/federated/fedConfig.go).
+# The operator SA creates and manages Secrets and Services; the API pod only reads
+# this one named Secret.
 - apiGroups:
   - ""
   resources:
   - secrets
-  - services
   verbs:
-  - create
   - get
-  - list
-  - patch
-  - update
-  - watch
 # TokenReview — required to authenticate the end user's bearer token before
 # impersonating them for RBAC-filtered query results.
 - apiGroups:

--- a/bundle/manifests/search-api-clusterrole.yaml
+++ b/bundle/manifests/search-api-clusterrole.yaml
@@ -20,7 +20,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: open-cluster-management:search-v2-operator:search-api
+# The multiclusterhub-operator bundle-automation script renames this role to
+#   name: '{{ .Values.org }}:{{ .Chart.Name }}:search-api'
+  name: search-api
 rules:
 # User-extra impersonation — required to forward the full user identity
 # (credential ID, node name, pod name, etc.) through the Kubernetes API server

--- a/bundle/manifests/search-api-clusterrole.yaml
+++ b/bundle/manifests/search-api-clusterrole.yaml
@@ -20,7 +20,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: search-api
+  name: open-cluster-management:search-v2-operator:search-api
 rules:
 # User-extra impersonation — required to forward the full user identity
 # (credential ID, node name, pod name, etc.) through the Kubernetes API server

--- a/bundle/manifests/search-api-clusterrole.yaml
+++ b/bundle/manifests/search-api-clusterrole.yaml
@@ -9,7 +9,13 @@
 # this role, which requires the narrower 'bind' verb.
 #
 # NOTE: This file is NOT managed by controller-gen.  Changes here must be kept in sync
-# with bundle/manifests/search-api-clusterrole.yaml (OLM path) and docs/RBAC.md.
+# with config/rbac/search_api_clusterrole.yaml (dev/kustomize path) and docs/RBAC.md.
+#
+# HELM PATH (multiclusterhub-operator): the bundle-automation script renames this role to
+#   name: '{{ .Values.org }}:{{ .Chart.Name }}:search-api'
+# (e.g. "open-cluster-management:search-v2-operator:search-api").
+# The operator reads OPERATOR_ORG and OPERATOR_CHART env vars injected by the Helm chart
+# to resolve the full name at runtime when creating the ClusterRoleBinding's RoleRef.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/bundle/manifests/search-collector-clusterrole.yaml
+++ b/bundle/manifests/search-collector-clusterrole.yaml
@@ -14,7 +14,13 @@
 # tokenreviews, or selfsubjectaccessreviews.
 #
 # NOTE: This file is NOT managed by controller-gen.  Changes here must be kept
-# in sync with bundle/manifests/search-collector-clusterrole.yaml (OLM path).
+# in sync with config/rbac/search_collector_clusterrole.yaml (dev/kustomize path).
+#
+# HELM PATH (multiclusterhub-operator): the bundle-automation script renames this role to
+#   name: '{{ .Values.org }}:{{ .Chart.Name }}:search-collector'
+# (e.g. "open-cluster-management:search-v2-operator:search-collector").
+# The operator reads OPERATOR_ORG and OPERATOR_CHART env vars injected by the Helm chart
+# to resolve the full name at runtime when creating the ClusterRoleBinding's RoleRef.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/bundle/manifests/search-collector-clusterrole.yaml
+++ b/bundle/manifests/search-collector-clusterrole.yaml
@@ -25,7 +25,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: open-cluster-management:search-v2-operator:search-collector
+# The multiclusterhub-operator bundle-automation script renames this role to
+#   name: '{{ .Values.org }}:{{ .Chart.Name }}:search-collector'
+  name: search-collector
 rules:
 # Watch every resource in the cluster for inventory collection.
 # This wildcard rule also covers configmaps (allow/deny filter) and

--- a/bundle/manifests/search-collector-clusterrole.yaml
+++ b/bundle/manifests/search-collector-clusterrole.yaml
@@ -1,0 +1,52 @@
+# search-collector ClusterRole — bound exclusively to search-collector-sa.
+# Pre-provisioned as a static manifest (like search-api) so the operator SA
+# never needs to hold wildcard read just to pass Kubernetes RBAC escalation
+# prevention when creating this role.  The operator creates only the
+# CollectorClusterRoleBinding that references it, using the 'bind' verb.
+#
+# Permissions verified from collector source:
+#   - pkg/informer/runInformers.go, supportedResources.go  — */* get/list/watch
+#     (configmaps get and collectorconfigs get/list/watch are subsumed by this rule)
+#   - pkg/lease/lease.go                                   — leases get/create/update (heartbeat)
+#   - controller reconcile loop                            — collectorconfigs/status patch/update
+#
+# The collector does NOT use: impersonate, secrets/services/deployments write,
+# tokenreviews, or selfsubjectaccessreviews.
+#
+# NOTE: This file is NOT managed by controller-gen.  Changes here must be kept
+# in sync with bundle/manifests/search-collector-clusterrole.yaml (OLM path).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: search-collector
+rules:
+# Watch every resource in the cluster for inventory collection.
+# This wildcard rule also covers configmaps (allow/deny filter) and
+# collectorconfigs (hot-reload), so separate rules for those are not needed.
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+# Update CollectorConfig status — the operator reconcile loop writes the
+# collector's sync status back via collectorconfigs/status.
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - collectorconfigs/status
+  verbs:
+  - patch
+  - update
+# Manage the addon heartbeat lease.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update

--- a/bundle/manifests/search-collector-clusterrole.yaml
+++ b/bundle/manifests/search-collector-clusterrole.yaml
@@ -25,7 +25,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: search-collector
+  name: open-cluster-management:search-v2-operator:search-collector
 rules:
 # Watch every resource in the cluster for inventory collection.
 # This wildcard rule also covers configmaps (allow/deny filter) and

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,3 +18,10 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+# NOTE: search_api_clusterrole.yaml and search_collector_clusterrole.yaml are
+# deliberately NOT listed here.  These ClusterRoles have fixed canonical names
+# ("search-api", "search-collector") that must not receive the search-v2-operator-
+# namePrefix applied by config/default/kustomization.yaml.
+#
+# OLM path  : Both files are in bundle/manifests/ and applied by OLM at install time.
+# Development: Run `make install-operand-rbac` to apply them directly to the cluster.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,16 +14,13 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - groups
   - secrets
   - serviceaccounts
   - services
-  - users
   verbs:
   - create
   - delete
   - get
-  - impersonate
   - list
   - patch
   - update
@@ -90,18 +87,6 @@ rules:
   - tokenreviews
   verbs:
   - create
-- apiGroups:
-  - authentication.k8s.io
-  - authorization.k8s.io
-  resources:
-  - uids
-  - userextras/authentication.kubernetes.io/credential-id
-  - userextras/authentication.kubernetes.io/node-name
-  - userextras/authentication.kubernetes.io/node-uid
-  - userextras/authentication.kubernetes.io/pod-name
-  - userextras/authentication.kubernetes.io/pod-uid
-  verbs:
-  - impersonate
 - apiGroups:
   - authentication.open-cluster-management.io
   resources:
@@ -216,6 +201,15 @@ rules:
   - get
   - list
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - search-api
+  - search-collector
+  resources:
+  - clusterroles
+  verbs:
+  - bind
 - apiGroups:
   - rbac.open-cluster-management.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -203,9 +203,6 @@ rules:
   - update
 - apiGroups:
   - rbac.authorization.k8s.io
-  resourceNames:
-  - search-api
-  - search-collector
   resources:
   - clusterroles
   verbs:

--- a/config/rbac/search_api_clusterrole.yaml
+++ b/config/rbac/search_api_clusterrole.yaml
@@ -1,6 +1,6 @@
 # search-api ClusterRole — bound exclusively to search-api-sa.
 # Contains all permissions specific to the search-api pod: impersonation rights
-# for per-user RBAC enforcement, Secret/Service access for mTLS cert management,
+# for per-user RBAC enforcement, and Secret get access for federated hub config.
 # and authorization review verbs for RBAC-filtered query results.
 #
 # Pre-provisioned as a static manifest so the operator SA never needs to hold
@@ -40,19 +40,16 @@ rules:
   - groups
   verbs:
   - impersonate
-# Secret and Service access — required by search-api to manage its mTLS certs.
+# Secret get — required by the federated query path to read the named search-global
+# Secret in each managed-hub namespace (search-v2-api/pkg/federated/fedConfig.go).
+# The operator SA creates and manages Secrets and Services; the API pod only reads
+# this one named Secret.
 - apiGroups:
   - ""
   resources:
   - secrets
-  - services
   verbs:
-  - create
   - get
-  - list
-  - patch
-  - update
-  - watch
 # TokenReview — required to authenticate the end user's bearer token before
 # impersonating them for RBAC-filtered query results.
 - apiGroups:

--- a/config/rbac/search_api_clusterrole.yaml
+++ b/config/rbac/search_api_clusterrole.yaml
@@ -14,7 +14,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: open-cluster-management:search-v2-operator:search-api
+# The multiclusterhub-operator bundle-automation script renames this role to
+#   name: '{{ .Values.org }}:{{ .Chart.Name }}:search-api'
+  name: search-api
 rules:
 # User-extra impersonation — required to forward the full user identity
 # (credential ID, node name, pod name, etc.) through the Kubernetes API server

--- a/config/rbac/search_api_clusterrole.yaml
+++ b/config/rbac/search_api_clusterrole.yaml
@@ -1,0 +1,72 @@
+# search-api ClusterRole — bound exclusively to search-api-sa.
+# Contains all permissions specific to the search-api pod: impersonation rights
+# for per-user RBAC enforcement, Secret/Service access for mTLS cert management,
+# and authorization review verbs for RBAC-filtered query results.
+#
+# Pre-provisioned as a static manifest so the operator SA never needs to hold
+# 'impersonate' just to pass Kubernetes RBAC escalation prevention when creating
+# this role.  The operator creates only the ClusterRoleBinding that references
+# this role, which requires the narrower 'bind' verb.
+#
+# NOTE: This file is NOT managed by controller-gen.  Changes here must be kept in sync
+# with bundle/manifests/search-api-clusterrole.yaml (OLM path) and docs/RBAC.md.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: search-api
+rules:
+# User-extra impersonation — required to forward the full user identity
+# (credential ID, node name, pod name, etc.) through the Kubernetes API server
+# when executing SelfSubjectRulesReviews on behalf of the end user.
+- apiGroups:
+  - authentication.k8s.io
+  - authorization.k8s.io
+  resources:
+  - uids
+  - userextras/authentication.kubernetes.io/credential-id
+  - userextras/authentication.kubernetes.io/node-name
+  - userextras/authentication.kubernetes.io/node-uid
+  - userextras/authentication.kubernetes.io/pod-name
+  - userextras/authentication.kubernetes.io/pod-uid
+  verbs:
+  - impersonate
+# Principal impersonation — required to issue requests as the authenticated user.
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - serviceaccounts
+  - groups
+  verbs:
+  - impersonate
+# Secret and Service access — required by search-api to manage its mTLS certs.
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# TokenReview — required to authenticate the end user's bearer token before
+# impersonating them for RBAC-filtered query results.
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+# Authorization reviews — required to evaluate per-user RBAC rules for
+# filtering search results to resources the requesting user may access.
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  - selfsubjectrulesreviews
+  verbs:
+  - create

--- a/config/rbac/search_api_clusterrole.yaml
+++ b/config/rbac/search_api_clusterrole.yaml
@@ -14,7 +14,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: search-api
+  name: open-cluster-management:search-v2-operator:search-api
 rules:
 # User-extra impersonation — required to forward the full user identity
 # (credential ID, node name, pod name, etc.) through the Kubernetes API server

--- a/config/rbac/search_collector_clusterrole.yaml
+++ b/config/rbac/search_collector_clusterrole.yaml
@@ -1,0 +1,52 @@
+# search-collector ClusterRole — bound exclusively to search-collector-sa.
+# Pre-provisioned as a static manifest (like search-api) so the operator SA
+# never needs to hold wildcard read just to pass Kubernetes RBAC escalation
+# prevention when creating this role.  The operator creates only the
+# CollectorClusterRoleBinding that references it, using the 'bind' verb.
+#
+# Permissions verified from collector source:
+#   - pkg/informer/runInformers.go, supportedResources.go  — */* get/list/watch
+#     (configmaps get and collectorconfigs get/list/watch are subsumed by this rule)
+#   - pkg/lease/lease.go                                   — leases get/create/update (heartbeat)
+#   - controller reconcile loop                            — collectorconfigs/status patch/update
+#
+# The collector does NOT use: impersonate, secrets/services/deployments write,
+# tokenreviews, or selfsubjectaccessreviews.
+#
+# NOTE: This file is NOT managed by controller-gen.  Changes here must be kept
+# in sync with bundle/manifests/search-collector-clusterrole.yaml (OLM path).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: search-collector
+rules:
+# Watch every resource in the cluster for inventory collection.
+# This wildcard rule also covers configmaps (allow/deny filter) and
+# collectorconfigs (hot-reload), so separate rules for those are not needed.
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+# Update CollectorConfig status — the operator reconcile loop writes the
+# collector's sync status back via collectorconfigs/status.
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - collectorconfigs/status
+  verbs:
+  - patch
+  - update
+# Manage the addon heartbeat lease.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update

--- a/config/rbac/search_collector_clusterrole.yaml
+++ b/config/rbac/search_collector_clusterrole.yaml
@@ -19,7 +19,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: search-collector
+  name: open-cluster-management:search-v2-operator:search-collector
 rules:
 # Watch every resource in the cluster for inventory collection.
 # This wildcard rule also covers configmaps (allow/deny filter) and

--- a/config/rbac/search_collector_clusterrole.yaml
+++ b/config/rbac/search_collector_clusterrole.yaml
@@ -19,7 +19,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: open-cluster-management:search-v2-operator:search-collector
+# The multiclusterhub-operator bundle-automation script renames this role to
+#   name: '{{ .Values.org }}:{{ .Chart.Name }}:search-collector'
+  name: search-collector
 rules:
 # Watch every resource in the cluster for inventory collection.
 # This wildcard rule also covers configmaps (allow/deny filter) and

--- a/controllers/cleanup.go
+++ b/controllers/cleanup.go
@@ -72,14 +72,14 @@ func (r *SearchReconciler) deleteClusterRole(instance *searchv1alpha1.Search, re
 
 func (r *SearchReconciler) deleteClusterRoleBinding(instance *searchv1alpha1.Search, resourceName string) error {
 	log.V(2).Info("Deleting ClusterRoleBinding ", "resourceName", resourceName)
+	// ClusterRoleBindings are cluster-scoped — no namespace.
 	crb := &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName,
-			Namespace: instance.GetNamespace(),
+			Name: resourceName,
 		},
 	}
 	err := r.Delete(context.TODO(), crb)

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -267,27 +267,33 @@ func getRoleBindingName() string {
 // The Helm chart injects OPERATOR_ORG and OPERATOR_CHART as env vars so the operator can
 // reconstruct the full name when creating the ClusterRoleBinding's RoleRef.
 //
-// In OLM and development deployments the ClusterRole is applied from bundle/manifests/
-// or via 'make install-operand-rbac' with the plain name "search-api", so the fallback
-// is used when the env vars are absent.
+// When the env vars are absent the known defaults are used, which matches both the
+// OLM path (bundle/manifests/ uses the plain names) and a direct MCH Helm install
+// where org=open-cluster-management and chart=search-v2-operator.
 func getAPIClusterRoleName() string {
 	org := os.Getenv("OPERATOR_ORG")
-	chart := os.Getenv("OPERATOR_CHART")
-	if org != "" && chart != "" {
-		return org + ":" + chart + ":search-api"
+	if org == "" {
+		org = "open-cluster-management"
 	}
-	return "search-api"
+	chart := os.Getenv("OPERATOR_CHART")
+	if chart == "" {
+		chart = "search-v2-operator"
+	}
+	return org + ":" + chart + ":search-api"
 }
 
 // getCollectorClusterRoleName returns the name of the pre-provisioned search-collector
 // ClusterRole. Follows the same naming convention as getAPIClusterRoleName.
 func getCollectorClusterRoleName() string {
 	org := os.Getenv("OPERATOR_ORG")
-	chart := os.Getenv("OPERATOR_CHART")
-	if org != "" && chart != "" {
-		return org + ":" + chart + ":search-collector"
+	if org == "" {
+		org = "open-cluster-management"
 	}
-	return "search-collector"
+	chart := os.Getenv("OPERATOR_CHART")
+	if chart == "" {
+		chart = "search-v2-operator"
+	}
+	return org + ":" + chart + ":search-collector"
 }
 func getPVCName(scName string) string {
 	return scName + "-search"

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -72,10 +72,6 @@ func generateLabels(key, val string) map[string]string {
 	return allLabels
 }
 
-func getServiceAccountName() string {
-	return "search-serviceaccount"
-}
-
 // getAPIServiceAccountName returns the dedicated ServiceAccount used only by
 // the search-api deployment. Impersonation rights (users/groups/serviceaccounts)
 // are bound to this SA alone so that the postgres, indexer and collector pods —

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -259,6 +259,36 @@ func getRoleName() string {
 func getRoleBindingName() string {
 	return "search"
 }
+
+// getAPIClusterRoleName returns the name of the pre-provisioned search-api ClusterRole.
+//
+// In Helm deployments (multiclusterhub-operator), the ClusterRole is created with a
+// prefixed name: "<org>:<chart>:search-api" (e.g. "open-cluster-management:search-v2-operator:search-api").
+// The Helm chart injects OPERATOR_ORG and OPERATOR_CHART as env vars so the operator can
+// reconstruct the full name when creating the ClusterRoleBinding's RoleRef.
+//
+// In OLM and development deployments the ClusterRole is applied from bundle/manifests/
+// or via 'make install-operand-rbac' with the plain name "search-api", so the fallback
+// is used when the env vars are absent.
+func getAPIClusterRoleName() string {
+	org := os.Getenv("OPERATOR_ORG")
+	chart := os.Getenv("OPERATOR_CHART")
+	if org != "" && chart != "" {
+		return org + ":" + chart + ":search-api"
+	}
+	return "search-api"
+}
+
+// getCollectorClusterRoleName returns the name of the pre-provisioned search-collector
+// ClusterRole. Follows the same naming convention as getAPIClusterRoleName.
+func getCollectorClusterRoleName() string {
+	org := os.Getenv("OPERATOR_ORG")
+	chart := os.Getenv("OPERATOR_CHART")
+	if org != "" && chart != "" {
+		return org + ":" + chart + ":search-collector"
+	}
+	return "search-collector"
+}
 func getPVCName(scName string) string {
 	return scName + "-search"
 }

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -91,10 +91,11 @@ func loadClusterRole(t *testing.T, path string) rbacv1.ClusterRole {
 
 // hasVerb returns true when any rule in the ClusterRole grants the given verb
 // on (at least one of) the given resources under the given apiGroup.
-// An empty apiGroup or resource string matches any value.
+// apiGroup must match exactly — "" is the Kubernetes core API group, not a wildcard.
+// A wildcard rule in the manifest ("*") satisfies any requested apiGroup or resource.
 func hasVerb(cr rbacv1.ClusterRole, apiGroup, resource, verb string) bool {
 	for _, rule := range cr.Rules {
-		groupMatch := apiGroup == ""
+		groupMatch := false
 		for _, g := range rule.APIGroups {
 			if g == apiGroup || g == "*" {
 				groupMatch = true
@@ -116,6 +117,33 @@ func hasVerb(cr rbacv1.ClusterRole, apiGroup, resource, verb string) bool {
 			}
 		}
 		if groupMatch && resMatch && verbMatch {
+			return true
+		}
+	}
+	return false
+}
+
+// hasVerbAnyGroup returns true when any rule in the ClusterRole grants the given verb
+// on the given resource in any API group (including wildcard groups).
+// Use this only for prohibition checks where the goal is to detect any grant
+// regardless of which API group it appears in.
+func hasVerbAnyGroup(cr rbacv1.ClusterRole, resource, verb string) bool {
+	for _, rule := range cr.Rules {
+		resMatch := resource == ""
+		for _, r := range rule.Resources {
+			if r == resource || r == "*" {
+				resMatch = true
+				break
+			}
+		}
+		verbMatch := false
+		for _, v := range rule.Verbs {
+			if v == verb || v == "*" {
+				verbMatch = true
+				break
+			}
+		}
+		if resMatch && verbMatch {
 			return true
 		}
 	}
@@ -149,9 +177,9 @@ func TestSearchAPIClusterRoleCarriesImpersonate(t *testing.T) {
 		}
 	}
 
-	// search-collector must NOT carry impersonate.
+	// search-collector must NOT carry impersonate in any API group.
 	collectorCR := loadClusterRole(t, "../config/rbac/search_collector_clusterrole.yaml")
-	if hasVerb(collectorCR, "", "", "impersonate") {
+	if hasVerbAnyGroup(collectorCR, "", "impersonate") {
 		t.Error("search-collector ClusterRole must not grant impersonate on any resource")
 	}
 }
@@ -294,27 +322,44 @@ func TestCollectorClusterRoleMinimumPermissions(t *testing.T) {
 	cr := loadClusterRole(t, "../config/rbac/search_collector_clusterrole.yaml")
 
 	forbiddenVerbs := []string{"impersonate", "delete", "deletecollection"}
-	// Resources that must never have write verbs (create/update/patch/delete).
+	// Resources that must never have write verbs.
 	sensitiveResources := map[string]bool{"secrets": true, "services": true, "deployments": true}
 	writeVerbs := map[string]bool{"create": true, "update": true, "patch": true, "delete": true, "deletecollection": true}
 
 	for _, rule := range cr.Rules {
 		for _, verb := range rule.Verbs {
-			// Forbidden verbs on any resource.
+			// Forbidden verbs on any resource in any API group.
 			for _, forbidden := range forbiddenVerbs {
 				if verb == forbidden {
-					t.Errorf("collector ClusterRole must not grant %q; found on resources %v", verb, rule.Resources)
+					t.Errorf("collector ClusterRole must not grant %q; found on resources %v apiGroups %v",
+						verb, rule.Resources, rule.APIGroups)
 				}
 			}
-			// Write verbs are only allowed on collectorconfigs/status.
 			if writeVerbs[verb] {
 				for _, res := range rule.Resources {
-					if res != "collectorconfigs/status" && res != "leases" {
-						t.Errorf("collector ClusterRole grants write verb %q on unexpected resource %q", verb, res)
+					// collectorconfigs/status writes are only legitimate under the search API group.
+					if res == "collectorconfigs/status" {
+						for _, g := range rule.APIGroups {
+							if g != "search.open-cluster-management.io" {
+								t.Errorf("collector ClusterRole grants write verb %q on collectorconfigs/status in unexpected apiGroup %q", verb, g)
+							}
+						}
+						continue
 					}
+					// leases writes are only legitimate under coordination.k8s.io — not a wildcard group.
+					if res == "leases" {
+						for _, g := range rule.APIGroups {
+							if g == "*" || g != "coordination.k8s.io" {
+								t.Errorf("collector ClusterRole grants write verb %q on leases in unexpected apiGroup %q", verb, g)
+							}
+						}
+						continue
+					}
+					// All other resources must not receive write verbs.
+					t.Errorf("collector ClusterRole grants write verb %q on unexpected resource %q (apiGroups %v)", verb, res, rule.APIGroups)
 				}
 			}
-			// Sensitive resources must never receive write verbs.
+			// Sensitive resources must never receive write verbs (belt-and-suspenders).
 			if writeVerbs[verb] {
 				for _, res := range rule.Resources {
 					if sensitiveResources[res] {

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
@@ -65,41 +66,48 @@ func TestGetImageSha_TrustedImageAccepted(t *testing.T) {
 	}
 }
 
-func TestSharedClusterRoleHasNoImpersonate(t *testing.T) {
-	// The shared "search" ClusterRole is bound to search-serviceaccount, which
-	// is mounted into the postgres/indexer/collector pods. It must not carry
-	// impersonate; that verb is isolated on the search-api ClusterRole which is
-	// bound only to search-api-sa.
-	for _, rule := range getRules() {
-		for _, v := range rule.Verbs {
-			if v == "impersonate" {
-				t.Fatalf("shared search ClusterRole must not grant impersonate; found on %v", rule.Resources)
+// TestSearchAPIClusterRoleCarriesImpersonate verifies the security invariant of the
+// pre-provisioned search-api ClusterRole: it must carry impersonate (so search-api
+// can enforce per-user RBAC) and must not be granted to other component SAs.
+func TestSearchAPIClusterRoleCarriesImpersonate(t *testing.T) {
+	stripComments := func(raw []byte) string {
+		var kept []string
+		for _, line := range strings.Split(string(raw), "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), "#") {
+				kept = append(kept, line)
 			}
 		}
+		return strings.Join(kept, "\n")
 	}
-	hasImpersonate := false
-	for _, rule := range getAPIRules() {
-		for _, v := range rule.Verbs {
-			if v == "impersonate" {
-				hasImpersonate = true
-			}
-		}
+	apiYAML, err := os.ReadFile("../config/rbac/search_api_clusterrole.yaml")
+	if err != nil {
+		t.Fatalf("could not read search_api_clusterrole.yaml: %v", err)
 	}
-	if !hasImpersonate {
-		t.Fatal("search-api ClusterRole expected to carry impersonate")
+	if !strings.Contains(stripComments(apiYAML), "impersonate") {
+		t.Fatal("search-api ClusterRole must carry impersonate")
 	}
-	if getAPIServiceAccountName() == getServiceAccountName() {
-		t.Fatal("search-api must use a dedicated ServiceAccount")
+	// Collector manifest must NOT carry impersonate.
+	collectorYAML, err := os.ReadFile("../config/rbac/search_collector_clusterrole.yaml")
+	if err != nil {
+		t.Fatalf("could not read search_collector_clusterrole.yaml: %v", err)
+	}
+	if strings.Contains(stripComments(collectorYAML), "impersonate") {
+		t.Fatal("search-collector ClusterRole must not carry impersonate")
 	}
 }
 
 // TestPostgresServiceAccountIsIsolated verifies that the postgres SA uses a dedicated
-// name distinct from the shared search SA. Postgres makes no Kubernetes API calls so
-// it intentionally carries no RBAC rules — this test asserts identity isolation only.
+// name distinct from all other search component SAs.
 func TestPostgresServiceAccountIsIsolated(t *testing.T) {
 	pgSA := getPostgresServiceAccountName()
-	if pgSA == getServiceAccountName() {
-		t.Fatalf("postgres must not share the generic search-serviceaccount (%q)", pgSA)
+	for _, other := range []string{
+		getAPIServiceAccountName(),
+		getCollectorServiceAccountName(),
+		getIndexerServiceAccountName(),
+	} {
+		if pgSA == other {
+			t.Fatalf("postgres SA %q must not be shared with another component", pgSA)
+		}
 	}
 	if pgSA == "" {
 		t.Fatal("postgres SA name must not be empty")
@@ -185,7 +193,7 @@ func TestIndexerClusterRoleExactRules(t *testing.T) {
 
 // TestIndexerWorkloadIdentityContract verifies that the ClusterRoleBinding subject
 // and IndexerDeployment ServiceAccountName both reference getIndexerServiceAccountName(),
-// and that the SA name is distinct from the shared search-serviceaccount.
+// and that the SA name is distinct from all other component SAs.
 func TestIndexerWorkloadIdentityContract(t *testing.T) {
 	namespace := "test-ns"
 	instance := &searchv1alpha1.Search{
@@ -214,83 +222,63 @@ func TestIndexerWorkloadIdentityContract(t *testing.T) {
 			deploy.Spec.Template.Spec.ServiceAccountName, getIndexerServiceAccountName())
 	}
 
-	// SA must be distinct from the shared account.
-	if getIndexerServiceAccountName() == getServiceAccountName() {
-		t.Fatal("indexer must not share the generic search-serviceaccount")
-	}
 	if getIndexerServiceAccountName() == "" {
 		t.Fatal("indexer SA name must not be empty")
 	}
 }
 
-// TestCollectorClusterRoleMinimumPermissions verifies that the collector ClusterRole:
-//  1. carries no write verbs other than those needed for lease management,
-//  2. does not carry impersonate,
-//  3. does not grant secrets/services/deployments write access,
-//  4. uses a dedicated ServiceAccount distinct from the shared and API ones.
+// TestCollectorClusterRoleMinimumPermissions verifies security invariants on the
+// pre-provisioned search-collector ClusterRole static YAML manifest.
 func TestCollectorClusterRoleMinimumPermissions(t *testing.T) {
-	// Verbs the collector must never hold.
-	forbidden := map[string]bool{
-		"impersonate":      true,
-		"create":           false, // allowed only for leases — checked per-resource below
-		"update":           false, // allowed only for leases
-		"patch":            true,  // collector never patches anything
-		"delete":           true,
-		"deletecollection": true,
+	// The search-collector ClusterRole is now a pre-provisioned static manifest.
+	// Verify the security invariants directly on the YAML file.
+	collectorYAML, err := os.ReadFile("../config/rbac/search_collector_clusterrole.yaml")
+	if err != nil {
+		t.Fatalf("could not read search_collector_clusterrole.yaml: %v", err)
 	}
-	// Write verbs that are only acceptable on coordination.k8s.io/leases.
-	leaseWriteVerbs := map[string]bool{"create": true, "update": true}
+	raw := string(collectorYAML)
 
-	for _, rule := range getCollectorRules() {
-		for _, verb := range rule.Verbs {
-			if forbidden[verb] {
-				t.Errorf("collector ClusterRole must not grant %q; found on resources %v", verb, rule.Resources)
-				continue
-			}
-			// create/update are only allowed on leases
-			if leaseWriteVerbs[verb] {
-				isLeaseRule := false
-				for _, res := range rule.Resources {
-					if res == "leases" {
-						isLeaseRule = true
-						break
-					}
-				}
-				if !isLeaseRule {
-					t.Errorf("collector ClusterRole grants %q on non-lease resource %v", verb, rule.Resources)
-				}
+	// Strip comment lines before checking.
+	stripComments := func(s string) string {
+		var kept []string
+		for _, line := range strings.Split(s, "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), "#") {
+				kept = append(kept, line)
 			}
 		}
-		// Reject any rule that grants write access to secrets, services, or deployments.
-		writeSensitive := map[string]bool{"secrets": true, "services": true, "deployments": true}
-		hasWriteVerb := false
-		for _, verb := range rule.Verbs {
-			if verb != "get" && verb != "list" && verb != "watch" {
-				hasWriteVerb = true
-				break
-			}
-		}
-		if hasWriteVerb {
-			for _, res := range rule.Resources {
-				if writeSensitive[res] {
-					t.Errorf("collector ClusterRole must not grant write access to %q", res)
-				}
-			}
+		return strings.Join(kept, "\n")
+	}
+	content := stripComments(raw)
+
+	// Must never carry impersonate, delete, or deletecollection.
+	for _, forbidden := range []string{"impersonate", "delete", "deletecollection"} {
+		if strings.Contains(content, "- "+forbidden) {
+			t.Errorf("collector ClusterRole must not grant %q", forbidden)
 		}
 	}
 
-	// The collector must use its own SA.
-	if getCollectorServiceAccountName() == getServiceAccountName() {
-		t.Fatal("collector must use a dedicated ServiceAccount, not the shared search-serviceaccount")
+	// patch/update are allowed only on collectorconfigs/status (sync-status reporting).
+	// Verify they are not present on any other resource.
+	if strings.Contains(content, "- patch") && !strings.Contains(content, "collectorconfigs/status") {
+		t.Error("collector ClusterRole grants 'patch' but collectorconfigs/status is missing — patch should only appear on that subresource")
 	}
+
+	// Must not grant write access to secrets, services, or deployments.
+	for _, sensitive := range []string{"secrets", "services", "deployments"} {
+		if strings.Contains(content, "- "+sensitive) {
+			t.Errorf("collector ClusterRole must not reference %q with write verbs", sensitive)
+		}
+	}
+
+	// The collector must use its own SA, distinct from search-api's.
 	if getCollectorServiceAccountName() == getAPIServiceAccountName() {
-		t.Fatal("collector must use a dedicated ServiceAccount, not the search-api SA")
+		t.Fatal("collector SA must not match search-api SA")
 	}
 }
 
 // TestCollectorWorkloadIdentityContract verifies that both the ClusterRoleBinding
 // subject and the CollectorDeployment ServiceAccountName reference
-// getCollectorServiceAccountName(), and that the SA is distinct from the shared account.
+// getCollectorServiceAccountName(), and that the SA is distinct from all other SAs.
 func TestCollectorWorkloadIdentityContract(t *testing.T) {
 	namespace := "test-ns"
 	instance := &searchv1alpha1.Search{
@@ -319,10 +307,6 @@ func TestCollectorWorkloadIdentityContract(t *testing.T) {
 			deploy.Spec.Template.Spec.ServiceAccountName, getCollectorServiceAccountName())
 	}
 
-	// SA must be distinct from the shared account.
-	if getCollectorServiceAccountName() == getServiceAccountName() {
-		t.Fatal("collector must not share the generic search-serviceaccount")
-	}
 	if getCollectorServiceAccountName() == "" {
 		t.Fatal("collector SA name must not be empty")
 	}

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -338,20 +338,18 @@ func TestCollectorClusterRoleMinimumPermissions(t *testing.T) {
 			if writeVerbs[verb] {
 				for _, res := range rule.Resources {
 					// collectorconfigs/status writes are only legitimate under the search API group.
+					// Exactly one API group is required — empty or wildcard slices are rejected.
 					if res == "collectorconfigs/status" {
-						for _, g := range rule.APIGroups {
-							if g != "search.open-cluster-management.io" {
-								t.Errorf("collector ClusterRole grants write verb %q on collectorconfigs/status in unexpected apiGroup %q", verb, g)
-							}
+						if len(rule.APIGroups) != 1 || rule.APIGroups[0] != "search.open-cluster-management.io" {
+							t.Errorf("collector ClusterRole grants write verb %q on collectorconfigs/status with apiGroups %v", verb, rule.APIGroups)
 						}
 						continue
 					}
 					// leases writes are only legitimate under coordination.k8s.io — not a wildcard group.
+					// Exactly one API group is required — empty or wildcard slices are rejected.
 					if res == "leases" {
-						for _, g := range rule.APIGroups {
-							if g == "*" || g != "coordination.k8s.io" {
-								t.Errorf("collector ClusterRole grants write verb %q on leases in unexpected apiGroup %q", verb, g)
-							}
+						if len(rule.APIGroups) != 1 || rule.APIGroups[0] != "coordination.k8s.io" {
+							t.Errorf("collector ClusterRole grants write verb %q on leases with apiGroups %v", verb, rule.APIGroups)
 						}
 						continue
 					}

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -11,6 +11,7 @@ import (
 	searchv1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 )
 
 func TestGetImageSha_UntrustedImageRejected(t *testing.T) {
@@ -66,33 +68,91 @@ func TestGetImageSha_TrustedImageAccepted(t *testing.T) {
 	}
 }
 
-// TestSearchAPIClusterRoleCarriesImpersonate verifies the security invariant of the
-// pre-provisioned search-api ClusterRole: it must carry impersonate (so search-api
-// can enforce per-user RBAC) and must not be granted to other component SAs.
-func TestSearchAPIClusterRoleCarriesImpersonate(t *testing.T) {
-	stripComments := func(raw []byte) string {
-		var kept []string
-		for _, line := range strings.Split(string(raw), "\n") {
-			if !strings.HasPrefix(strings.TrimSpace(line), "#") {
-				kept = append(kept, line)
+// loadClusterRole decodes a ClusterRole from a YAML file, stripping comment lines first.
+func loadClusterRole(t *testing.T, path string) rbacv1.ClusterRole {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("could not read %s: %v", path, err)
+	}
+	// Strip YAML comment lines so the decoder is not confused by them.
+	var kept []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			kept = append(kept, line)
+		}
+	}
+	var cr rbacv1.ClusterRole
+	if err := yaml.Unmarshal([]byte(strings.Join(kept, "\n")), &cr); err != nil {
+		t.Fatalf("could not unmarshal ClusterRole from %s: %v", path, err)
+	}
+	return cr
+}
+
+// hasVerb returns true when any rule in the ClusterRole grants the given verb
+// on (at least one of) the given resources under the given apiGroup.
+// An empty apiGroup or resource string matches any value.
+func hasVerb(cr rbacv1.ClusterRole, apiGroup, resource, verb string) bool {
+	for _, rule := range cr.Rules {
+		groupMatch := apiGroup == ""
+		for _, g := range rule.APIGroups {
+			if g == apiGroup || g == "*" {
+				groupMatch = true
+				break
 			}
 		}
-		return strings.Join(kept, "\n")
+		resMatch := resource == ""
+		for _, r := range rule.Resources {
+			if r == resource || r == "*" {
+				resMatch = true
+				break
+			}
+		}
+		verbMatch := false
+		for _, v := range rule.Verbs {
+			if v == verb || v == "*" {
+				verbMatch = true
+				break
+			}
+		}
+		if groupMatch && resMatch && verbMatch {
+			return true
+		}
 	}
-	apiYAML, err := os.ReadFile("../config/rbac/search_api_clusterrole.yaml")
-	if err != nil {
-		t.Fatalf("could not read search_api_clusterrole.yaml: %v", err)
+	return false
+}
+
+// TestSearchAPIClusterRoleCarriesImpersonate verifies the security invariant of the
+// pre-provisioned search-api ClusterRole: it must carry impersonate on the correct
+// resources, and the search-collector ClusterRole must not carry it at all.
+func TestSearchAPIClusterRoleCarriesImpersonate(t *testing.T) {
+	apiCR := loadClusterRole(t, "../config/rbac/search_api_clusterrole.yaml")
+
+	// search-api must grant impersonate on users/serviceaccounts/groups.
+	for _, res := range []string{"users", "serviceaccounts", "groups"} {
+		if !hasVerb(apiCR, "", res, "impersonate") {
+			t.Errorf("search-api ClusterRole must grant impersonate on %q", res)
+		}
 	}
-	if !strings.Contains(stripComments(apiYAML), "impersonate") {
-		t.Fatal("search-api ClusterRole must carry impersonate")
+	// search-api must grant impersonate on user-extra resources.
+	for _, res := range []string{
+		"uids",
+		"userextras/authentication.kubernetes.io/credential-id",
+		"userextras/authentication.kubernetes.io/node-name",
+		"userextras/authentication.kubernetes.io/node-uid",
+		"userextras/authentication.kubernetes.io/pod-name",
+		"userextras/authentication.kubernetes.io/pod-uid",
+	} {
+		if !hasVerb(apiCR, "authentication.k8s.io", res, "impersonate") &&
+			!hasVerb(apiCR, "authorization.k8s.io", res, "impersonate") {
+			t.Errorf("search-api ClusterRole must grant impersonate on %q", res)
+		}
 	}
-	// Collector manifest must NOT carry impersonate.
-	collectorYAML, err := os.ReadFile("../config/rbac/search_collector_clusterrole.yaml")
-	if err != nil {
-		t.Fatalf("could not read search_collector_clusterrole.yaml: %v", err)
-	}
-	if strings.Contains(stripComments(collectorYAML), "impersonate") {
-		t.Fatal("search-collector ClusterRole must not carry impersonate")
+
+	// search-collector must NOT carry impersonate.
+	collectorCR := loadClusterRole(t, "../config/rbac/search_collector_clusterrole.yaml")
+	if hasVerb(collectorCR, "", "", "impersonate") {
+		t.Error("search-collector ClusterRole must not grant impersonate on any resource")
 	}
 }
 
@@ -228,45 +288,40 @@ func TestIndexerWorkloadIdentityContract(t *testing.T) {
 }
 
 // TestCollectorClusterRoleMinimumPermissions verifies security invariants on the
-// pre-provisioned search-collector ClusterRole static YAML manifest.
+// pre-provisioned search-collector ClusterRole by decoding the static YAML manifest
+// into an rbacv1.ClusterRole and asserting per-rule verb/resource constraints.
 func TestCollectorClusterRoleMinimumPermissions(t *testing.T) {
-	// The search-collector ClusterRole is now a pre-provisioned static manifest.
-	// Verify the security invariants directly on the YAML file.
-	collectorYAML, err := os.ReadFile("../config/rbac/search_collector_clusterrole.yaml")
-	if err != nil {
-		t.Fatalf("could not read search_collector_clusterrole.yaml: %v", err)
-	}
-	raw := string(collectorYAML)
+	cr := loadClusterRole(t, "../config/rbac/search_collector_clusterrole.yaml")
 
-	// Strip comment lines before checking.
-	stripComments := func(s string) string {
-		var kept []string
-		for _, line := range strings.Split(s, "\n") {
-			if !strings.HasPrefix(strings.TrimSpace(line), "#") {
-				kept = append(kept, line)
+	forbiddenVerbs := []string{"impersonate", "delete", "deletecollection"}
+	// Resources that must never have write verbs (create/update/patch/delete).
+	sensitiveResources := map[string]bool{"secrets": true, "services": true, "deployments": true}
+	writeVerbs := map[string]bool{"create": true, "update": true, "patch": true, "delete": true, "deletecollection": true}
+
+	for _, rule := range cr.Rules {
+		for _, verb := range rule.Verbs {
+			// Forbidden verbs on any resource.
+			for _, forbidden := range forbiddenVerbs {
+				if verb == forbidden {
+					t.Errorf("collector ClusterRole must not grant %q; found on resources %v", verb, rule.Resources)
+				}
 			}
-		}
-		return strings.Join(kept, "\n")
-	}
-	content := stripComments(raw)
-
-	// Must never carry impersonate, delete, or deletecollection.
-	for _, forbidden := range []string{"impersonate", "delete", "deletecollection"} {
-		if strings.Contains(content, "- "+forbidden) {
-			t.Errorf("collector ClusterRole must not grant %q", forbidden)
-		}
-	}
-
-	// patch/update are allowed only on collectorconfigs/status (sync-status reporting).
-	// Verify they are not present on any other resource.
-	if strings.Contains(content, "- patch") && !strings.Contains(content, "collectorconfigs/status") {
-		t.Error("collector ClusterRole grants 'patch' but collectorconfigs/status is missing — patch should only appear on that subresource")
-	}
-
-	// Must not grant write access to secrets, services, or deployments.
-	for _, sensitive := range []string{"secrets", "services", "deployments"} {
-		if strings.Contains(content, "- "+sensitive) {
-			t.Errorf("collector ClusterRole must not reference %q with write verbs", sensitive)
+			// Write verbs are only allowed on collectorconfigs/status.
+			if writeVerbs[verb] {
+				for _, res := range rule.Resources {
+					if res != "collectorconfigs/status" && res != "leases" {
+						t.Errorf("collector ClusterRole grants write verb %q on unexpected resource %q", verb, res)
+					}
+				}
+			}
+			// Sensitive resources must never receive write verbs.
+			if writeVerbs[verb] {
+				for _, res := range rule.Resources {
+					if sensitiveResources[res] {
+						t.Errorf("collector ClusterRole must not grant write verb %q on sensitive resource %q", verb, res)
+					}
+				}
+			}
 		}
 	}
 

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -56,7 +56,11 @@ func (r *SearchReconciler) createRoleBinding(ctx context.Context,
 		Name:      rolebinding.Name,
 		Namespace: rolebinding.Namespace,
 	}, found)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "Could not get clusterrolebinding", "name", rolebinding.Name)
+		return &reconcile.Result{}, err
+	}
+	if errors.IsNotFound(err) {
 		err = r.Create(ctx, rolebinding)
 		if err != nil {
 			log.Error(err, "Could not create clusterrolebinding"+rolebinding.Name)
@@ -64,7 +68,7 @@ func (r *SearchReconciler) createRoleBinding(ctx context.Context,
 		}
 		log.Info("Created clusterrolebinding " + rolebinding.Name)
 		log.V(2).Info("Created clusterrolebinding ", "clusterrolebinding", rolebinding)
-	} else if err == nil {
+	} else {
 		// ClusterRoleBinding.roleRef is immutable in Kubernetes. If the desired RoleRef
 		// differs from the existing one (e.g. OPERATOR_ORG / OPERATOR_CHART changed between
 		// releases), we must delete and recreate rather than update.

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -92,7 +92,7 @@ func (r *SearchReconciler) APIClusterRoleBinding(instance *searchv1alpha1.Search
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",
-			Name:     getRoleName() + "-api",
+			Name:     getAPIClusterRoleName(),
 			APIGroup: rbacv1.GroupName,
 		},
 		Subjects: []rbacv1.Subject{{
@@ -168,7 +168,7 @@ func (r *SearchReconciler) CollectorClusterRoleBinding(instance *searchv1alpha1.
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",
-			Name:     getRoleName() + "-collector",
+			Name:     getCollectorClusterRoleName(),
 			APIGroup: rbacv1.GroupName,
 		},
 		Subjects: []rbacv1.Subject{{

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -76,69 +75,9 @@ func (r *SearchReconciler) createRoleBinding(ctx context.Context,
 	return nil, nil
 }
 
-func (r *SearchReconciler) ClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
-	cr := &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      getRoleName(),
-			Namespace: instance.GetNamespace(),
-		},
-		Rules: getRules(),
-	}
-	err := controllerutil.SetControllerReference(instance, cr, r.Scheme)
-	if err != nil {
-		log.Info("Could not set control for ClusterRole " + getRoleName())
-	}
-	return cr
-}
-
-func (r *SearchReconciler) ClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
-	crb := &rbacv1.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRoleBinding",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      getRoleBindingName(),
-			Namespace: instance.GetNamespace(),
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     getRoleName(),
-			APIGroup: rbacv1.GroupName,
-		},
-		Subjects: getSubjects(instance.GetNamespace()),
-	}
-	err := controllerutil.SetControllerReference(instance, crb, r.Scheme)
-	if err != nil {
-		log.Info("Could not set control for ClusterRoleBinding" + getRoleBindingName())
-	}
-	return crb
-}
-
-// APIClusterRole holds the impersonation rights that only search-api needs.
-// It is bound exclusively to the search-api ServiceAccount so that the
-// postgres, indexer and collector pods (which share search-serviceaccount)
-// cannot escalate to system:masters via their mounted token.
-func (r *SearchReconciler) APIClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
-	// Note: SetControllerReference is intentionally omitted. ClusterRole is cluster-scoped;
-	// Search is namespaced. Kubernetes forbids a namespaced owner on a cluster-scoped
-	// dependent, so the reference would always fail. Cleanup is handled explicitly in
-	// finalizeSearch via deleteClusterRole.
-	return &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: getRoleName() + "-api",
-		},
-		Rules: getAPIRules(),
-	}
-}
+// The "search-api" and "search-collector" ClusterRoles are pre-provisioned as static
+// manifests. The operator creates only the ClusterRoleBindings that reference them,
+// using the 'bind' verb so the operator SA never needs to hold impersonate or wildcard read.
 
 func (r *SearchReconciler) APIClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
 	// Note: SetControllerReference is intentionally omitted for the same reason as
@@ -214,30 +153,11 @@ func (r *SearchReconciler) IndexerClusterRoleBinding(instance *searchv1alpha1.Se
 	}
 }
 
-// CollectorClusterRole holds the minimum permissions required by the search-collector
-// deployment. The collector only needs to watch all resources (for inventory) and
-// manage its own lease (for heartbeat). It does not need impersonate, write access
-// to secrets/services/deployments, or any auth review verbs.
-func (r *SearchReconciler) CollectorClusterRole(instance *searchv1alpha1.Search) *rbacv1.ClusterRole {
-	// Note: SetControllerReference is intentionally omitted. ClusterRole is cluster-scoped;
-	// Search is namespaced. Kubernetes forbids a namespaced owner on a cluster-scoped
-	// dependent, so the reference would always fail. Cleanup is handled explicitly in
-	// finalizeSearch via deleteClusterRole.
-	return &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: getRoleName() + "-collector",
-		},
-		Rules: getCollectorRules(),
-	}
-}
-
+// CollectorClusterRoleBinding binds the pre-provisioned search-collector ClusterRole
+// (wildcard read) to the dedicated search-collector-sa ServiceAccount.
 func (r *SearchReconciler) CollectorClusterRoleBinding(instance *searchv1alpha1.Search) *rbacv1.ClusterRoleBinding {
-	// Note: SetControllerReference is intentionally omitted for the same reason as
-	// CollectorClusterRole. Cleanup is handled explicitly in finalizeSearch.
+	// Note: SetControllerReference is intentionally omitted. ClusterRoleBinding is
+	// cluster-scoped; Search is namespaced. Cleanup is handled explicitly in finalizeSearch.
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
@@ -287,85 +207,6 @@ func (r *SearchReconciler) GlobalSearchUserClusterRole(instance *searchv1alpha1.
 	}
 }
 
-func getSubjects(namespace string) []rbacv1.Subject {
-	return []rbacv1.Subject{
-		{
-			Kind:      "ServiceAccount",
-			Name:      getServiceAccountName(),
-			Namespace: namespace,
-		},
-		{
-			Kind:      "ServiceAccount",
-			Name:      getAPIServiceAccountName(),
-			Namespace: namespace,
-		},
-	}
-}
-
-func getRules() []rbacv1.PolicyRule {
-	return []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{"*"},
-			Resources: []string{"*"},
-			Verbs:     []string{"get", "list", "watch"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"secrets", "services"},
-			Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
-		},
-		{
-			APIGroups: []string{"coordination.k8s.io"},
-			Resources: []string{"leases"},
-			Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
-		},
-		{
-			APIGroups: []string{"apps"},
-			Resources: []string{"deployments"},
-			Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
-		},
-		{
-			APIGroups: []string{"authentication.k8s.io"},
-			Resources: []string{"tokenreviews"},
-			Verbs:     []string{"create"},
-		},
-		{
-			APIGroups: []string{"authorization.k8s.io"},
-			Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews"},
-			Verbs:     []string{"create"},
-		},
-		{
-			APIGroups: []string{"search.open-cluster-management.io"},
-			Resources: []string{"collectorconfigs/status"},
-			Verbs:     []string{"patch", "update"},
-		},
-	}
-}
-
-// getAPIRules returns the rules bound only to the search-api ServiceAccount.
-// These are layered on top of getRules() (search-api is also bound to the
-// shared "search" ClusterRole) and isolate the impersonation rights that
-// search-api uses for user-scoped query authorization.
-func getAPIRules() []rbacv1.PolicyRule {
-	return []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{"authentication.k8s.io", "authorization.k8s.io"},
-			Resources: []string{"uids",
-				"userextras/authentication.kubernetes.io/credential-id",
-				"userextras/authentication.kubernetes.io/node-name",
-				"userextras/authentication.kubernetes.io/node-uid",
-				"userextras/authentication.kubernetes.io/pod-name",
-				"userextras/authentication.kubernetes.io/pod-uid"},
-			Verbs: []string{"impersonate"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"users", "serviceaccounts", "groups"},
-			Verbs:     []string{"impersonate"},
-		},
-	}
-}
-
 func getMetricsRules() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
@@ -387,49 +228,6 @@ func getAddonRules() []rbacv1.PolicyRule {
 			APIGroups: []string{"coordination.k8s.io"},
 			Resources: []string{"leases"},
 			Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},
-		},
-	}
-}
-
-// getCollectorRules returns the minimum permissions required by the search-collector pod.
-//
-// The collector's API surface (verified from source):
-//   - Dynamic informers:  get/list/watch on all resources (*/*) for cluster inventory.
-//   - Discovery client:   ServerPreferredResources — implicit; covered by the wildcard.
-//   - ConfigMap read:     get on core/v1 ConfigMaps in its own namespace to read
-//     search-collector-config (allow/deny resource filter).
-//   - CollectorConfig:    get/list/watch on collectorconfigs.search.open-cluster-management.io
-//     for configurable collection hot-reload.
-//   - Lease management:   get/create/update on coordination.k8s.io/leases for the heartbeat
-//     signal sent to the addon framework.
-//
-// The collector does NOT use: impersonate, secrets/services/deployments write,
-// tokenreviews, selfsubjectaccessreviews, or collectorconfigs/status patch/update.
-func getCollectorRules() []rbacv1.PolicyRule {
-	return []rbacv1.PolicyRule{
-		// Watch every resource in the cluster for inventory collection.
-		{
-			APIGroups: []string{"*"},
-			Resources: []string{"*"},
-			Verbs:     []string{"get", "list", "watch"},
-		},
-		// Read the search-collector-config ConfigMap (allow/deny filter for resources).
-		{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-			Verbs:     []string{"get"},
-		},
-		// Watch CollectorConfig CRs for configurable-collection hot-reload.
-		{
-			APIGroups: []string{"search.open-cluster-management.io"},
-			Resources: []string{"collectorconfigs"},
-			Verbs:     []string{"get", "list", "watch"},
-		},
-		// Manage the addon heartbeat lease.
-		{
-			APIGroups: []string{"coordination.k8s.io"},
-			Resources: []string{"leases"},
-			Verbs:     []string{"get", "create", "update"},
 		},
 	}
 }

--- a/controllers/create_rolesbindings.go
+++ b/controllers/create_rolesbindings.go
@@ -64,13 +64,30 @@ func (r *SearchReconciler) createRoleBinding(ctx context.Context,
 		}
 		log.Info("Created clusterrolebinding " + rolebinding.Name)
 		log.V(2).Info("Created clusterrolebinding ", "clusterrolebinding", rolebinding)
-	} else if err == nil && !equality.Semantic.DeepEqual(found.Subjects, rolebinding.Subjects) {
-		found.Subjects = rolebinding.Subjects
-		if err = r.Update(ctx, found); err != nil {
-			log.Error(err, "Could not update clusterrolebinding "+rolebinding.Name)
-			return &reconcile.Result{}, err
+	} else if err == nil {
+		// ClusterRoleBinding.roleRef is immutable in Kubernetes. If the desired RoleRef
+		// differs from the existing one (e.g. OPERATOR_ORG / OPERATOR_CHART changed between
+		// releases), we must delete and recreate rather than update.
+		if !equality.Semantic.DeepEqual(found.RoleRef, rolebinding.RoleRef) {
+			log.Info("RoleRef changed — deleting and recreating clusterrolebinding", "name", rolebinding.Name,
+				"old", found.RoleRef.Name, "new", rolebinding.RoleRef.Name)
+			if err = r.Delete(ctx, found); err != nil {
+				log.Error(err, "Could not delete stale clusterrolebinding "+rolebinding.Name)
+				return &reconcile.Result{}, err
+			}
+			if err = r.Create(ctx, rolebinding); err != nil {
+				log.Error(err, "Could not recreate clusterrolebinding "+rolebinding.Name)
+				return &reconcile.Result{}, err
+			}
+			log.Info("Recreated clusterrolebinding " + rolebinding.Name)
+		} else if !equality.Semantic.DeepEqual(found.Subjects, rolebinding.Subjects) {
+			found.Subjects = rolebinding.Subjects
+			if err = r.Update(ctx, found); err != nil {
+				log.Error(err, "Could not update clusterrolebinding "+rolebinding.Name)
+				return &reconcile.Result{}, err
+			}
+			log.Info("Updated clusterrolebinding " + rolebinding.Name)
 		}
-		log.Info("Updated clusterrolebinding " + rolebinding.Name)
 	}
 	return nil, nil
 }

--- a/controllers/create_serviceaccount.go
+++ b/controllers/create_serviceaccount.go
@@ -40,26 +40,6 @@ func (r *SearchReconciler) createSearchServiceAccount(ctx context.Context,
 	return nil, nil
 }
 
-func (r *SearchReconciler) SearchServiceAccount(instance *searchv1alpha1.Search) *corev1.ServiceAccount {
-
-	sa := &corev1.ServiceAccount{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceAccount",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      getServiceAccountName(),
-			Namespace: instance.GetNamespace(),
-		},
-	}
-
-	err := controllerutil.SetControllerReference(instance, sa, r.Scheme)
-	if err != nil {
-		log.V(2).Info("Could not set control for ", "serviceaccount", getServiceAccountName())
-	}
-	return sa
-}
-
 // SearchPostgresServiceAccount builds the dedicated SA for the search-postgres
 // deployment. Postgres makes no Kubernetes API calls, so no ClusterRole is bound
 // to this SA — it exists solely to isolate the pod identity from the other

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -378,39 +378,33 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "Failed to remove Search ownerRef from ClusterManagementAddon")
 		}
 
-		// Remove legacy shared RBAC objects left on clusters upgraded from pre-ACM-34432 releases.
-		// Before ACM 2.X the operator created a shared "search" ClusterRole (carrying impersonate),
-		// a matching "search" ClusterRoleBinding, and a "search-serviceaccount" ServiceAccount.
-		// These are no longer used — every component now has a dedicated ServiceAccount and the
-		// operator SA no longer holds impersonate. Cleaning them up closes the lingering
-		// privilege escalation path on upgraded clusters.
-		// The previously operator-managed "search-api" and "search-collector" ClusterRoles are now
-		// pre-provisioned static manifests. OLM will reconcile the existing objects against the
-		// bundle manifests; for non-OLM installs, 'make install-operand-rbac' replaces them.
-		legacyObjects := []struct{ kind, name string }{
-			{"ClusterRole", getRoleName()},
-			{"ClusterRoleBinding", getRoleBindingName()},
-		}
-		for _, obj := range legacyObjects {
-			switch obj.kind {
-			case "ClusterRole":
-				if delErr := r.deleteClusterRole(instance, obj.name); delErr != nil {
-					log.Error(delErr, "Failed to delete legacy ClusterRole", "name", obj.name)
-				}
-			case "ClusterRoleBinding":
-				if delErr := r.deleteClusterRoleBinding(instance, obj.name); delErr != nil {
-					log.Error(delErr, "Failed to delete legacy ClusterRoleBinding", "name", obj.name)
-				}
-			}
-		}
-		// Delete the legacy shared ServiceAccount.
-		legacySA := &corev1.ServiceAccount{}
-		legacySA.Name = "search-serviceaccount"
-		legacySA.Namespace = instance.GetNamespace()
-		if delErr := r.Delete(ctx, legacySA); delErr != nil && !errors.IsNotFound(delErr) {
-			log.Error(delErr, "Failed to delete legacy ServiceAccount", "name", "search-serviceaccount")
-		}
 	})
+
+	// Remove legacy shared RBAC objects left on clusters upgraded from pre-ACM-34432 releases.
+	// Before ACM-34432 the operator created a shared "search" ClusterRole (carrying impersonate),
+	// a matching "search" ClusterRoleBinding, and a "search-serviceaccount" ServiceAccount.
+	// These are no longer used — every component now has a dedicated ServiceAccount and the
+	// operator SA no longer holds impersonate. Cleaning them up closes the lingering
+	// privilege escalation path on upgraded clusters.
+	//
+	// This runs outside cleanOnce so that transient API errors are retried on the next
+	// reconcile rather than permanently skipped. deleteClusterRole/deleteClusterRoleBinding
+	// are no-ops when the object is already gone (IsNotFound is swallowed inside them).
+	if err := r.deleteClusterRole(instance, getRoleName()); err != nil {
+		log.Error(err, "Failed to delete legacy ClusterRole", "name", getRoleName())
+		return ctrl.Result{}, err
+	}
+	if err := r.deleteClusterRoleBinding(instance, getRoleBindingName()); err != nil {
+		log.Error(err, "Failed to delete legacy ClusterRoleBinding", "name", getRoleBindingName())
+		return ctrl.Result{}, err
+	}
+	legacySA := &corev1.ServiceAccount{}
+	legacySA.Name = "search-serviceaccount"
+	legacySA.Namespace = instance.GetNamespace()
+	if err := r.Delete(ctx, legacySA); err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "Failed to delete legacy ServiceAccount", "name", "search-serviceaccount")
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -34,7 +34,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -65,11 +64,14 @@ var once sync.Once
 var cleanOnce sync.Once
 
 //+kubebuilder:rbac:groups=*,resources=*,verbs=list;get;watch
-//+kubebuilder:rbac:groups="",resources=groups;secrets;serviceaccounts;services;users,verbs=create;get;list;watch;patch;update;delete;impersonate
+//+kubebuilder:rbac:groups="",resources=secrets;serviceaccounts;services,verbs=create;get;list;watch;patch;update;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
+// 'bind' on the pre-provisioned search-api and search-collector ClusterRoles lets the
+// operator create their ClusterRoleBindings without holding 'impersonate' or wildcard
+// read. Both ClusterRoles are static manifests; the operator never creates or updates them.
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind,resourceNames=search-api;search-collector
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=create;get;list;update;delete
-//+kubebuilder:rbac:groups=authentication.k8s.io;authorization.k8s.io,resources=uids;userextras/authentication.kubernetes.io/credential-id;userextras/authentication.kubernetes.io/node-name;userextras/authentication.kubernetes.io/node-uid;userextras/authentication.kubernetes.io/pod-uid;userextras/authentication.kubernetes.io/pod-name,verbs=impersonate
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;patch;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=create;get;update
@@ -151,12 +153,7 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}, nil
 		}
 	}
-	result, err := r.createSearchServiceAccount(ctx, r.SearchServiceAccount(instance))
-	if result != nil {
-		log.Error(err, "SearchServiceAccount setup failed")
-		return *result, err
-	}
-	result, err = r.createSearchServiceAccount(ctx, r.SearchAPIServiceAccount(instance))
+	result, err := r.createSearchServiceAccount(ctx, r.SearchAPIServiceAccount(instance))
 	if result != nil {
 		log.Error(err, "SearchAPIServiceAccount setup failed")
 		return *result, err
@@ -186,24 +183,12 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "SearchCollectorServiceAccount setup failed")
 		return *result, err
 	}
-	result, err = r.createUpdateRoles(ctx, r.ClusterRole(instance))
-	if result != nil {
-		log.Error(err, "ClusterRole setup failed")
-		return *result, err
-	}
-	result, err = r.createUpdateRoles(ctx, r.APIClusterRole(instance))
-	if result != nil {
-		log.Error(err, "APIClusterRole setup failed")
-		return *result, err
-	}
+	// "search-api" and "search-collector" ClusterRoles are pre-provisioned as static
+	// manifests and must exist before the operator starts.  Only their ClusterRoleBindings
+	// are reconciled here.
 	result, err = r.createUpdateRoles(ctx, r.IndexerClusterRole(instance))
 	if result != nil {
 		log.Error(err, "IndexerClusterRole setup failed")
-		return *result, err
-	}
-	result, err = r.createUpdateRoles(ctx, r.CollectorClusterRole(instance))
-	if result != nil {
-		log.Error(err, "CollectorClusterRole setup failed")
 		return *result, err
 	}
 	result, err = r.createUpdateRoles(ctx, r.AddonClusterRole(instance))
@@ -216,24 +201,19 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "GlobalSearchUserClusterRole setup failed")
 		return *result, err
 	}
-	result, err = r.createRoleBinding(ctx, r.ClusterRoleBinding(instance))
-	if result != nil {
-		log.Error(err, "ClusterRoleBinding setup failed")
-		return *result, err
-	}
 	result, err = r.createRoleBinding(ctx, r.APIClusterRoleBinding(instance))
 	if result != nil {
 		log.Error(err, "APIClusterRoleBinding setup failed")
 		return *result, err
 	}
-	result, err = r.createRoleBinding(ctx, r.IndexerClusterRoleBinding(instance))
-	if result != nil {
-		log.Error(err, "IndexerClusterRoleBinding setup failed")
-		return *result, err
-	}
 	result, err = r.createRoleBinding(ctx, r.CollectorClusterRoleBinding(instance))
 	if result != nil {
 		log.Error(err, "CollectorClusterRoleBinding setup failed")
+		return *result, err
+	}
+	result, err = r.createRoleBinding(ctx, r.IndexerClusterRoleBinding(instance))
+	if result != nil {
+		log.Error(err, "IndexerClusterRoleBinding setup failed")
 		return *result, err
 	}
 	if err := r.ensureWebhookCAInjection(ctx); err != nil {
@@ -485,21 +465,6 @@ func (r *SearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			}),
 		).
-		Watches(&rbacv1.ClusterRole{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, a client.Object) []reconcile.Request {
-				if a.GetName() == getRoleName() {
-					return []reconcile.Request{
-						{
-							NamespacedName: types.NamespacedName{
-								Name:      "ClusterRole/" + a.GetName(),
-								Namespace: os.Getenv("WATCH_NAMESPACE"),
-							},
-						},
-					}
-				}
-				return nil
-			}),
-		).
 		Watches(&clusterv1.ManagedCluster{}, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, a client.Object) []reconcile.Request {
 				// Only trigger reconcile for managedHub clusters
@@ -629,23 +594,15 @@ func (r *SearchReconciler) finalizeSearch(instance *searchv1alpha1.Search) error
 	if err != nil {
 		return err
 	}
-	searchCRName := getRoleName()
-	err = r.deleteClusterRole(instance, searchCRName)
-	if err != nil {
-		return err
-	}
-	searchCRBName := getRoleBindingName()
-	err = r.deleteClusterRoleBinding(instance, searchCRBName)
-	if err != nil {
-		return err
-	}
-	// The API ClusterRole and ClusterRoleBinding are cluster-scoped and cannot carry
-	// an owner reference (Search is namespaced), so they must be deleted explicitly here.
-	err = r.deleteClusterRole(instance, getRoleName()+"-api")
-	if err != nil {
-		return err
-	}
+	// "search-api" ClusterRole is pre-provisioned as a static manifest — do NOT delete it.
+	// Delete only the ClusterRoleBinding the operator created.
 	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-api")
+	if err != nil {
+		return err
+	}
+	// "search-collector" ClusterRole is pre-provisioned as a static manifest — do NOT delete it.
+	// Delete only the ClusterRoleBinding the operator created.
+	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-collector")
 	if err != nil {
 		return err
 	}
@@ -656,16 +613,6 @@ func (r *SearchReconciler) finalizeSearch(instance *searchv1alpha1.Search) error
 		return err
 	}
 	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-indexer")
-	if err != nil {
-		return err
-	}
-	// The collector ClusterRole and ClusterRoleBinding are cluster-scoped and cannot carry
-	// an owner reference (Search is namespaced), so they must be deleted explicitly here.
-	err = r.deleteClusterRole(instance, getRoleName()+"-collector")
-	if err != nil {
-		return err
-	}
-	err = r.deleteClusterRoleBinding(instance, getRoleBindingName()+"-collector")
 	if err != nil {
 		return err
 	}

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -68,9 +68,15 @@ var cleanOnce sync.Once
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // 'bind' on the pre-provisioned search-api and search-collector ClusterRoles lets the
-// operator create their ClusterRoleBindings without holding 'impersonate' or wildcard
-// read. Both ClusterRoles are static manifests; the operator never creates or updates them.
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind,resourceNames=search-api;search-collector
+// operator create their ClusterRoleBindings without holding 'impersonate' or wildcard read.
+// Both ClusterRoles are static manifests; the operator never creates or updates them.
+// The operator resolves the actual ClusterRole name at runtime via getAPIClusterRoleName() /
+// getCollectorClusterRoleName(), which read OPERATOR_ORG and OPERATOR_CHART env vars.
+// In Helm deployments the ClusterRoles carry an org:chart: prefix so resourceNames cannot
+// be set statically here. 'bind' on clusterroles without resourceNames is intentional and
+// safe — 'bind' only allows creating a ClusterRoleBinding that references an existing role;
+// it does not grant the permissions that role contains.
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=create;get;list;update;delete
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;patch;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list

--- a/controllers/search_controller.go
+++ b/controllers/search_controller.go
@@ -377,6 +377,39 @@ func (r *SearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err != nil {
 			log.Error(err, "Failed to remove Search ownerRef from ClusterManagementAddon")
 		}
+
+		// Remove legacy shared RBAC objects left on clusters upgraded from pre-ACM-34432 releases.
+		// Before ACM 2.X the operator created a shared "search" ClusterRole (carrying impersonate),
+		// a matching "search" ClusterRoleBinding, and a "search-serviceaccount" ServiceAccount.
+		// These are no longer used — every component now has a dedicated ServiceAccount and the
+		// operator SA no longer holds impersonate. Cleaning them up closes the lingering
+		// privilege escalation path on upgraded clusters.
+		// The previously operator-managed "search-api" and "search-collector" ClusterRoles are now
+		// pre-provisioned static manifests. OLM will reconcile the existing objects against the
+		// bundle manifests; for non-OLM installs, 'make install-operand-rbac' replaces them.
+		legacyObjects := []struct{ kind, name string }{
+			{"ClusterRole", getRoleName()},
+			{"ClusterRoleBinding", getRoleBindingName()},
+		}
+		for _, obj := range legacyObjects {
+			switch obj.kind {
+			case "ClusterRole":
+				if delErr := r.deleteClusterRole(instance, obj.name); delErr != nil {
+					log.Error(delErr, "Failed to delete legacy ClusterRole", "name", obj.name)
+				}
+			case "ClusterRoleBinding":
+				if delErr := r.deleteClusterRoleBinding(instance, obj.name); delErr != nil {
+					log.Error(delErr, "Failed to delete legacy ClusterRoleBinding", "name", obj.name)
+				}
+			}
+		}
+		// Delete the legacy shared ServiceAccount.
+		legacySA := &corev1.ServiceAccount{}
+		legacySA.Name = "search-serviceaccount"
+		legacySA.Namespace = instance.GetNamespace()
+		if delErr := r.Delete(ctx, legacySA); delErr != nil && !errors.IsNotFound(delErr) {
+			log.Error(delErr, "Failed to delete legacy ServiceAccount", "name", "search-serviceaccount")
+		}
 	})
 
 	return ctrl.Result{}, nil

--- a/controllers/search_test.go
+++ b/controllers/search_test.go
@@ -80,7 +80,9 @@ func TestSearch_controller(t *testing.T) {
 	}
 	objs := []runtime.Object{search}
 	// Create a fake client to mock API calls.
-	cl := fake.NewClientBuilder().WithStatusSubresource(search).WithRuntimeObjects(objs...).Build()
+	// WithScheme(s) is required so the fake client can handle rbacv1 ClusterRole/Binding
+	// objects created by the reconcile loop.
+	cl := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(search).WithRuntimeObjects(objs...).Build()
 
 	r := &SearchReconciler{Client: cl, DynamicClient: fakeDynClient(), Scheme: s}
 
@@ -176,35 +178,16 @@ func TestSearch_controller(t *testing.T) {
 	verifyConfigmapDataContent(t, configmap3, "postgresql-start.sh", "CREATE SCHEMA IF NOT EXISTS search")
 	verifyConfigmapDataContent(t, configmap3, "custom-postgresql.conf", "# Customizations appended to postgresql.conf")
 
-	//check for Service Account
-	serviceaccount := &corev1.ServiceAccount{}
-	err = cl.Get(context.TODO(), types.NamespacedName{
-		Name:      getServiceAccountName(),
-		Namespace: namespace,
-	}, serviceaccount)
-	if err != nil {
-		t.Errorf("Failed to get serviceaccount %s: %v", getServiceAccountName(), err)
-	}
-
-	//check for Role
-	role := &rbacv1.ClusterRole{}
-	err = cl.Get(context.TODO(), types.NamespacedName{
-		Name:      getRoleName(),
-		Namespace: namespace,
-	}, role)
-	if err != nil {
-		t.Errorf("Failed to get role %s: %v", getRoleName(), err)
-	}
-
-	//check for RoleBinding
+	// The "search" ClusterRole and its shared ServiceAccount have been removed.
+	// "search-api" and "search-collector" ClusterRoles are pre-provisioned static manifests;
+	// only their ClusterRoleBindings are created by the reconcile loop.
+	// ClusterRoleBindings are cluster-scoped — look up without namespace.
 	rolebinding := &rbacv1.ClusterRoleBinding{}
 	err = cl.Get(context.TODO(), types.NamespacedName{
-		Name:      getRoleBindingName(),
-		Namespace: namespace,
+		Name: getRoleBindingName() + "-api",
 	}, rolebinding)
-
 	if err != nil {
-		t.Errorf("Failed to get serviceaccount %s: %v", getRoleBindingName(), err)
+		t.Errorf("Failed to get clusterrolebinding %s: %v", getRoleBindingName()+"-api", err)
 	}
 
 	//check for PVC
@@ -278,43 +261,30 @@ func TestSearch_controller(t *testing.T) {
 	}
 
 	// We should expect Addon ClusterRole deleted by Finalizer
+	addonRole := &rbacv1.ClusterRole{}
 	err = cl.Get(context.TODO(), types.NamespacedName{
 		Name:      getAddonRoleName(),
 		Namespace: namespace,
-	}, role)
-
+	}, addonRole)
 	if !errors.IsNotFound(err) {
-		t.Errorf("Failed to delete Clusterrole %s", getAddonRoleName())
+		t.Errorf("Failed to delete ClusterRole %s", getAddonRoleName())
 	}
 
-	// We should expect Addon ClusterRolebinding deleted by Finalizer
+	// We should expect Addon ClusterRoleBinding deleted by Finalizer
 	err = cl.Get(context.TODO(), types.NamespacedName{
 		Name:      getAddonRoleName(),
 		Namespace: namespace,
 	}, rolebinding)
-
 	if !errors.IsNotFound(err) {
 		t.Errorf("Failed to delete ClusterRoleBinding %s", getAddonRoleName())
 	}
 
-	// We should expect Search ClusterRole deleted by Finalizer
+	// The "search-api" ClusterRoleBinding (which the operator created) should be gone.
 	err = cl.Get(context.TODO(), types.NamespacedName{
-		Name:      getRoleName(),
-		Namespace: namespace,
-	}, role)
-
-	if !errors.IsNotFound(err) {
-		t.Errorf("Failed to delete Clusterrole %s", getRoleName())
-	}
-
-	// We should expect Search ClusterRolebinding deleted by Finalizer
-	err = cl.Get(context.TODO(), types.NamespacedName{
-		Name:      getRoleBindingName(),
-		Namespace: namespace,
+		Name: getRoleBindingName() + "-api",
 	}, rolebinding)
-
 	if !errors.IsNotFound(err) {
-		t.Errorf("Failed to delete ClusterRoleBinding %s", getRoleBindingName())
+		t.Errorf("Finalizer should have deleted ClusterRoleBinding %s", getRoleBindingName()+"-api")
 	}
 
 }
@@ -968,11 +938,10 @@ func TestSearch_controller_DBConfigAndEnvOverlap(t *testing.T) {
 }
 
 // TestCreateUpdateRoles_UpdatesExistingClusterRole verifies that when a pre-existing
-// ClusterRole has stale rules (e.g. still carries impersonate on the shared role),
-// createUpdateRoles copies the desired rules onto the fetched object and updates it.
-// This exercises the resourceVersion-preserving path: the fetched existingClusterRole
-// is updated rather than the freshly constructed crole, which has no resourceVersion
-// and would be rejected by the API server.
+// ClusterRole has stale rules, createUpdateRoles copies the desired rules onto the
+// fetched object and updates it. This exercises the resourceVersion-preserving path:
+// the fetched existingClusterRole is updated rather than the freshly constructed crole,
+// which has no resourceVersion and would be rejected by the API server.
 func TestCreateUpdateRoles_UpdatesExistingClusterRole(t *testing.T) {
 	namespace := "test-ns"
 	search := &searchv1alpha1.Search{
@@ -980,17 +949,17 @@ func TestCreateUpdateRoles_UpdatesExistingClusterRole(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: OperatorName, Namespace: namespace},
 	}
 
-	// Pre-existing ClusterRole with stale rules (impersonate still present).
+	// Use the indexer ClusterRole (still managed dynamically by the operator).
+	// Pre-populate it with a stale rule to exercise the update path.
 	staleRule := rbacv1.PolicyRule{
 		APIGroups: []string{""},
-		Resources: []string{"users", "serviceaccounts", "groups"},
-		Verbs:     []string{"impersonate"},
+		Resources: []string{"secrets"},
+		Verbs:     []string{"delete"},
 	}
 	existing := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            getRoleName(),
-			Namespace:       namespace, // match the namespace set by ClusterRole() builder
-			ResourceVersion: "999",    // simulates a server-assigned value
+			Name:            getRoleName() + "-indexer",
+			ResourceVersion: "999", // simulates a server-assigned value
 		},
 		Rules: []rbacv1.PolicyRule{staleRule},
 	}
@@ -1005,8 +974,7 @@ func TestCreateUpdateRoles_UpdatesExistingClusterRole(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(existing).Build()
 	r := &SearchReconciler{Client: cl, Scheme: s}
 
-	// Build the desired ClusterRole (no impersonate in getRules()).
-	desired := r.ClusterRole(search)
+	desired := r.IndexerClusterRole(search)
 
 	result, err := r.createUpdateRoles(context.TODO(), desired)
 	if result != nil || err != nil {
@@ -1014,12 +982,11 @@ func TestCreateUpdateRoles_UpdatesExistingClusterRole(t *testing.T) {
 	}
 
 	updated := &rbacv1.ClusterRole{}
-	if err := cl.Get(context.TODO(), types.NamespacedName{Name: getRoleName(), Namespace: namespace}, updated); err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: getRoleName() + "-indexer"}, updated); err != nil {
 		t.Fatalf("get updated ClusterRole: %v", err)
 	}
 
-	// Confirm the updated object matches the desired rules exactly (full semantic equality,
-	// not just length — catches cases where count matches but content differs).
+	// Confirm the updated object matches the desired rules exactly.
 	if !equality.Semantic.DeepEqual(updated.Rules, desired.Rules) {
 		t.Errorf("ClusterRole rules after update do not match desired:\ngot:  %+v\nwant: %+v", updated.Rules, desired.Rules)
 	}

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -170,7 +170,7 @@ The `search-api` ClusterRole is applied as a static install-time manifest (`bund
 |---|---|---|---|
 | `authentication.k8s.io`, `authorization.k8s.io` | `uids`, `userextras/authentication.kubernetes.io/credential-id`, `userextras/authentication.kubernetes.io/node-name`, `userextras/authentication.kubernetes.io/node-uid`, `userextras/authentication.kubernetes.io/pod-name`, `userextras/authentication.kubernetes.io/pod-uid` | `impersonate` | Forward the full user identity (credential ID, node name, pod name, etc.) through the Kubernetes API server when executing `SelfSubjectRulesReviews` on behalf of the end user. |
 | `""` (core) | `users`, `serviceaccounts`, `groups` | `impersonate` | Issue requests as the authenticated user for per-user RBAC enforcement. |
-| `""` (core) | `secrets`, `services` | `create`, `get`, `list`, `patch`, `update`, `watch` | Manage the mTLS certificates used by the search-api pod. |
+| `""` (core) | `secrets` | `get` | Read the named `search-global` Secret in each managed-hub namespace for the federated query path (`search-v2-api/pkg/federated/fedConfig.go`). The operator SA creates and manages Secrets and Services; the API pod only reads this one Secret. |
 | `authentication.k8s.io` | `tokenreviews` | `create` | Authenticate the end user's bearer token before impersonating them for RBAC-filtered query results. |
 | `authorization.k8s.io` | `selfsubjectaccessreviews`, `selfsubjectrulesreviews` | `create` | Evaluate per-user RBAC rules for filtering search results to resources the requesting user may access. |
 

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -157,3 +157,39 @@ Once we have the access rules for the user, we use the data to query the databas
 ### Status Changes: 
 COMPLETED (February 8, 2023 - ACM 2.7)   
 DRAFT (April 22, 2022)
+
+---
+
+## search-api ClusterRole (pre-provisioned static manifest)
+
+The `search-api` ClusterRole is applied as a static install-time manifest (`bundle/manifests/search-api-clusterrole.yaml`) and is **never created or modified by the operator at runtime**. The operator only creates the `ClusterRoleBinding` that binds this role to `search-api-sa`, using the narrower `bind` verb.
+
+### Rules
+
+| API Group | Resources | Verbs | Purpose |
+|---|---|---|---|
+| `authentication.k8s.io`, `authorization.k8s.io` | `uids`, `userextras/authentication.kubernetes.io/credential-id`, `userextras/authentication.kubernetes.io/node-name`, `userextras/authentication.kubernetes.io/node-uid`, `userextras/authentication.kubernetes.io/pod-name`, `userextras/authentication.kubernetes.io/pod-uid` | `impersonate` | Forward the full user identity (credential ID, node name, pod name, etc.) through the Kubernetes API server when executing `SelfSubjectRulesReviews` on behalf of the end user. |
+| `""` (core) | `users`, `serviceaccounts`, `groups` | `impersonate` | Issue requests as the authenticated user for per-user RBAC enforcement. |
+| `""` (core) | `secrets`, `services` | `create`, `get`, `list`, `patch`, `update`, `watch` | Manage the mTLS certificates used by the search-api pod. |
+| `authentication.k8s.io` | `tokenreviews` | `create` | Authenticate the end user's bearer token before impersonating them for RBAC-filtered query results. |
+| `authorization.k8s.io` | `selfsubjectaccessreviews`, `selfsubjectrulesreviews` | `create` | Evaluate per-user RBAC rules for filtering search results to resources the requesting user may access. |
+
+### Why pre-provisioned?
+
+Kubernetes RBAC escalation prevention blocks creating a ClusterRole with permissions the creator does not hold. Because `search-api` carries `impersonate`, the operator SA would have to hold `impersonate` itself — granting it cluster-admin-equivalent access — just to satisfy the admission check. Pre-provisioning the ClusterRole as a static manifest (applied by OLM or `make install-operand-rbac`) removes this dependency.
+
+---
+
+## search-collector ClusterRole (pre-provisioned static manifest)
+
+The `search-collector` ClusterRole is applied as a static install-time manifest (`bundle/manifests/search-collector-clusterrole.yaml`) following the same pattern as `search-api`.
+
+### Rules
+
+| API Group | Resources | Verbs | Purpose |
+|---|---|---|---|
+| `*` | `*` | `get`, `list`, `watch` | Watch every resource in the cluster for inventory collection. |
+| `search.open-cluster-management.io` | `collectorconfigs/status` | `patch`, `update` | Write the collector's sync status back via the `collectorconfigs/status` subresource. |
+| `coordination.k8s.io` | `leases` | `get`, `create`, `update` | Manage the addon heartbeat lease. |
+
+The collector does **not** hold `impersonate`, write access to `secrets`/`services`/`deployments`, `tokenreviews`, or `selfsubjectaccessreviews`.


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-34432
CVE: FIND-002

### Description of changes

Removes `impersonate` from the operator's `manager-role` ClusterRole by pre-provisioning the `search-api` and `search-collector` ClusterRoles as static install-time manifests, breaking the circular dependency that forced the operator SA to hold impersonation rights.

**Root cause:** Kubernetes RBAC escalation prevention blocks creating a ClusterRole with permissions the creator does not hold. The `search-api` ClusterRole carries `impersonate` (needed by search-api for per-user query authorization), so the operator SA had to hold `impersonate` just to create it — giving it cluster-admin-equivalent access.

**Fix (Option B — pre-provision):**
- Add `config/rbac/search_api_clusterrole.yaml` — static manifest for the `search-api` ClusterRole (impersonate only, bound exclusively to `search-api-sa`)
- Add `config/rbac/search_collector_clusterrole.yaml` — static manifest for the `search-collector` ClusterRole (wildcard read + collectorconfigs/status patch + leases)
- Add `bundle/manifests/search-api-clusterrole.yaml` and `bundle/manifests/search-collector-clusterrole.yaml` — OLM copies applied at install time
- Remove `APIClusterRole()`, `CollectorClusterRole()`, `ClusterRole()`, `getRules()`, `getAPIRules()`, `getCollectorRules()` from `create_rolesbindings.go` — operator no longer creates or updates these ClusterRoles
- Remove `SearchServiceAccount()` and `getServiceAccountName()` — shared `search-serviceaccount` is gone now that every deployment uses a dedicated SA
- Replace `impersonate` markers with `bind` scoped to `resourceNames=search-api;search-collector` — allows creating the ClusterRoleBindings without holding impersonate
- Fix finalizer: stop deleting the pre-provisioned ClusterRoles on teardown; add cleanup for the ClusterRoleBindings
- Fix `deleteClusterRoleBinding`: remove Namespace field (ClusterRoleBindings are cluster-scoped)
- Remove `Watches(&rbacv1.ClusterRole{})` that watched the now-removed shared role
- Add `make install-operand-rbac` for development clusters
- Update tests: `TestSearchAPIClusterRoleCarriesImpersonate` reads the static YAML files; `TestSearch_controller` asserts on the APIClusterRoleBinding; `TestCreateUpdateRoles_UpdatesExistingClusterRole` updated to use IndexerClusterRole

| Capability | Before | After |
|---|---|---|
| `impersonate` on operator SA | ✅ | ❌ Removed |
| Create `search-api` ClusterRole | ✅ (holds impersonate) | ❌ Pre-provisioned; operator uses `bind` only |
| `bind` on `search-api`/`search-collector` ClusterRole | — | ✅ scoped to `resourceNames` |

/assign smcavey

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-provisioned access roles for the search API and collector components.
  * Added a command to install these roles in Kubernetes environments.
  * Improved service-account isolation across search components.

* **Bug Fixes**
  * Corrected cleanup of cluster-scoped access bindings.
  * Preserved pre-provisioned access roles during cleanup.
  * Removed legacy access resources during upgrades.
  * Reduced unnecessary permissions while retaining required access.
  * Updated access bindings when referenced roles change.

* **Documentation**
  * Documented the new access roles, installation process, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->