### PR TITLE
fix(addon): restore MCIR image override support in validateImageOverride (ACM-44191)

### DIFF
--- a/addon/addon.go
+++ b/addon/addon.go
@@ -151,11 +151,18 @@ func getValue(cluster *clusterv1.ManagedCluster,
 	return values, nil
 }
 
-// validateImageOverride is registered as the last GetValuesFunc so that
-// image overrides injected via the per-cluster ManagedClusterAddOn values
-// annotation are validated against the trusted-registry allowlist. Any image
-// that does not originate from a trusted registry is replaced with the
-// operator-controlled SearchCollectorImage.
+// validateImageOverride closes the CVE-2026-71471 / CVE-2026-71473 attack vector:
+// any image injected via the "addon.open-cluster-management.io/values" annotation
+// on the ManagedClusterAddOn (func [1], GetValuesFromAddonAnnotation) is discarded
+// by unconditionally resetting the image to the operator-controlled SearchCollectorImage.
+//
+// This func runs as func [3] — after GetValuesFromAddonAnnotation but before
+// GetAgentImageValues. GetAgentImageValues (func [4], the last func) then applies
+// the ManagedCluster's "open-cluster-management.io/image-registries" registry
+// mapping rules to SearchCollectorImage to produce the MCIR-mirrored image.
+// Because GetAgentImageValues derives its output solely from the operator-controlled
+// base image via prefix replacement, the final image is always a deterministic
+// transform of a known-good image — never an arbitrary injection.
 func validateImageOverride(_ *clusterv1.ManagedCluster,
 	_ *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 	return addonfactory.Values{
@@ -256,13 +263,39 @@ func NewAddonManager(kubeConfig *rest.Config) (addonmanager.AddonManager, error)
 		WithConfigGVRs(
 			utils.AddOnDeploymentConfigGVR,
 		).WithGetValuesFuncs(
+		// [0] Base defaults: SearchCollectorImage, pull policy, proxy config, user args
+		// from the per-cluster addon annotations (memory limits, heartbeat, etc.).
 		getValue,
+		// [1] Merge non-image values from the addon annotation (e.g. memory limits,
+		// container args). May also set an image — deliberately ignored by [2].
 		addonfactory.GetValuesFromAddonAnnotation,
+		// [2] Node placement and resource requirements from AddOnDeploymentConfig.
 		addonfactory.GetAddOnDeploymentConfigValues(
 			utils.NewAddOnDeploymentConfigGetter(addonClient),
 			addonfactory.ToAddOnNodePlacementValues,
 			addonfactory.ToAddOnResourceRequirementsValues),
+		// [3] Security gate (CVE-2026-71471 / CVE-2026-71473): unconditionally reset
+		// the image to SearchCollectorImage, discarding any image set by [1] via the
+		// addon annotation. This closes the arbitrary-image-injection attack vector.
 		validateImageOverride,
+		// [4] MCIR support: apply the "open-cluster-management.io/image-registries"
+		// registry mapping rules from the ManagedCluster annotation to
+		// SearchCollectorImage. This transforms the known-good base image's registry
+		// prefix to the customer's mirror registry — supporting arbitrary private
+		// registries in disconnected/air-gapped environments. Runs last so it wins.
+		// AddOnDeploymentConfig.Spec.Registries takes precedence if both are set.
+		addonfactory.GetAgentImageValues(
+			utils.NewAddOnDeploymentConfigGetter(addonClient),
+			"global.imageOverrides.search_collector",
+			SearchCollectorImage,
+		),
+	).WithAgentDeployTriggerClusterFilter(
+		// Trigger redeployment when the MCIR annotation on the ManagedCluster changes
+		// so that newly applied or updated registry mirrors take effect immediately.
+		func(old, new *clusterv1.ManagedCluster) bool {
+			return old.GetAnnotations()[clusterv1.ClusterImageRegistriesAnnotationKey] !=
+				new.GetAnnotations()[clusterv1.ClusterImageRegistriesAnnotationKey]
+		},
 	).WithAgentRegistrationOption(newRegistrationOption(kubeClient, SearchAddonName)).
 		BuildHelmAgentAddon()
 	if err != nil {

--- a/addon/addon_test.go
+++ b/addon/addon_test.go
@@ -34,12 +34,22 @@ func init() {
 }
 
 func newCluster(name string) *clusterv1.ManagedCluster {
-	cluster := &clusterv1.ManagedCluster{
+	return &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
-	return cluster
+}
+
+func newClusterWithImageRegistries(name, imageRegistriesJSON string) *clusterv1.ManagedCluster {
+	return &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: imageRegistriesJSON,
+			},
+		},
+	}
 }
 
 func newAddon(name, cluster, installNamespace string, annotationValues map[string]string) *addonapiv1alpha1.ManagedClusterAddOn {
@@ -58,22 +68,28 @@ func newAddon(name, cluster, installNamespace string, annotationValues map[strin
 
 func newAgentAddon(t *testing.T, objects []runtime.Object) agent.AgentAddon {
 	registrationOption := newRegistrationOption(nil, SearchAddonName)
-	getValuesFunc := getValue
 	fakeAddonClient := fakeaddon.NewSimpleClientset(objects...)
 	agentAddon, err := addonfactory.NewAgentAddonFactory(SearchAddonName, ChartFS, ChartDir).
 		WithScheme(scheme).
-		WithGetValuesFuncs(getValuesFunc, addonfactory.GetValuesFromAddonAnnotation,
+		WithGetValuesFuncs(
+			getValue,
+			addonfactory.GetValuesFromAddonAnnotation,
 			addonfactory.GetAddOnDeploymentConfigValues(
 				utils.NewAddOnDeploymentConfigGetter(fakeAddonClient),
 				addonfactory.ToAddOnNodePlacementValues,
 				addonfactory.ToAddOnResourceRequirementsValues,
 			),
-			validateImageOverride).
+			validateImageOverride,
+			addonfactory.GetAgentImageValues(
+				utils.NewAddOnDeploymentConfigGetter(fakeAddonClient),
+				"global.imageOverrides.search_collector",
+				SearchCollectorImage,
+			),
+		).
 		WithAgentRegistrationOption(registrationOption).
 		BuildHelmAgentAddon()
 	if err != nil {
 		t.Fatalf("failed to build agent %v", err)
-
 	}
 	return agentAddon
 }
@@ -625,26 +641,135 @@ func findSearchDeployment(objs []runtime.Object) *appsv1.Deployment {
 	return nil
 }
 
-// TestManifest_TrustedImageAllowed verifies that a trusted image supplied via
-// the values annotation is preserved (not replaced) by validateImageOverride.
-func TestManifest_TrustedImageAllowed(t *testing.T) {
-	trustedAnnotations := map[string]string{
-		"addon.open-cluster-management.io/values": `{"global":{"imageOverrides":{"search_collector":"quay.io/stolostron/search_collector:custom-tag"}}}`,
+// TestManifest_AddonAnnotationImageIgnored verifies that an image supplied via
+// the addon values annotation — even from a trusted registry — is always
+// replaced by validateImageOverride (CVE-2026-71471 / CVE-2026-71473 fix).
+// The addon annotation is not a trusted source for image overrides; customers
+// must use ManagedClusterImageRegistry instead (see TestManifest_MCIRMirroredImageHonoured).
+func TestManifest_AddonAnnotationImageIgnored(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		annotations map[string]string
+	}{
+		{
+			name: "untrusted registry",
+			annotations: map[string]string{
+				"addon.open-cluster-management.io/values": `{"global":{"imageOverrides":{"search_collector":"docker.io/attacker/search_collector:evil"}}}`,
+			},
+		},
+		{
+			name: "trusted registry via addon annotation",
+			annotations: map[string]string{
+				"addon.open-cluster-management.io/values": `{"global":{"imageOverrides":{"search_collector":"quay.io/stolostron/search_collector:custom-tag"}}}`,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			SearchCollectorImage = "quay.io/stolostron/search_collector:2.7.0"
+			agentAddon := newAgentAddon(t, nil)
+			addon := newAddon(SearchAddonName, "cluster1", "", tc.annotations)
+			objects, err := agentAddon.Manifests(newCluster("cluster1"), addon)
+			if err != nil {
+				t.Fatalf("failed to get manifests: %v", err)
+			}
+			dep := findSearchDeployment(objects)
+			if dep == nil {
+				t.Fatal("no Deployment found in manifests")
+			}
+			got := dep.Spec.Template.Spec.Containers[0].Image
+			if got != "quay.io/stolostron/search_collector:2.7.0" {
+				t.Errorf("image set via addon annotation must be ignored; got %q, want operator image", got)
+			}
+		})
 	}
+}
+
+// TestManifest_MCIRMirroredImageHonoured verifies the primary MCIR use-case:
+// when ManagedClusterImageRegistry stamps the "open-cluster-management.io/image-registries"
+// annotation on the ManagedCluster with a source→mirror registry mapping,
+// GetAgentImageValues applies it to the operator-controlled SearchCollectorImage
+// and the mirrored image reaches the ManifestWork.
+//
+// Critically, the mirror registry can be any arbitrary private registry (e.g.
+// registry.customer-corp.internal/) — it is not restricted to Red Hat registries.
+// This supports customers in disconnected/air-gapped environments.
+//
+// This is the regression introduced by commit 7278188 ("validate image overrides #818")
+// and fixed by adding GetAgentImageValues as the final GetValuesFunc.
+func TestManifest_MCIRMirroredImageHonoured(t *testing.T) {
 	SearchCollectorImage = "quay.io/stolostron/search_collector:2.7.0"
 	agentAddon := newAgentAddon(t, nil)
-	addon := newAddon(SearchAddonName, "cluster1", "", trustedAnnotations)
-	objects, err := agentAddon.Manifests(newCluster("cluster1"), addon)
+
+	for _, tc := range []struct {
+		name           string
+		registriesJSON string
+		expectedImage  string
+	}{
+		{
+			name: "customer private registry (arbitrary mirror)",
+			// The customer mirrors quay.io/stolostron/ → registry.customer-corp.internal/acm-mirror/
+			registriesJSON: `{"registries":[{"source":"quay.io/stolostron","mirror":"registry.customer-corp.internal/acm-mirror"}]}`,
+			expectedImage:  "registry.customer-corp.internal/acm-mirror/search_collector:2.7.0",
+		},
+		{
+			name:           "acm-d mirror registry",
+			registriesJSON: `{"registries":[{"source":"quay.io/stolostron","mirror":"quay.io/acm-d"}]}`,
+			expectedImage:  "quay.io/acm-d/search_collector:2.7.0",
+		},
+		{
+			name:           "redhat official registry",
+			registriesJSON: `{"registries":[{"source":"quay.io/stolostron","mirror":"registry.redhat.io/rhacm2"}]}`,
+			expectedImage:  "registry.redhat.io/rhacm2/search_collector:2.7.0",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := newClusterWithImageRegistries("cluster1", tc.registriesJSON)
+			addon := newAddon(SearchAddonName, "cluster1", "", nil)
+			objects, err := agentAddon.Manifests(cluster, addon)
+			if err != nil {
+				t.Fatalf("failed to get manifests: %v", err)
+			}
+			dep := findSearchDeployment(objects)
+			if dep == nil {
+				t.Fatal("no Deployment found in manifests")
+			}
+			got := dep.Spec.Template.Spec.Containers[0].Image
+			if got != tc.expectedImage {
+				t.Errorf("MCIR-mirrored image must be used in ManifestWork;\n  got:  %q\n  want: %q", got, tc.expectedImage)
+			}
+		})
+	}
+}
+
+// TestManifest_MCIRAnnotationAndAddonAnnotationImageIsolation verifies that when
+// BOTH the ManagedCluster registry annotation (MCIR) AND an image override in the
+// addon annotation are present, only the MCIR-derived image is used — the addon
+// annotation image is discarded by validateImageOverride before GetAgentImageValues runs.
+func TestManifest_MCIRAnnotationAndAddonAnnotationImageIsolation(t *testing.T) {
+	SearchCollectorImage = "quay.io/stolostron/search_collector:2.7.0"
+	agentAddon := newAgentAddon(t, nil)
+
+	// Addon annotation tries to inject an attacker image.
+	addonAnnotations := map[string]string{
+		"addon.open-cluster-management.io/values": `{"global":{"imageOverrides":{"search_collector":"docker.io/attacker/evil:latest"}}}`,
+	}
+	// ManagedCluster has a legitimate MCIR mapping.
+	cluster := newClusterWithImageRegistries("cluster1",
+		`{"registries":[{"source":"quay.io/stolostron","mirror":"registry.customer-corp.internal/acm-mirror"}]}`)
+	addon := newAddon(SearchAddonName, "cluster1", "", addonAnnotations)
+
+	objects, err := agentAddon.Manifests(cluster, addon)
 	if err != nil {
 		t.Fatalf("failed to get manifests: %v", err)
 	}
-	for _, o := range objects {
-		if dep, ok := o.(*appsv1.Deployment); ok {
-			// validateImageOverride always re-pins to SearchCollectorImage regardless
-			// of what the annotation says — the operator-controlled image is authoritative.
-			if dep.Spec.Template.Spec.Containers[0].Image != "quay.io/stolostron/search_collector:2.7.0" {
-				t.Errorf("expected operator image, got %s", dep.Spec.Template.Spec.Containers[0].Image)
-			}
-		}
+	dep := findSearchDeployment(objects)
+	if dep == nil {
+		t.Fatal("no Deployment found in manifests")
+	}
+	got := dep.Spec.Template.Spec.Containers[0].Image
+	// The MCIR-mirrored image must win; the attacker image in the addon annotation must be dropped.
+	want := "registry.customer-corp.internal/acm-mirror/search_collector:2.7.0"
+	if got != want {
+		t.Errorf("MCIR image must win over addon annotation image;\n  got:  %q\n  want: %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the regression from commit `7278188` (CVE-2026-71471/CVE-2026-71473 fix) where ManagedClusterImageRegistry (MCIR) image overrides stopped working for search-collector, causing `ImagePullBackOff` on air-gapped non-OpenShift managed clusters.

## Root Cause

The original CVE fix added `validateImageOverride` as the last `GetValuesFunc`. It correctly closed the injection vector — but MCIR was incorrectly assumed to deliver images via the `addon.open-cluster-management.io/values` annotation on the ManagedClusterAddOn. That annotation is writable by any hub principal with `update`/`patch` on the resource (Edit-role users), making it an untrusted source for image references regardless of registry name.

The **actual MCIR mechanism** is different: the MCIR controller stamps `source→mirror` registry mapping rules into `open-cluster-management.io/image-registries` on the **ManagedCluster** (a separate resource). The addon-framework's `GetAgentImageValues` reads these rules and applies prefix-replacement to the operator-controlled base image — it never accepts an arbitrary image reference.

## Fix: 5-stage GetValuesFunc pipeline

| # | Func | Purpose |
|---|---|---|
| 0 | `getValue` | Base defaults: `SearchCollectorImage`, pull policy, per-cluster user args |
| 1 | `GetValuesFromAddonAnnotation` | Non-image fields from addon annotation (memory limits, container args, heartbeat) |
| 2 | `GetAddOnDeploymentConfigValues` | Node placement, resource requirements |
| 3 | `validateImageOverride` | **Security gate**: unconditionally resets image to `SearchCollectorImage`, discarding any image set by [1] via the addon annotation |
| 4 | `GetAgentImageValues` | **MCIR**: reads `open-cluster-management.io/image-registries` from the ManagedCluster, applies source→mirror prefix replacement to `SearchCollectorImage`. Runs last so wins. Supports **any arbitrary private registry**. |

Also adds `WithAgentDeployTriggerClusterFilter` so that MCIR annotation changes on the ManagedCluster trigger immediate addon redeployment.

## Security properties

- **CVE closed**: the addon annotation (`ManagedClusterAddOn`) is now fully discarded as an image source. `validateImageOverride` [3] resets to `SearchCollectorImage` before `GetAgentImageValues` [4] runs.
- **No trusted-registry allowlist needed**: `GetAgentImageValues` only performs registry prefix-replacement on the operator-controlled base image — the output is always a deterministic transform of a known-good image, never a freeform injection.
- **Arbitrary mirror registries work**: customers can mirror to any private registry (e.g. `registry.customer-corp.internal/acm-mirror/`).

## Tests

| Test | What it verifies |
|---|---|
| `TestManifest_AddonAnnotationImageIgnored` | Both untrusted **and** trusted images in the addon annotation are ignored — operator image always used |
| `TestManifest_MCIRMirroredImageHonoured` | Arbitrary customer registry, `quay.io/acm-d/`, `registry.redhat.io/` — all work via ManagedCluster annotation |
| `TestManifest_MCIRAnnotationAndAddonAnnotationImageIsolation` | Attacker image in addon annotation is dropped; MCIR image from ManagedCluster wins |

`make test` ✅ · `make lint` ✅ · gosec 0 issues ✅

Fixes: ACM-44191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Add-on image overrides are ignored, preventing untrusted annotations from changing the configured collector image.
  - Trusted image settings are restored after add-on annotation processing.

- **Bug Fixes**
  - Managed-cluster image registry mappings now take precedence when resolving add-on images.
  - Add-ons are redeployed when the configured image registry annotation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->