### PR TITLE
ACM-34432 fix make bundle and pin operator-sdk to v1.37.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,18 +151,33 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+.PHONY: operator-sdk
+OPERATOR_SDK_VERSION = v1.37.0
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+operator-sdk: ## Download operator-sdk v1.37.0 locally if necessary.
+ifeq (,$(wildcard $(OPERATOR_SDK)))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPERATOR_SDK)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+	chmod +x $(OPERATOR_SDK) ;\
+	}
+endif
+
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata.
-	operator-sdk generate kustomize manifests -q
+bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	# Workaround: operator-sdk v1.34+ copies the kustomize-prefixed SA name into the CSV.
 	# The production SA is search-v2-operator, not search-v2-operator-controller-manager.
-	sed -i 's/serviceAccountName: search-v2-operator-controller-manager/serviceAccountName: search-v2-operator/g' bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+	sed -i.bak 's/serviceAccountName: search-v2-operator-controller-manager/serviceAccountName: search-v2-operator/g' bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+	rm -f bundle/manifests/search-v2-operator.clusterserviceversion.yaml.bak
 
 .PHONY: bundle-validate
-bundle-validate: ## Validate the bundle (informational — ClusterManagementAddOn triggers a known false-positive warning).
-	operator-sdk bundle validate ./bundle
+bundle-validate: operator-sdk ## Validate the bundle (informational — ClusterManagementAddOn triggers a known false-positive warning).
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -154,16 +154,31 @@ endef
 .PHONY: operator-sdk
 OPERATOR_SDK_VERSION = v1.37.0
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
-operator-sdk: ## Download operator-sdk v1.37.0 locally if necessary.
-ifeq (,$(wildcard $(OPERATOR_SDK)))
+operator-sdk: ## Download operator-sdk locally if necessary, validating version and checksum.
 	@{ \
 	set -e ;\
+	OS=$(shell go env GOHOSTOS) && ARCH=$(shell go env GOHOSTARCH) && \
+	if [ -f "$(OPERATOR_SDK)" ] && $(OPERATOR_SDK) version 2>/dev/null | grep -q "$(OPERATOR_SDK_VERSION)"; then \
+		echo "operator-sdk $(OPERATOR_SDK_VERSION) already present"; \
+		exit 0; \
+	fi; \
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+	TMP_SDK=$$(mktemp) ;\
+	TMP_SUMS=$$(mktemp) ;\
+	curl -fLo "$${TMP_SDK}" "https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH}" ;\
+	curl -fLo "$${TMP_SUMS}" "https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/checksums.txt" ;\
+	EXPECTED=$$(grep "operator-sdk_$${OS}_$${ARCH}$$" "$${TMP_SUMS}" | awk '{print $$1}') ;\
+	ACTUAL=$$(sha256sum "$${TMP_SDK}" 2>/dev/null || shasum -a 256 "$${TMP_SDK}") ;\
+	ACTUAL=$$(echo "$${ACTUAL}" | awk '{print $$1}') ;\
+	if [ "$${EXPECTED}" != "$${ACTUAL}" ]; then \
+		echo "ERROR: operator-sdk checksum mismatch (expected=$${EXPECTED} actual=$${ACTUAL})"; \
+		rm -f "$${TMP_SDK}" "$${TMP_SUMS}"; \
+		exit 1; \
+	fi; \
+	mv "$${TMP_SDK}" $(OPERATOR_SDK) ;\
 	chmod +x $(OPERATOR_SDK) ;\
+	rm -f "$${TMP_SUMS}" ;\
 	}
-endif
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata.

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-28T18:11:21Z"
+    createdAt: "2026-08-20T19:06:56Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: search-v2-operator.v0.0.1
@@ -52,16 +52,13 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - groups
           - secrets
           - serviceaccounts
           - services
-          - users
           verbs:
           - create
           - delete
           - get
-          - impersonate
           - list
           - patch
           - update
@@ -128,18 +125,6 @@ spec:
           - tokenreviews
           verbs:
           - create
-        - apiGroups:
-          - authentication.k8s.io
-          - authorization.k8s.io
-          resources:
-          - uids
-          - userextras/authentication.kubernetes.io/credential-id
-          - userextras/authentication.kubernetes.io/node-name
-          - userextras/authentication.kubernetes.io/node-uid
-          - userextras/authentication.kubernetes.io/pod-name
-          - userextras/authentication.kubernetes.io/pod-uid
-          verbs:
-          - impersonate
         - apiGroups:
           - authentication.open-cluster-management.io
           resources:
@@ -245,10 +230,20 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
-          - clusterroles
           - rolebindings
           - roles
           verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - bind
           - create
           - delete
           - get
@@ -380,6 +375,10 @@ spec:
                   value: quay.io/stolostron/search-collector:placeholder-image-tag
                 - name: API_IMAGE
                   value: quay.io/stolostron/search-v2-api:placeholder-image-tag
+                - name: OPERATOR_ORG
+                  value: '{{ .Values.org }}'
+                - name: OPERATOR_CHART
+                  value: '{{ .Chart.Name }}'
                 image: quay.io/stolostron/search-v2-operator:placeholder-image-tag
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,6 +47,10 @@ spec:
           value: quay.io/stolostron/search-collector:placeholder-image-tag
         - name: API_IMAGE
           value: quay.io/stolostron/search-v2-api:placeholder-image-tag
+        - name: OPERATOR_ORG
+          value: '{{ .Values.org }}'
+        - name: OPERATOR_CHART
+          value: '{{ .Chart.Name }}'
         args:
         - --leader-elect
         image: controller:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -192,7 +192,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - clusterroles
   - rolebindings
   - roles
   verbs:
@@ -207,6 +206,11 @@ rules:
   - clusterroles
   verbs:
   - bind
+  - create
+  - delete
+  - get
+  - list
+  - update
 - apiGroups:
   - rbac.open-cluster-management.io
   resources:


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-34432

### 🧔‍♂️ Description of changes 
- Fixes inconsistencies with this project chart and openclusterhub-operator repo.

### 🤖  Description of changes 
- Pin `operator-sdk` to v1.37.0 via a new Makefile download target (`bin/operator-sdk`), consistent with the existing `controller-gen` and `kustomize` pattern; removes reliance on any globally-installed operator-sdk version
- Fix `sed -i` compatibility on macOS (BSD sed): use `sed -i.bak` + `rm -f *.bak`, which works identically on GNU sed (Linux) and BSD sed (macOS)
- Regenerate bundle CSV to reflect ACM-34432 RBAC changes (remove impersonate, add `clusterroles` create/delete/get/list/update verbs)
- Add `OPERATOR_ORG` and `OPERATOR_CHART` env vars to `config/manager/manager.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Operator deployments now receive organization and chart metadata through environment settings.
  - Bundle generation and validation now automatically obtain the required platform-specific Operator SDK binary.

- **Security**
  - Refined cluster permissions by removing unnecessary user, group, and impersonation access.
  - Isolated cluster-role permissions and added required binding capability.
  - Added SHA-256 verification for downloaded tooling.

- **Maintenance**
  - Improved bundle generation and validation reliability with version checks and temporary-file cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->