### PR TITLE
[release-2.17] ACM-34432 fix make bundle and pin operator-sdk to v1.37.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,12 +151,48 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+.PHONY: operator-sdk
+OPERATOR_SDK_VERSION = v1.37.0
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+operator-sdk: ## Download operator-sdk locally if necessary, validating version and checksum.
+	@{ \
+	set -e ;\
+	OS=$(shell go env GOHOSTOS) && ARCH=$(shell go env GOHOSTARCH) && \
+	if [ -f "$(OPERATOR_SDK)" ] && $(OPERATOR_SDK) version 2>/dev/null | grep -q "$(OPERATOR_SDK_VERSION)"; then \
+		echo "operator-sdk $(OPERATOR_SDK_VERSION) already present"; \
+		exit 0; \
+	fi; \
+	mkdir -p $(dir $(OPERATOR_SDK)) ;\
+	TMP_SDK=$$(mktemp) ;\
+	TMP_SUMS=$$(mktemp) ;\
+	curl -fLo "$${TMP_SDK}" "https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH}" ;\
+	curl -fLo "$${TMP_SUMS}" "https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/checksums.txt" ;\
+	EXPECTED=$$(grep "operator-sdk_$${OS}_$${ARCH}$$" "$${TMP_SUMS}" | awk '{print $$1}') ;\
+	ACTUAL=$$(sha256sum "$${TMP_SDK}" 2>/dev/null || shasum -a 256 "$${TMP_SDK}") ;\
+	ACTUAL=$$(echo "$${ACTUAL}" | awk '{print $$1}') ;\
+	if [ "$${EXPECTED}" != "$${ACTUAL}" ]; then \
+		echo "ERROR: operator-sdk checksum mismatch (expected=$${EXPECTED} actual=$${ACTUAL})"; \
+		rm -f "$${TMP_SDK}" "$${TMP_SUMS}"; \
+		exit 1; \
+	fi; \
+	mv "$${TMP_SDK}" $(OPERATOR_SDK) ;\
+	chmod +x $(OPERATOR_SDK) ;\
+	rm -f "$${TMP_SUMS}" ;\
+	}
+
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	# Workaround: operator-sdk v1.34+ copies the kustomize-prefixed SA name into the CSV.
+	# The production SA is search-v2-operator, not search-v2-operator-controller-manager.
+	sed -i.bak 's/serviceAccountName: search-v2-operator-controller-manager/serviceAccountName: search-v2-operator/g' bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+	rm -f bundle/manifests/search-v2-operator.clusterserviceversion.yaml.bak
+
+.PHONY: bundle-validate
+bundle-validate: operator-sdk ## Validate the bundle (informational — ClusterManagementAddOn triggers a known false-positive warning).
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-27T19:14:13Z"
+    createdAt: "2026-08-20T19:06:56Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: search-v2-operator.v0.0.1
@@ -50,16 +50,13 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - groups
           - secrets
           - serviceaccounts
           - services
-          - users
           verbs:
           - create
           - delete
           - get
-          - impersonate
           - list
           - patch
           - update
@@ -118,18 +115,6 @@ spec:
           - tokenreviews
           verbs:
           - create
-        - apiGroups:
-          - authentication.k8s.io
-          - authorization.k8s.io
-          resources:
-          - uids
-          - userextras/authentication.kubernetes.io/credential-id
-          - userextras/authentication.kubernetes.io/node-name
-          - userextras/authentication.kubernetes.io/node-uid
-          - userextras/authentication.kubernetes.io/pod-name
-          - userextras/authentication.kubernetes.io/pod-uid
-          verbs:
-          - impersonate
         - apiGroups:
           - authentication.open-cluster-management.io
           resources:
@@ -223,10 +208,20 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
-          - clusterroles
           - rolebindings
           - roles
           verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - bind
           - create
           - delete
           - get
@@ -345,6 +340,10 @@ spec:
                   value: quay.io/stolostron/search-collector:placeholder-image-tag
                 - name: API_IMAGE
                   value: quay.io/stolostron/search-v2-api:placeholder-image-tag
+                - name: OPERATOR_ORG
+                  value: '{{ .Values.org }}'
+                - name: OPERATOR_CHART
+                  value: '{{ .Chart.Name }}'
                 image: quay.io/stolostron/search-v2-operator:placeholder-image-tag
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,6 +47,10 @@ spec:
           value: quay.io/stolostron/search-collector:placeholder-image-tag
         - name: API_IMAGE
           value: quay.io/stolostron/search-v2-api:placeholder-image-tag
+        - name: OPERATOR_ORG
+          value: '{{ .Values.org }}'
+        - name: OPERATOR_CHART
+          value: '{{ .Chart.Name }}'
         args:
         - --leader-elect
         image: controller:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -172,7 +172,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - clusterroles
   - rolebindings
   - roles
   verbs:
@@ -187,6 +186,11 @@ rules:
   - clusterroles
   verbs:
   - bind
+  - create
+  - delete
+  - get
+  - list
+  - update
 - apiGroups:
   - rbac.open-cluster-management.io
   resources:


### PR DESCRIPTION
This is a cherry-pick of #846 to release-2.17.

### Related Issue
https://issues.redhat.com/browse/ACM-34432

### Conflicts resolved
- `Makefile` — `bundle` target: release-2.17 already had the hardened `operator-sdk` download target (from PR #837); kept the cherry-pick's `bundle` target which uses `$(OPERATOR_SDK)` and adds the `sed` workaround for the SA name.
- `bundle/manifests/search-v2-operator.clusterserviceversion.yaml` — `createdAt` timestamp conflict; took the newer value from the cherry-pick.

/assign smcavey