### PR TITLE
ACM-42665: stop backup-labeling operator-owned integration CollectorConfigs

### DIFF
--- a/config/integration_collector_configs/app-lifecycle.yaml
+++ b/config/integration_collector_configs/app-lifecycle.yaml
@@ -7,13 +7,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: app-lifecycle-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/app-lifecycle.yaml
+++ b/config/integration_collector_configs/app-lifecycle.yaml
@@ -12,7 +12,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/argo.yaml
+++ b/config/integration_collector_configs/argo.yaml
@@ -5,13 +5,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: argo-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/argo.yaml
+++ b/config/integration_collector_configs/argo.yaml
@@ -10,7 +10,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -6,13 +6,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: cnv-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/cnv.yaml
+++ b/config/integration_collector_configs/cnv.yaml
@@ -11,7 +11,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/gatekeeper.yaml
+++ b/config/integration_collector_configs/gatekeeper.yaml
@@ -10,7 +10,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/gatekeeper.yaml
+++ b/config/integration_collector_configs/gatekeeper.yaml
@@ -5,13 +5,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: gatekeeper-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/grc.yaml
+++ b/config/integration_collector_configs/grc.yaml
@@ -10,7 +10,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/grc.yaml
+++ b/config/integration_collector_configs/grc.yaml
@@ -5,13 +5,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: grc-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/kyverno.yaml
+++ b/config/integration_collector_configs/kyverno.yaml
@@ -5,13 +5,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: kyverno-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/config/integration_collector_configs/kyverno.yaml
+++ b/config/integration_collector_configs/kyverno.yaml
@@ -10,7 +10,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/olm.yaml
+++ b/config/integration_collector_configs/olm.yaml
@@ -10,7 +10,7 @@
 # deterministically reseeded from this file on every operator restart, so backing it up is
 # redundant — and the label actively breaks hub restore, since the CollectorConfig admission
 # webhook rejects restore-time patches from Velero's service account for operator-owned
-# configs (ACM-42665). Do not add it back.
+# configs. Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:

--- a/config/integration_collector_configs/olm.yaml
+++ b/config/integration_collector_configs/olm.yaml
@@ -5,13 +5,18 @@
 #
 # Managed by the operator — reset to this default on restart unless annotated with
 # search.open-cluster-management.io/manual-override. See docs/ARCHITECTURE.md.
+#
+# Deliberately has NO cluster.open-cluster-management.io/backup label: this config is
+# deterministically reseeded from this file on every operator restart, so backing it up is
+# redundant — and the label actively breaks hub restore, since the CollectorConfig admission
+# webhook rejects restore-time patches from Velero's service account for operator-owned
+# configs (ACM-42665). Do not add it back.
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: CollectorConfig
 metadata:
   name: olm-integration
   labels:
     search.open-cluster-management.io/config-type: integration
-    cluster.open-cluster-management.io/backup: ""
 spec:
   collectionRules:
     - action: include

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -30,8 +30,7 @@ import (
 // Callers must NOT call this for operator-owned CollectorConfigs (see isOperatorOwnedCC): those
 // are deterministically reseeded by the operator on every restart, so backing them up is
 // redundant, and the label actively breaks hub restore — the CollectorConfig admission webhook
-// rejects restore-time patches from Velero's service account for operator-owned configs
-// (ACM-42665).
+// rejects restore-time patches from Velero's service account for operator-owned configs.
 func (r *SearchReconciler) addBackupLabel(ctx context.Context, cc *searchv1alpha1.CollectorConfig) error {
 	if _, hasLabel := cc.Labels[backupLabel]; hasLabel {
 		return nil
@@ -217,7 +216,7 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 	// Also ensure each non-operator-owned source config carries the backup label so it
 	// survives hub backup/restore. Operator-owned integration configs (the canonical, seeded
 	// ones — see IntegrationCollectorConfigSeeder) are skipped: they are deterministically
-	// reseeded on every restart, and labeling them for backup breaks hub restore (ACM-42665).
+	// reseeded on every restart, and labeling them for backup breaks hub restore.
 	// A team's differently-named test config (the manual-override escape hatch) has no
 	// ownerReference, so it still gets backed up here like user-collector-config.
 	mergedSpec := searchv1alpha1.CollectorConfigSpec{}

--- a/controllers/create_collectorconfig.go
+++ b/controllers/create_collectorconfig.go
@@ -23,9 +23,15 @@ import (
 // addBackupLabel patches the backup label onto a CollectorConfig if it is missing.
 // The search.open-cluster-management.io API group is excluded from the automatic resources
 // backup (backup.go excludedAPIGroups). Resources labeled with backupLabel are picked up by
-// the acm-resources-generic-schedule backup instead. All source CollectorConfigs — integration
-// team configs, user-collector-config, and any future per-cluster override configs — should
-// carry this label so they survive a hub backup/restore cycle.
+// the acm-resources-generic-schedule backup instead. User-authored source CollectorConfigs —
+// user-collector-config, and any future per-cluster override configs — should carry this label
+// so they survive a hub backup/restore cycle.
+//
+// Callers must NOT call this for operator-owned CollectorConfigs (see isOperatorOwnedCC): those
+// are deterministically reseeded by the operator on every restart, so backing them up is
+// redundant, and the label actively breaks hub restore — the CollectorConfig admission webhook
+// rejects restore-time patches from Velero's service account for operator-owned configs
+// (ACM-42665).
 func (r *SearchReconciler) addBackupLabel(ctx context.Context, cc *searchv1alpha1.CollectorConfig) error {
 	if _, hasLabel := cc.Labels[backupLabel]; hasLabel {
 		return nil
@@ -41,6 +47,21 @@ func (r *SearchReconciler) addBackupLabel(ctx context.Context, cc *searchv1alpha
 	}
 	log.V(2).Info("Added backup label to CollectorConfig", "name", cc.Name)
 	return nil
+}
+
+// isOperatorOwnedCC returns true if cc has a controller ownerReference, meaning it is
+// managed by the operator (created/reseeded by IntegrationCollectorConfigSeeder or
+// createOrUpdateMergedCollectorConfig) and therefore protected by the CollectorConfig admission
+// webhook's ownership check. Mirrors isOperatorOwned in api/v1alpha1/collectorconfig_webhook.go —
+// duplicated here (rather than imported) to avoid a dependency from controllers on that
+// package's internal helper.
+func isOperatorOwnedCC(cc *searchv1alpha1.CollectorConfig) bool {
+	for _, ref := range cc.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -193,11 +214,19 @@ func (r *SearchReconciler) createOrUpdateMergedCollectorConfig(
 	// FUTURE: detect and handle rule collisions between integration team configs.
 
 	// Build merged spec: integration team rules first, then user rules.
-	// Also ensure each source config carries the backup label so it survives hub backup/restore.
+	// Also ensure each non-operator-owned source config carries the backup label so it
+	// survives hub backup/restore. Operator-owned integration configs (the canonical, seeded
+	// ones — see IntegrationCollectorConfigSeeder) are skipped: they are deterministically
+	// reseeded on every restart, and labeling them for backup breaks hub restore (ACM-42665).
+	// A team's differently-named test config (the manual-override escape hatch) has no
+	// ownerReference, so it still gets backed up here like user-collector-config.
 	mergedSpec := searchv1alpha1.CollectorConfigSpec{}
 	for i := range teamConfigs.Items {
 		tc := &teamConfigs.Items[i]
 		mergedSpec.CollectionRules = append(mergedSpec.CollectionRules, tc.Spec.CollectionRules...)
+		if isOperatorOwnedCC(tc) {
+			continue
+		}
 		if err := r.addBackupLabel(ctx, tc); err != nil {
 			return &reconcile.Result{}, err
 		}

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -28,6 +28,8 @@ func newSearchInstance() *searchv1alpha1.Search {
 	}
 }
 
+// newCollectorConfig builds a bare CollectorConfig fixture with the given name and spec, with no
+// labels or ownerReferences set.
 func newCollectorConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
 	return &searchv1alpha1.CollectorConfig{
 		TypeMeta: metav1.TypeMeta{Kind: "CollectorConfig", APIVersion: searchv1alpha1.GroupVersion.String()},

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -39,12 +39,31 @@ func newCollectorConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *s
 	}
 }
 
-// newIntegrationTeamConfig creates a CollectorConfig with the integration team label.
+// newIntegrationTeamConfig creates a CollectorConfig with the integration team label but no
+// ownerReference — representing a team's differently-named test config (the manual-override
+// escape hatch), which is user-authored and not reseeded by the operator.
 func newIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
 	cc := newCollectorConfig(name, spec)
 	cc.Labels = map[string]string{
 		searchv1alpha1.IntegrationTeamLabel: searchv1alpha1.IntegrationTeamLabelValue,
 	}
+	return cc
+}
+
+// newOwnedIntegrationTeamConfig creates an integration team CollectorConfig with a controller
+// ownerReference — representing a canonical config created by IntegrationCollectorConfigSeeder.
+// These are deterministically reseeded on every operator restart and must never carry the
+// backup label (ACM-42665).
+func newOwnedIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
+	cc := newIntegrationTeamConfig(name, spec)
+	isController := true
+	cc.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: searchv1alpha1.GroupVersion.String(),
+		Kind:       "Search",
+		Name:       OperatorName,
+		UID:        "test-owner-uid",
+		Controller: &isController,
+	}}
 	return cc
 }
 
@@ -560,6 +579,26 @@ func TestBackupLabel_IntegrationTeamConfig_GetsLabeled(t *testing.T) {
 	assert.Nil(t, r.Get(context.TODO(), nn, updated))
 	_, hasLabel := updated.Labels[backupLabel]
 	assert.True(t, hasLabel, "integration team config should have the backup label")
+}
+
+// An operator-owned integration team CollectorConfig (the canonical, seeded kind — see
+// IntegrationCollectorConfigSeeder) must NOT get the backup label: it is deterministically
+// reseeded on every operator restart, and the label would break hub restore by conflicting
+// with the CollectorConfig admission webhook's ownership check (ACM-42665).
+func TestBackupLabel_OwnedIntegrationTeamConfig_NotLabeled(t *testing.T) {
+	instance := newSearchInstance()
+	ownedCC := newOwnedIntegrationTeamConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{})
+	r := setupReconciler(instance, ownedCC)
+
+	result, err := r.createOrUpdateMergedCollectorConfig(context.TODO(), instance)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+
+	updated := &searchv1alpha1.CollectorConfig{}
+	nn := types.NamespacedName{Name: "cnv-integration", Namespace: testNamespace}
+	assert.Nil(t, r.Get(context.TODO(), nn, updated))
+	_, hasLabel := updated.Labels[backupLabel]
+	assert.False(t, hasLabel, "operator-owned integration config must NOT have the backup label")
 }
 
 // merged-collector-config is never passed to addBackupLabel — it is operator-managed and

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -56,7 +56,9 @@ func newIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSp
 // ownerReference — representing a canonical config created by IntegrationCollectorConfigSeeder.
 // These are deterministically reseeded on every operator restart and must never carry the
 // backup label (ACM-42665).
-func newOwnedIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSpec) *searchv1alpha1.CollectorConfig {
+func newOwnedIntegrationTeamConfig(
+	name string, spec searchv1alpha1.CollectorConfigSpec,
+) *searchv1alpha1.CollectorConfig {
 	cc := newIntegrationTeamConfig(name, spec)
 	isController := true
 	cc.OwnerReferences = []metav1.OwnerReference{{

--- a/controllers/create_collectorconfig_test.go
+++ b/controllers/create_collectorconfig_test.go
@@ -55,7 +55,7 @@ func newIntegrationTeamConfig(name string, spec searchv1alpha1.CollectorConfigSp
 // newOwnedIntegrationTeamConfig creates an integration team CollectorConfig with a controller
 // ownerReference — representing a canonical config created by IntegrationCollectorConfigSeeder.
 // These are deterministically reseeded on every operator restart and must never carry the
-// backup label (ACM-42665).
+// backup label.
 func newOwnedIntegrationTeamConfig(
 	name string, spec searchv1alpha1.CollectorConfigSpec,
 ) *searchv1alpha1.CollectorConfig {
@@ -588,7 +588,7 @@ func TestBackupLabel_IntegrationTeamConfig_GetsLabeled(t *testing.T) {
 // An operator-owned integration team CollectorConfig (the canonical, seeded kind — see
 // IntegrationCollectorConfigSeeder) must NOT get the backup label: it is deterministically
 // reseeded on every operator restart, and the label would break hub restore by conflicting
-// with the CollectorConfig admission webhook's ownership check (ACM-42665).
+// with the CollectorConfig admission webhook's ownership check.
 func TestBackupLabel_OwnedIntegrationTeamConfig_NotLabeled(t *testing.T) {
 	instance := newSearchInstance()
 	ownedCC := newOwnedIntegrationTeamConfig("cnv-integration", searchv1alpha1.CollectorConfigSpec{})

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -169,7 +169,7 @@ func applyOneIntegrationCollectorConfig(
 	// reseeded from this embedded YAML on every operator restart, so backing them up is
 	// redundant, and the label actively breaks hub restore — the CollectorConfig admission
 	// webhook rejects restore-time patches from Velero's service account for operator-owned
-	// configs (ACM-42665). Strip it unconditionally (not just omit it from desired.Labels) so
+	// configs. Strip it unconditionally (not just omit it from desired.Labels) so
 	// clusters upgrading from an operator version that shipped the label self-heal here,
 	// rather than carrying it forever since the merge above is otherwise additive-only.
 	delete(found.Labels, backupLabel)

--- a/controllers/create_integration_collectorconfigs.go
+++ b/controllers/create_integration_collectorconfigs.go
@@ -147,8 +147,10 @@ func applyOneIntegrationCollectorConfig(
 
 	hasAllLabels := hasDesiredLabels(found, desired)
 	hasOwnerRef := hasControllerOwnerRef(found, owner)
-	if hasAllLabels && hasOwnerRef && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
-		// Already matches the currently shipped default, correctly labeled, and owned — skip.
+	_, hasStaleBackupLabel := found.Labels[backupLabel]
+	if hasAllLabels && hasOwnerRef && !hasStaleBackupLabel && equality.Semantic.DeepEqual(found.Spec, desired.Spec) {
+		// Already matches the currently shipped default, correctly labeled, owned, and free
+		// of the stale backup label — skip.
 		return nil
 	}
 	found.Spec = desired.Spec
@@ -157,12 +159,20 @@ func applyOneIntegrationCollectorConfig(
 	}
 	// Merge all labels from the shipped YAML, then enforce the integration label on top.
 	// This makes Create and Update symmetric: the shipped YAML's labels are always the
-	// source of truth — if someone removes the backup label from a live config, the seeder
+	// source of truth — if someone removes a desired label from a live config, the seeder
 	// restores it on the next restart.
 	for k, v := range desired.Labels {
 		found.Labels[k] = v
 	}
 	found.Labels[searchv1alpha1.IntegrationTeamLabel] = searchv1alpha1.IntegrationTeamLabelValue
+	// Integration configs must never carry the backup label: they are deterministically
+	// reseeded from this embedded YAML on every operator restart, so backing them up is
+	// redundant, and the label actively breaks hub restore — the CollectorConfig admission
+	// webhook rejects restore-time patches from Velero's service account for operator-owned
+	// configs (ACM-42665). Strip it unconditionally (not just omit it from desired.Labels) so
+	// clusters upgrading from an operator version that shipped the label self-heal here,
+	// rather than carrying it forever since the merge above is otherwise additive-only.
+	delete(found.Labels, backupLabel)
 	// Ensure ownerReference is set for GC when Search is torn down.
 	if scheme != nil && owner != nil && owner.UID != "" && !hasOwnerRef {
 		if err := controllerutil.SetControllerReference(owner, found, scheme); err != nil {

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -352,8 +352,16 @@ func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
 // admission webhook otherwise rejects backup/restore patches to these operator-owned configs
 // (ACM-42665). The additive label-merge alone would never remove it, since the shipped YAML
 // simply omits the key rather than requesting its removal.
+//
+// existing carries a real controller ownerReference and owner has a matching non-empty UID, so
+// hasControllerOwnerRef evaluates the actual "already owned" path instead of the empty-UID
+// shortcut that testSearchOwner()/hasControllerOwnerRef otherwise take in tests that don't care
+// about ownership.
 func TestApplyOneIntegrationCollectorConfig_StripsStaleBackupLabel(t *testing.T) {
-	existing := newIntegrationTeamConfig("real-config", searchv1alpha1.CollectorConfigSpec{
+	owner := newSearchInstance()
+	owner.UID = "test-owner-uid"
+
+	existing := newOwnedIntegrationTeamConfig("real-config", searchv1alpha1.CollectorConfigSpec{
 		CollectionRules: []searchv1alpha1.CollectionRule{
 			{
 				Action:           searchv1alpha1.ActionInclude,
@@ -367,7 +375,7 @@ func TestApplyOneIntegrationCollectorConfig_StripsStaleBackupLabel(t *testing.T)
 		"configs/real-config.yaml": &fstest.MapFile{Data: validCollectorConfigYAML("real-config")},
 	}
 
-	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), owner, fsys, "configs")
 	require.NoError(t, err)
 
 	after := &searchv1alpha1.CollectorConfig{}

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -55,6 +55,10 @@ func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T
 		require.NoError(t, err, "expected %s to be created", name)
 		assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, cc.Labels[searchv1alpha1.IntegrationTeamLabel])
 		assert.NotEmpty(t, cc.Spec.CollectionRules, "%s should have collection rules", name)
+		_, hasBackupLabel := cc.Labels[backupLabel]
+		assert.False(t, hasBackupLabel,
+			"%s must NOT have the backup label — it is reseeded on every restart, and the "+
+				"label breaks hub restore via the admission webhook's ownership check (ACM-42665)", name)
 	}
 }
 
@@ -336,6 +340,40 @@ func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
 
 	err := applyIntegrationCollectorConfigs(context.TODO(), failingClient, testScheme(), testSearchOwner())
 	assert.Error(t, err)
+}
+
+// A canonical integration CollectorConfig created by a previous operator version that still
+// carries the (now-removed) backup label must have it stripped on the next seeder run — even
+// when the spec and every other label already matches the shipped default — since the
+// admission webhook otherwise rejects backup/restore patches to these operator-owned configs
+// (ACM-42665). The additive label-merge alone would never remove it, since the shipped YAML
+// simply omits the key rather than requesting its removal.
+func TestApplyOneIntegrationCollectorConfig_StripsStaleBackupLabel(t *testing.T) {
+	existing := newIntegrationTeamConfig("real-config", searchv1alpha1.CollectorConfigSpec{
+		CollectionRules: []searchv1alpha1.CollectionRule{
+			{
+				Action:           searchv1alpha1.ActionInclude,
+				ResourceSelector: searchv1alpha1.ResourceSelector{APIGroups: []string{"example.io"}, Kinds: []string{"*"}},
+			},
+		},
+	})
+	existing.Labels[backupLabel] = "" // simulate a pre-fix operator version's stale label
+	r := setupReconciler(existing)
+	fsys := fstest.MapFS{
+		"configs/real-config.yaml": &fstest.MapFile{Data: validCollectorConfigYAML("real-config")},
+	}
+
+	err := applyIntegrationCollectorConfigsFrom(context.TODO(), r.Client, testScheme(), testSearchOwner(), fsys, "configs")
+	require.NoError(t, err)
+
+	after := &searchv1alpha1.CollectorConfig{}
+	require.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name: "real-config", Namespace: testNamespace,
+	}, after))
+	_, hasLabel := after.Labels[backupLabel]
+	assert.False(t, hasLabel, "stale backup label must be stripped from operator-owned integration configs")
+	assert.Equal(t, searchv1alpha1.IntegrationTeamLabelValue, after.Labels[searchv1alpha1.IntegrationTeamLabel],
+		"integration team label must be preserved while stripping the backup label")
 }
 
 func TestApplyOneIntegrationCollectorConfig_UpdateError(t *testing.T) {

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -43,6 +43,8 @@ var expectedIntegrationConfigNames = []string{
 	"app-lifecycle-integration",
 }
 
+// Every embedded integration CollectorConfig must be created with the integration-team label and
+// collection rules, and must NOT carry the backup label — see ACM-42665.
 func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T) {
 	r := setupReconciler()
 
@@ -330,6 +332,8 @@ func TestApplyOneIntegrationCollectorConfig_GetErrorOtherThanNotFound(t *testing
 	assert.Error(t, err)
 }
 
+// applyIntegrationCollectorConfigs must propagate an error from the client when creating a new
+// integration CollectorConfig fails.
 func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
 	base := setupReconciler().Client.(client.WithWatch)
 	failingClient := interceptor.NewClient(base, interceptor.Funcs{
@@ -376,6 +380,8 @@ func TestApplyOneIntegrationCollectorConfig_StripsStaleBackupLabel(t *testing.T)
 		"integration team label must be preserved while stripping the backup label")
 }
 
+// applyIntegrationCollectorConfigs must propagate an error from the client when updating an
+// out-of-date integration CollectorConfig fails.
 func TestApplyOneIntegrationCollectorConfig_UpdateError(t *testing.T) {
 	// Pre-create one config with a spec that differs from the shipped default, so the code
 	// takes the Update path rather than Create.

--- a/controllers/create_integration_collectorconfigs_test.go
+++ b/controllers/create_integration_collectorconfigs_test.go
@@ -44,7 +44,7 @@ var expectedIntegrationConfigNames = []string{
 }
 
 // Every embedded integration CollectorConfig must be created with the integration-team label and
-// collection rules, and must NOT carry the backup label — see ACM-42665.
+// collection rules, and must NOT carry the backup label.
 func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T) {
 	r := setupReconciler()
 
@@ -60,7 +60,7 @@ func TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs(t *testing.T
 		_, hasBackupLabel := cc.Labels[backupLabel]
 		assert.False(t, hasBackupLabel,
 			"%s must NOT have the backup label — it is reseeded on every restart, and the "+
-				"label breaks hub restore via the admission webhook's ownership check (ACM-42665)", name)
+				"label breaks hub restore via the admission webhook's ownership check", name)
 	}
 }
 
@@ -349,9 +349,9 @@ func TestApplyOneIntegrationCollectorConfig_CreateError(t *testing.T) {
 // A canonical integration CollectorConfig created by a previous operator version that still
 // carries the (now-removed) backup label must have it stripped on the next seeder run — even
 // when the spec and every other label already matches the shipped default — since the
-// admission webhook otherwise rejects backup/restore patches to these operator-owned configs
-// (ACM-42665). The additive label-merge alone would never remove it, since the shipped YAML
-// simply omits the key rather than requesting its removal.
+// admission webhook otherwise rejects backup/restore patches to these operator-owned configs.
+// The additive label-merge alone would never remove it, since the shipped YAML simply omits
+// the key rather than requesting its removal.
 //
 // existing carries a real controller ownerReference and owner has a matching non-empty UID, so
 // hasControllerOwnerRef evaluates the actual "already owned" path instead of the empty-UID


### PR DESCRIPTION
## Summary

Fixes [ACM-42665](https://redhat.atlassian.net/browse/ACM-42665): a hub restore of `acm-resources-generic-schedule` fails with `PartiallyFailed` because Velero's service account is denied by the `CollectorConfig` admission webhook when patching backed-up integration-team `CollectorConfig`s (`app-lifecycle-integration`, `argo-integration`, `cnv-integration`, `gatekeeper-integration`, `grc-integration`, `kyverno-integration`, `olm-integration`).

## Root cause

These configs carry both:
1. The `cluster.open-cluster-management.io/backup` label (added in [ACM-20052](https://redhat.atlassian.net/browse/ACM-20052)) — so ACM's generic backup schedule picks them up.
2. A controller `ownerReference` (added in [ACM-21883](https://redhat.atlassian.net/browse/ACM-21883)) — so the admission webhook's `rejectIfProtected` rejects any writer that isn't a service account in the config's own namespace. Velero's SA (`open-cluster-management-backup`) doesn't qualify, so every restore-time patch is deterministically rejected.

This is a timing gap between two features that shipped ~2 months apart:
- ACM-20052 (backup labeling) landed **before** integration configs were made deterministically reseeded at startup — at that time, backing them up was a reasonable safety net.
- ACM-37052 (built-in integration configs, seeded from embedded YAML at every operator restart) made them redundant to back up — same rationale that already excludes `merged-collector-config` from the backup label — but the ACM-20052 decision was never revisited.

No existing test could catch this: unit tests use a fake client that bypasses admission webhooks entirely, and there's no backup/restore E2E coverage in `search-e2e-test` (that's cluster-backup-operator/QE territory).

## Fix

- Remove the hardcoded backup label from the 7 static integration `CollectorConfig` manifests (`config/integration_collector_configs/*.yaml`).
- `create_collectorconfig.go`: skip `addBackupLabel` for operator-owned (ownerReference-carrying) integration configs during merge, via a new `isOperatorOwnedCC` helper. Non-owned configs (a team's differently-named test config — the manual-override escape hatch) still get backed up, same as `user-collector-config`, since they're user-authored and not reseeded.
- `create_integration_collectorconfigs.go`: the seeder now actively **strips** a stale backup label from already-existing canonical configs on its next run (not just omits adding it), so hubs upgrading from an operator version that shipped the label self-heal — the existing label-merge logic is otherwise additive-only.

## Test plan

- New unit tests:
  - `TestBackupLabel_OwnedIntegrationTeamConfig_NotLabeled` — owned configs never get the label.
  - `TestApplyOneIntegrationCollectorConfig_StripsStaleBackupLabel` — stale label is removed on the next seeder run even when spec/other labels already match.
  - Extended `TestApplyIntegrationCollectorConfigs_CreatesAllEmbeddedConfigs` to assert the real embedded YAMLs never produce the label.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- QE: re-run the `acm-resources-generic-schedule` restore scenario from ACM-42665 against a build with this fix; existing backups taken before this fix will still carry the stale label until a fresh backup is taken (the seeder-side strip only fixes the live cluster's own configs, not already-taken backup snapshots).



[ACM-42665]: https://redhat.atlassian.net/browse/ACM-42665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-20052]: https://redhat.atlassian.net/browse/ACM-20052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-21883]: https://redhat.atlassian.net/browse/ACM-21883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Operator-managed integration configurations are no longer included in backups.
- Existing configurations have outdated backup metadata removed during upgrades.
- User-created configurations retain appropriate backup handling.
- Prevented restore-time admission and patch failures for managed configurations.

## Documentation

- Clarified which configurations are automatically recreated and should not be backed up.
- Added guidance distinguishing managed configurations from user-created configurations during backup and restore operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->