### PR TITLE
[release-2.17] ACM-42672 Add namespaces and managedclusters list/watch to search-api ClusterRole

### DIFF
--- a/bundle/manifests/search-api-clusterrole.yaml
+++ b/bundle/manifests/search-api-clusterrole.yaml
@@ -75,3 +75,25 @@ rules:
   - selfsubjectrulesreviews
   verbs:
   - create
+# Namespace list/watch — required by cacheValidation and sharedData to build the
+# cache of accessible namespaces used for per-user RBAC filtering of search results
+# (search-v2-api/pkg/cachevalidation, pkg/rbac/sharedData.go).
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+# ManagedCluster list/watch — required by sharedData to build the fleet-wide cluster
+# inventory used for cross-cluster search result scoping
+# (search-v2-api/pkg/rbac/sharedData.go).
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/search_api_clusterrole.yaml
+++ b/config/rbac/search_api_clusterrole.yaml
@@ -69,3 +69,25 @@ rules:
   - selfsubjectrulesreviews
   verbs:
   - create
+# Namespace list/watch — required by cacheValidation and sharedData to build the
+# cache of accessible namespaces used for per-user RBAC filtering of search results
+# (search-v2-api/pkg/cachevalidation, pkg/rbac/sharedData.go).
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+# ManagedCluster list/watch — required by sharedData to build the fleet-wide cluster
+# inventory used for cross-cluster search result scoping
+# (search-v2-api/pkg/rbac/sharedData.go).
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -184,6 +184,37 @@ func TestSearchAPIClusterRoleCarriesImpersonate(t *testing.T) {
 	}
 }
 
+// TestSearchAPIClusterRoleHasCachePermissions verifies that the pre-provisioned
+// search-api ClusterRole grants the list/watch permissions on namespaces and
+// managedclusters that are required by cacheValidation and sharedData.
+//
+// These were missing after ACM-34431 split the shared search-serviceaccount into
+// per-component SAs (ACM-42672).
+func TestSearchAPIClusterRoleHasCachePermissions(t *testing.T) {
+	apiCR := loadClusterRole(t, "../config/rbac/search_api_clusterrole.yaml")
+
+	checks := []struct {
+		apiGroup string
+		resource string
+		verb     string
+	}{
+		// namespaces — required by cacheValidation and sharedData
+		{"", "namespaces", "get"},
+		{"", "namespaces", "list"},
+		{"", "namespaces", "watch"},
+		// managedclusters — required by sharedData fleet inventory
+		{"cluster.open-cluster-management.io", "managedclusters", "get"},
+		{"cluster.open-cluster-management.io", "managedclusters", "list"},
+		{"cluster.open-cluster-management.io", "managedclusters", "watch"},
+	}
+	for _, c := range checks {
+		if !hasVerb(apiCR, c.apiGroup, c.resource, c.verb) {
+			t.Errorf("search-api ClusterRole must grant %q on apiGroup=%q resource=%q (needed by cacheValidation/sharedData)",
+				c.verb, c.apiGroup, c.resource)
+		}
+	}
+}
+
 // TestPostgresServiceAccountIsIsolated verifies that the postgres SA uses a dedicated
 // name distinct from all other search component SAs.
 func TestPostgresServiceAccountIsIsolated(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of #863 to `release-2.17`.

Fixes **ACM-42672** — `search-api-sa` was missing `list`/`watch` on `namespaces` and `managedclusters` after the ACM-34431 ServiceAccount split, causing continuous RBAC forbidden errors in search-api and breaking all search results.